### PR TITLE
Java: Fix file not found bug

### DIFF
--- a/collection/java/wrapper.sh
+++ b/collection/java/wrapper.sh
@@ -10,7 +10,7 @@ UPDATE_RC=${4:-"true"}
 ADDITIONAL_JAVA_VERSION=11
 
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-chmod +x java-debian.sh
+chmod +x install.sh
 
 is_jdk_8="false"
 if echo "${JAVA_VERSION}" | grep -E '^8([\s\.]|$)' > /dev/null 2>&1; then
@@ -20,7 +20,7 @@ fi
 # If the user selected JDK 8, install the JDK 11 as well since this is needed by the Java extension
 if [ "${is_jdk_8}" = "true" ]; then
     echo "(*) Installing JDK ${ADDITIONAL_JAVA_VERSION} as Java VS Code extension requires a recent JDK..."
-    ./java-debian.sh "${ADDITIONAL_JAVA_VERSION}" "${SDKMAN_DIR}" "${USERNAME}" "${UPDATE_RC}"
+    ./install.sh "${ADDITIONAL_JAVA_VERSION}" "${SDKMAN_DIR}" "${USERNAME}" "${UPDATE_RC}"
     jdk_11_folder="$(ls --format=single-column ${SDKMAN_DIR}/candidates/java | grep -oE -m 1 '11\..+')"
     ln -s "${SDKMAN_DIR}/candidates/java/${jdk_11_folder}" /extension-java-home
 
@@ -41,7 +41,7 @@ else
 fi
 
 echo "(*) Installing JDK ${JAVA_VERSION}..."
-./java-debian.sh "${JAVA_VERSION}" "${SDKMAN_DIR}" "${USERNAME}" "${UPDATE_RC}"
+./install.sh "${JAVA_VERSION}" "${SDKMAN_DIR}" "${USERNAME}" "${UPDATE_RC}"
 if [ "${is_jdk_8}" = "true" ]; then
     # Set current and default version to last SDK installed
     jdk_full_version="$(ls --format=single-column "${SDKMAN_DIR}/candidates/java" | sort -rV | grep -oE -m 1 "${JAVA_VERSION}\\..+" )"


### PR DESCRIPTION
The `Java` feature is incorrectly looking for `java-debian.sh`. It should instead look for `install.sh`. fixing that! 