### PR TITLE
replace temporary action for generating docs

### DIFF
--- a/.github/workflows/update-documentation.yml
+++ b/.github/workflows/update-documentation.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Generate Documentation
-        uses: ./.github/devcontainers-action # devcontainers/action
+        uses: devcontainers/action@v1
         with:
           generate-docs: "true"
           base-path-to-features: "./src"


### PR DESCRIPTION
Missed a spot where we were referencing the checked in copy of `devcontainers/action`.