### PR TITLE
Anaconda - Clean up and shrink size

### DIFF
--- a/src/anaconda/devcontainer-feature.json
+++ b/src/anaconda/devcontainer-feature.json
@@ -6,14 +6,16 @@
         "version": {
             "type": "string",
             "proposals": [
-                "latest"
+                "latest",
+                "4.11.0",
+                "4.12.0"
             ],
             "default": "latest",
             "description": "Select or enter an anaconda version."
         }
     },
     "containerEnv": {
-        "CONDA_DIR": "/usr/local/conda",
+        "CONDA_DIR": "/opt/conda",
         "PATH": "${PATH}:${CONDA_DIR}/bin:"
     }
 }

--- a/src/anaconda/devcontainer-feature.json
+++ b/src/anaconda/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "anaconda",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "name": "Anaconda",
     "options": {
         "version": {

--- a/src/anaconda/install.sh
+++ b/src/anaconda/install.sh
@@ -11,7 +11,7 @@
 VERSION=${VERSION:-"latest"}
 USERNAME=${USERNAME:-"automatic"}
 UPDATE_RC=${UPDATE_RC:-"true"}
-CONDA_DIR=${CONDA_DIR:-"/usr/local/conda"}
+CONDA_DIR="/opt/conda"
 
 set -eux
 export DEBIAN_FRONTEND=noninteractive
@@ -66,6 +66,10 @@ check_packages() {
     if ! dpkg -s "$@" > /dev/null 2>&1; then
         apt-get update -y
         apt-get -y install --no-install-recommends "$@"
+
+        # Clean up
+        apt-get clean -y
+        rm -rf /var/lib/apt/lists/*
     fi
 }
 
@@ -77,29 +81,33 @@ if ! conda --version &> /dev/null ; then
     usermod -a -G conda "${USERNAME}"
 
     # Install dependencies
-    check_packages wget ca-certificates
+    check_packages curl ca-certificates gnupg2
 
-    mkdir -p $CONDA_DIR
+    echo "Installing Anaconda..."
+
+    curl -sS https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc | gpg --dearmor > /usr/share/keyrings/conda-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/conda-archive-keyring.gpg] https://repo.anaconda.com/pkgs/misc/debrepo/conda stable main" > /etc/apt/sources.list.d/conda.list
+
+    CONDA_PKG="conda=${VERSION}-0"
+    if [ "${VERSION}" = "latest" ]; then
+        CONDA_PKG="conda"
+    fi
+
+    check_packages $CONDA_PKG
+
+    CONDA_SCRIPT="/opt/conda/etc/profile.d/conda.sh"
+    . $CONDA_SCRIPT
+
+    conda config --add channels conda-forge
+    conda config --set channel_priority strict
+    conda config --set env_prompt '({name})'
+    echo "source ${CONDA_SCRIPT}" >> ~/.bashrc
+
     chown -R "${USERNAME}:conda" "${CONDA_DIR}"
     chmod -R g+r+w "${CONDA_DIR}"
     
     find "${CONDA_DIR}" -type d -print0 | xargs -n 1 -0 chmod g+s
-    echo "Installing Anaconda..."
 
-    CONDA_VERSION=$VERSION
-    if [ "${VERSION}" = "latest" ] || [ "${VERSION}" = "lts" ]; then
-        CONDA_VERSION="2021.11"
-    fi
-
-    su --login -c "wget -q https://repo.anaconda.com/archive/Anaconda3-${CONDA_VERSION}-Linux-x86_64.sh -O /tmp/anaconda-install.sh \
-        && /bin/bash /tmp/anaconda-install.sh -u -b -p ${CONDA_DIR}" ${USERNAME} 2>&1 
-    
-    if [ "${VERSION}" = "latest" ] || [ "${VERSION}" = "lts" ]; then
-        PATH=$PATH:${CONDA_DIR}/bin
-        conda update -y conda
-    fi
-
-    rm /tmp/anaconda-install.sh 
     updaterc "export CONDA_DIR=${CONDA_DIR}/bin"
 fi
 


### PR DESCRIPTION
With this cleanup, the size of the docker layer for the Anaconda Feature reduced from **`4.0 GB`** to **`200 MB`**

Cause - Previously it was built from source where `conda/lib` was approx 2 GB. Switched to `apt-get install`

Before these changes

![image](https://user-images.githubusercontent.com/24955913/187565832-95261833-622e-4999-9316-b8760b5c8f26.png)

After

![image](https://user-images.githubusercontent.com/24955913/187564950-859aa9e5-4f52-47c1-907b-27a4465c30d2.png)