### PR TITLE
conda: path changes

### DIFF
--- a/src/anaconda/devcontainer-feature.json
+++ b/src/anaconda/devcontainer-feature.json
@@ -13,7 +13,7 @@
     },
     "containerEnv": {
         "CONDA_DIR": "/usr/local/conda",
-        "PATH": "${CONDA_DIR}/bin:${PATH}"
+        "PATH": "${PATH}:${CONDA_DIR}/bin:"
     },
     "install": {
         "app": "",


### PR DESCRIPTION
Conda comes with a python version of it's own. This python path comes first before the root python path.
Hence, fixing that! 