### PR TITLE
Set HashiCorp Terraform Extension Defaults

### DIFF
--- a/src/terraform/devcontainer-feature.json
+++ b/src/terraform/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "terraform",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "name": "Terraform, tflint, and TFGrunt",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/terraform",
     "description": "Installs the Terraform CLI and optionally TFLint and Terragrunt. Auto-detects latest version and installs needed dependencies.",

--- a/src/terraform/devcontainer-feature.json
+++ b/src/terraform/devcontainer-feature.json
@@ -41,12 +41,10 @@
                 "ms-azuretools.vscode-azureterraform"
             ],
             "settings": {
-                "terraform.languageServer": {
-                    "enabled": true,
-                    "args": [
-                        "serve"
-                    ]
-                },
+                "terraform.languageServer.enable": true,
+                "terraform.languageServer.args": [
+                    "serve"
+                ],
                 "azureTerraform.terminal": "integrated"
             }
         }


### PR DESCRIPTION
This updates the HashiCorp Extension settings to the updated naming convention.

The HashiCorp Extension [changed it's setting structure](https://github.com/hashicorp/vscode-terraform/blob/main/docs/settings-migration.md#settings-migration) for some settings in v2.24.0. Old settings are still honored for a period of time, but we should update this devcontainer with the correct names.

Related: https://github.com/microsoft/vscode-dev-containers/issues/1608
