### PR TITLE
Python: Install python tools if python exists

### DIFF
--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -366,7 +366,7 @@ if [ "${PYTHON_VERSION}" != "none" ]; then
     chmod -R g+r+w "${PYTHON_INSTALL_PATH}"
     find "${PYTHON_INSTALL_PATH}" -type d | xargs -n 1 chmod g+s
 
-    PATH="${CURRENT_PATH}/bin:${PATH}"
+    PATH="${INSTALL_PATH}/bin:${PATH}"
 fi
 
 # Install Python tools if needed


### PR DESCRIPTION
For the `miniconda` image, it needs pip which needs to be installed by the python feature when python:version = none