### PR TITLE
Oryx - Clean up and shrink size

### DIFF
--- a/src/oryx/devcontainer-feature.json
+++ b/src/oryx/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "oryx",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "name": "Oryx",
     "description": "Installs the oryx CLI",
     "containerEnv": {

--- a/src/oryx/devcontainer-feature.json
+++ b/src/oryx/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "oryx",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "name": "Oryx",
     "description": "Installs the oryx CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/oryx",

--- a/src/oryx/devcontainer-feature.json
+++ b/src/oryx/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "oryx",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "name": "Oryx",
     "description": "Installs the oryx CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/oryx",

--- a/src/oryx/install.sh
+++ b/src/oryx/install.sh
@@ -98,7 +98,7 @@ architecture="$(dpkg --print-architecture)"
 
 # Currently, oryx is not supported with "jammy"
 if [[ "jammy" = *"${VERSION_CODENAME}"* ]]; then
-    echo "(!) Unsupported distribution version '${VERSION_CODENAME}'"
+    echo "(!) Unsupported distribution version '${VERSION_CODENAME}'."
     exit 1
 fi
 

--- a/src/oryx/install.sh
+++ b/src/oryx/install.sh
@@ -93,6 +93,15 @@ install_dotnet_using_apt() {
     rm -rf /var/lib/apt/lists/*
 }
 
+. /etc/os-release
+architecture="$(dpkg --print-architecture)"
+
+# Currently, oryx is not supported with "jammy"
+if [[ "jammy" = *"${VERSION_CODENAME}"* ]]; then
+    echo "(!) Unsupported distribution version '${VERSION_CODENAME}'"
+    exit 1
+fi
+
 # If we don't already have Oryx installed, install it now.
 if  oryx --version > /dev/null ; then
     echo "oryx is already installed. Skipping installation."
@@ -104,8 +113,6 @@ echo "Installing Oryx..."
 # Ensure apt is in non-interactive to avoid prompts
 export DEBIAN_FRONTEND=noninteractive
 
-. /etc/os-release
-architecture="$(dpkg --print-architecture)"
 
 # Install dependencies
 check_packages git sudo curl ca-certificates apt-transport-https gnupg2 dirmngr libc-bin

--- a/src/oryx/install.sh
+++ b/src/oryx/install.sh
@@ -62,6 +62,10 @@ check_packages() {
     if ! dpkg -s "$@" > /dev/null 2>&1; then
         apt_get_update
         DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends "$@"
+
+        # Clean up
+        apt-get clean -y
+        rm -rf /var/lib/apt/lists/*
     fi
 }
 
@@ -81,6 +85,10 @@ install_dotnet_using_apt() {
 
     echo -e "Finished attempt to install dotnet.  Sdks installed:\n"
     dotnet --list-sdks
+
+    # Clean up
+    apt-get clean -y
+    rm -rf /var/lib/apt/lists/*
 }
 
 # If we don't already have Oryx installed, install it now.
@@ -116,9 +124,9 @@ if ! dotnet --version > /dev/null ; then
     fi
 fi
 
-BUILD_SCRIPT_GENERATOR=/usr/local/buildscriptgen 
+BUILD_SCRIPT_GENERATOR=/usr/local/buildscriptgen
 ORYX=/usr/local/oryx
-GIT_ORYX=/opt/tmp
+GIT_ORYX=/opt/tmp/oryx-repo
 
 mkdir -p ${BUILD_SCRIPT_GENERATOR}
 mkdir -p ${ORYX}
@@ -145,5 +153,12 @@ chmod -R g+r+w "${ORYX_INSTALL_DIR}" "${BUILD_SCRIPT_GENERATOR}" "${ORYX}"
 find "${ORYX_INSTALL_DIR}" -type d -print0 | xargs -n 1 -0 chmod g+s
 find "${BUILD_SCRIPT_GENERATOR}" -type d -print0 | xargs -n 1 -0 chmod g+s
 find "${ORYX}" -type d -print0 | xargs -n 1 -0 chmod g+s
+
+# Clean up
+rm -rf $GIT_ORYX
+
+# Remove NuGet installed by the build/buildSln.sh
+rm -rf /root/.nuget
+rm -rf /root/.local/share/NuGet
 
 echo "Done!"

--- a/test/oryx/install_dotnet_and_oryx.sh
+++ b/test/oryx/install_dotnet_and_oryx.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "Oryx version" oryx --version
+check "Dotnet is not removed if it is not installed by the Oryx Feature" dotnet --version
+
+# Report result
+reportResults

--- a/test/oryx/scenarios.json
+++ b/test/oryx/scenarios.json
@@ -1,0 +1,9 @@
+{
+    "install_dotnet_and_oryx": {
+        "image": "ubuntu:focal",
+        "features": {
+            "dotnet": "6",
+            "oryx": {}
+        }
+    }
+}

--- a/test/oryx/test.sh
+++ b/test/oryx/test.sh
@@ -10,5 +10,8 @@ check "Dotnet version" dotnet --version
 check "ORYX_SDK_STORAGE_BASE_URL" echo $ORYX_SDK_STORAGE_BASE_URL
 check "ENABLE_DYNAMIC_INSTALL" echo $ENABLE_DYNAMIC_INSTALL
 
+check "oryx-install-nodejs-12.22.11" oryx prep --skip-detection --platforms-and-versions nodejs=12.22.11
+check "nodejs-12.22.11-installed-by-oryx" ls /opt/nodejs/ | grep 12.22.11
+
 # Report result
 reportResults

--- a/test/oryx/test.sh
+++ b/test/oryx/test.sh
@@ -6,7 +6,6 @@ set -e
 source dev-container-features-test-lib
 
 check "Oryx version" oryx --version
-check "Dotnet version" dotnet --version
 check "ORYX_SDK_STORAGE_BASE_URL" echo $ORYX_SDK_STORAGE_BASE_URL
 check "ENABLE_DYNAMIC_INSTALL" echo $ENABLE_DYNAMIC_INSTALL
 


### PR DESCRIPTION
With this cleanup, the size of the docker layer for the oryx feature reduced from `2.6 GB` to `205 MB`

Before these changes

![image](https://user-images.githubusercontent.com/24955913/186477621-1dfaffae-a6a6-402c-908c-5abb334f2b01.png)

After

![image](https://user-images.githubusercontent.com/24955913/186476886-fe60c429-87af-4372-a100-593dab9b3641.png)
