### PR TITLE
Oryx - Fix bug when dynamically installing dotnet in universal image

### DIFF
--- a/src/oryx/devcontainer-feature.json
+++ b/src/oryx/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "oryx",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "name": "Oryx",
     "description": "Installs the oryx CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/oryx",

--- a/src/oryx/install.sh
+++ b/src/oryx/install.sh
@@ -166,6 +166,9 @@ find "${ORYX_INSTALL_DIR}" -type d -print0 | xargs -n 1 -0 chmod g+s
 find "${BUILD_SCRIPT_GENERATOR}" -type d -print0 | xargs -n 1 -0 chmod g+s
 find "${ORYX}" -type d -print0 | xargs -n 1 -0 chmod g+s
 
+#  /opt/tmp/build is required by Oryx for dynamically installing platforms
+cp -rf $GIT_ORYX/build /opt/tmp
+
 # Clean up
 rm -rf $GIT_ORYX
 

--- a/src/oryx/install.sh
+++ b/src/oryx/install.sh
@@ -166,8 +166,9 @@ find "${ORYX_INSTALL_DIR}" -type d -print0 | xargs -n 1 -0 chmod g+s
 find "${BUILD_SCRIPT_GENERATOR}" -type d -print0 | xargs -n 1 -0 chmod g+s
 find "${ORYX}" -type d -print0 | xargs -n 1 -0 chmod g+s
 
-#  /opt/tmp/build is required by Oryx for dynamically installing platforms
+# /opt/tmp/build and /opt/tmp/images is required by Oryx for dynamically installing platforms
 cp -rf $GIT_ORYX/build /opt/tmp
+cp -rf $GIT_ORYX/images /opt/tmp
 
 # Clean up
 rm -rf $GIT_ORYX

--- a/test/oryx/install_dotnet_and_oryx.sh
+++ b/test/oryx/install_dotnet_and_oryx.sh
@@ -8,5 +8,40 @@ source dev-container-features-test-lib
 check "Oryx version" oryx --version
 check "Dotnet is not removed if it is not installed by the Oryx Feature" dotnet --version
 
+# Install platforms with oryx build tool
+check "oryx-install-dotnet-2.1" oryx prep --skip-detection --platforms-and-versions dotnet=2.1.30
+check "dotnet-2-installed-by-oryx" ls /opt/dotnet/ | grep 2.1
+
+check "oryx-install-nodejs-12.22.11" oryx prep --skip-detection --platforms-and-versions nodejs=12.22.11
+check "nodejs-12.22.11-installed-by-oryx" ls /opt/nodejs/ | grep 12.22.11
+
+check "oryx-install-php-7.3.25" oryx prep --skip-detection --platforms-and-versions php=7.3.25
+check "php-7.3.25-installed-by-oryx" ls /opt/php/ | grep 7.3.25
+
+check "oryx-install-java-12.0.2" oryx prep --skip-detection --platforms-and-versions java=12.0.2
+check "java-12.0.2-installed-by-oryx" ls /opt/java/ | grep 12.0.2
+
+# Replicates Oryx's behavior for universal image
+mkdir -p /opt/oryx
+echo "vso-focal" >> /opt/oryx/.imagetype
+
+mkdir -p /opt/dotnet/lts
+cp -R /usr/local/dotnet/current/dotnet /opt/dotnet/lts
+cp -R /usr/local/dotnet/current/LICENSE.txt /opt/dotnet/lts
+cp -R /usr/local/dotnet/current/ThirdPartyNotices.txt /opt/dotnet/lts
+
+# Install platforms with oryx build tool
+check "oryx-install-dotnet-2.1-universal" oryx prep --skip-detection --platforms-and-versions dotnet=2.1.30
+check "dotnet-2-installed-by-oryx-universal" ls /opt/dotnet/ | grep 2.1
+
+check "oryx-install-nodejs-12.22.11-universal" oryx prep --skip-detection --platforms-and-versions nodejs=12.22.11
+check "nodejs-12.22.11-installed-by-oryx-universal" ls /opt/nodejs/ | grep 12.22.11
+
+check "oryx-install-php-7.3.25-universal" oryx prep --skip-detection --platforms-and-versions php=7.3.25
+check "php-7.3.25-installed-by-oryx-universal" ls /opt/php/ | grep 7.3.25
+
+check "oryx-install-java-12.0.2-universal" oryx prep --skip-detection --platforms-and-versions java=12.0.2
+check "java-12.0.2-installed-by-oryx-universal" ls /opt/java/ | grep 12.0.2
+
 # Report result
 reportResults

--- a/test/oryx/scenarios.json
+++ b/test/oryx/scenarios.json
@@ -2,7 +2,10 @@
     "install_dotnet_and_oryx": {
         "image": "ubuntu:focal",
         "features": {
-            "dotnet": "6",
+            "dotnet": {
+                "version": "6",
+                "installUsingApt": "false"
+            },
             "oryx": {}
         }
     }

--- a/test/oryx/test.sh
+++ b/test/oryx/test.sh
@@ -9,8 +9,18 @@ check "Oryx version" oryx --version
 check "ORYX_SDK_STORAGE_BASE_URL" echo $ORYX_SDK_STORAGE_BASE_URL
 check "ENABLE_DYNAMIC_INSTALL" echo $ENABLE_DYNAMIC_INSTALL
 
+# Install platforms with oryx build tool
+check "oryx-install-dotnet-2.1" oryx prep --skip-detection --platforms-and-versions dotnet=2.1.30
+check "dotnet-2-installed-by-oryx" ls /opt/dotnet/ | grep 2.1
+
 check "oryx-install-nodejs-12.22.11" oryx prep --skip-detection --platforms-and-versions nodejs=12.22.11
 check "nodejs-12.22.11-installed-by-oryx" ls /opt/nodejs/ | grep 12.22.11
+
+check "oryx-install-php-7.3.25" oryx prep --skip-detection --platforms-and-versions php=7.3.25
+check "php-7.3.25-installed-by-oryx" ls /opt/php/ | grep 7.3.25
+
+check "oryx-install-java-12.0.2" oryx prep --skip-detection --platforms-and-versions java=12.0.2
+check "java-12.0.2-installed-by-oryx" ls /opt/java/ | grep 12.0.2
 
 # Report result
 reportResults


### PR DESCRIPTION
Fixes - https://github.com/devcontainers/images/runs/8118223037?check_suite_focus=true

<img width="964" alt="image" src="https://user-images.githubusercontent.com/24955913/187781941-757b8d85-d6d2-49c2-add3-8ab76b616b07.png">

- Oryx Feature is now `223 MB` with this change
- Regression from https://github.com/devcontainers/features/pull/116
- Added tests which replicates Oryx's behavior for universal image


