### PR TITLE
Jupyterlab: Update script and add pythonBinary as option

### DIFF
--- a/src/jupyterlab/feature.json
+++ b/src/jupyterlab/feature.json
@@ -7,6 +7,12 @@
             "proposals": ["latest", "3.6.2"],
             "default": "latest",
             "description": "Select or enter a jupyterlab version."
+        },
+        "pythonBinary": {
+            "type": "string",
+            "proposals": ["python", "/usr/local/python/bin/python"],
+            "default": "python",
+            "description": "Select or enter the python binary path."
         }
     },
     "extensions": [

--- a/src/jupyterlab/install.sh
+++ b/src/jupyterlab/install.sh
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/jupyterlab.md
+# Maintainer: The VS Code and Codespaces Teams
+#
+# Syntax: ./jupyter-debian.sh
 
 set -e
 
 VERSION=${1:-"latest"}
 USERNAME=${2:-"automatic"}
+PYTHON=${3:-"python"}
+ALLOW_ORIGIN=${4:-""}
 
 # If in automatic mode, determine if a user already exists, if not use vscode
 if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
@@ -24,9 +35,8 @@ elif [ "${USERNAME}" = "none" ]; then
     USER_GID=0
 fi
 
-# Use sudo to run as non-root user is not already running
-sudoUserIf()
-{
+# Make sure we run the command as non-root user
+sudoUserIf() {
   if [ "$(id -u)" -eq 0 ] && [ "${USERNAME}" != "root" ]; then
     sudo -u ${USERNAME} "$@"
   else
@@ -34,18 +44,32 @@ sudoUserIf()
   fi
 }
 
-# If we don't yet have Python, install it now.
-if ! python --version > /dev/null ; then
+addToJupyterConfig() {
+  JUPYTER_DIR="/home/${USERNAME}/.jupyter"
+  JUPYTER_CONFIG="${JUPYTER_DIR}/jupyter_notebook_config.py"
+
+  # Make sure the config file exists
+  test -d ${JUPYTER_DIR} || sudoUserIf mkdir ${JUPYTER_DIR}
+  test -f ${JUPYTER_CONFIG} || sudoUserIf touch ${JUPYTER_CONFIG}
+
+  # Don't write the same line more than once
+  grep -q ${1} ${JUPYTER_CONFIG} || echo ${1} >> ${JUPYTER_CONFIG}
+}
+
+# Make sure that Python is available
+if ! ${PYTHON} --version > /dev/null ; then
   echo "You need to install Python before installing JupyterLab."
   exit 1
 fi
 
-# If we don't already have JupyterLab installed, install it now.
-if ! jupyter-lab --version > /dev/null ; then
-  echo "Installing JupyterLab..."
-  if [ "${VERSION}" = "latest" ]; then
-    pip install jupyterlab
-  else
-    pip install jupyterlab=="${VERSION}" --no-cache-dir
-  fi
+# pip skips installation if JupyterLab is already installed
+echo "Installing JupyterLab..."
+if [ "${VERSION}" = "latest" ]; then
+  sudoUserIf ${PYTHON} -m pip install jupyterlab --no-cache-dir
+else
+  sudoUserIf ${PYTHON} -m pip install jupyterlab=="${VERSION}" --no-cache-dir
+fi
+
+if [ "${ALLOW_ORIGIN}" = 'true' ]; then
+  addToJupyterConfig "c.ServerApp.allow_origin = '*'"
 fi

--- a/v1/feature-scripts.env
+++ b/v1/feature-scripts.env
@@ -20,4 +20,4 @@ _BUILD_ARG_RUST="./rust/install.sh                                          /usr
 _BUILD_ARG_POWERSHELL="./powershell/install.sh                              ${_BUILD_ARG_POWERSHELL_VERSION:-latest}"
 _BUILD_ARG_DESKTOP_LITE="./desktop-lite/install.sh                          automatic ${_BUILD_ARG_DESKTOP_LITE_PASSWORD:-vscode} true ${_BUILD_ARG_DESKTOP_LITE_VNCPORT:-5901} ${_BUILD_ARG_DESKTOP_LITE_WEBPORT:-6080}"
 _BUILD_ARG_DOTNET="./dotnet/install.sh                                      ${_BUILD_ARG_DOTNET_VERSION:-latest} ${_BUILD_ARG_DOTNET_RUNTIMEONLY:-false} automatic true /usr/local/dotnet dotnet"
-_BUILD_ARG_JUPYTERLAB="./jupyterlab/install.sh                              ${_BUILD_ARG_JUPYTERLAB_VERSION:-latest}"
+_BUILD_ARG_JUPYTERLAB="./jupyterlab/install.sh                              ${_BUILD_ARG_JUPYTERLAB_VERSION:-latest}" automatic ${_BUILD_ARG_JUPYTERLAB_PYTHONBINARY:-python}" true


### PR DESCRIPTION
Copied latest jupyterlab-debian.sh from dev-conatainers repo.
`codespaces-linux` needs to specify the Python_Binary for the jupyter-lab feature. Hence, surfaced! 