### PR TITLE
Common: Moving contents from setup-user.sh

### DIFF
--- a/src/common/install.sh
+++ b/src/common/install.sh
@@ -207,7 +207,7 @@ fi
 
 # Add add sudo support for non-root user
 if [ "${USERNAME}" != "root" ] && [ "${EXISTING_NON_ROOT_USER}" != "${USERNAME}" ]; then
-    echo $USERNAME ALL=\(root\) NOPASSWD:ALL >> /etc/sudoers.d/$USERNAME
+    echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME
     chmod 0440 /etc/sudoers.d/$USERNAME
     EXISTING_NON_ROOT_USER="${USERNAME}"
 fi
@@ -369,7 +369,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
         apt-get install -y zsh
     fi
     if [ "${ZSH_ALREADY_INSTALLED}" != "true" ]; then
-        echo "${rc_snippet}" > /etc/zsh/zshrc
+        echo "${rc_snippet}" >> /etc/zsh/zshrc
         ZSH_ALREADY_INSTALLED="true"
     fi
 


### PR DESCRIPTION
Moving contents from https://github.com/devcontainers/images/blob/samruddhikhandale/init/src/codespaces-linux/setup-user.sh#L22-L38 to avoid creating a local feature for building the codespaces-linux image. 