### PR TITLE
Add NOTES.md for CUDA feature

### DIFF
--- a/src/nvidia-cuda/NOTES.md
+++ b/src/nvidia-cuda/NOTES.md
@@ -1,0 +1,19 @@
+## Compatibility
+
+This Feature adds shared libraries for NVIDIA CUDA and is only useful for devcontainers that run on a host machine with an NVIDIA GPU. Within your devcontainer, use the `nvidia-smi` command to ensure that your GPU is available for CUDA.
+
+If the `nvidia-smi` command is not available within your devcontainer, you may need to complete the following steps:
+
+### Install the NVIDIA Container Toolkit
+
+Follow [NVIDIA's instructions to install the NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/overview.html) on your host machine. The NVIDIA Container Toolkit is available on a variety of Linux distributions. Make sure you have installed the NVIDIA driver for your Linux distribution before installing the NVIDIA Container Toolkit.
+
+### Enable GPU passthrough
+
+Enable GPU passthrough to your devcontainer by adding `["--gpus", "all"]` to your devcontainer's `runArgs` property. Here's an example of a devcontainer with this property:
+
+```json
+{
+  "runArgs": ["--gpus", "all"]
+}
+```


### PR DESCRIPTION
Related: https://github.com/devcontainers/features/pull/109#discussion_r950883586

Adds a NOTES.md file for the `nvidia-cuda` feature with details about compatibility. The `nvidia-cuda` feature is only useful to devcontainers that are running on a host machine with an NVIDIA GPU that is configured correctly. Users need to make sure that the following requirements are met in order to use the `nvidia-cuda` feature:

- Host machine must have an NVIDIA GPU
- Host machine must have NVIDIA drivers installed 
- Host machine must have NVIDIA Container Toolkit installer
- `devcontainer.json` must specify `"runArgs": ["--gpus", "all"]` to enable GPU passthrough