### PR TITLE
update `rust` version proposals

### DIFF
--- a/src/rust/devcontainer-feature.json
+++ b/src/rust/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "rust",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Rust",
     "description": "Installs Rust, common Rust utilities, and their required dependencies",
     "options": {
@@ -9,9 +9,9 @@
             "proposals": [
                 "latest",
                 "none",
-                "1.55",
-                "1.54",
-                "1.53"
+                "1.63",
+                "1.62",
+                "1.61"
             ],
             "default": "latest",
             "description": "Select or enter a version of Rust to install."


### PR DESCRIPTION
Rust 1.63 was released last week (https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html)