### PR TITLE
Node: support latest as version option

### DIFF
--- a/collection/node/install.sh
+++ b/collection/node/install.sh
@@ -98,6 +98,8 @@ if [ "${NODE_VERSION}" = "none" ]; then
     export NODE_VERSION=
 elif [ "${NODE_VERSION}" = "lts" ]; then
     export NODE_VERSION="lts/*"
+elif [ "${NODE_VERSION}" = "latest" ]; then
+    export NODE_VERSION="node"
 fi
 
 # Create a symlink to the installed version for use in Dockerfile PATH statements


### PR DESCRIPTION
Currently, if you pass `latest` as value for the `version` argument, then it does not install node. fixing this! 