### PR TITLE
Go - Adds `/go/bin` to PATH

### DIFF
--- a/src/go/devcontainer-feature.json
+++ b/src/go/devcontainer-feature.json
@@ -27,8 +27,8 @@
     },
     "containerEnv": {
         "GOROOT": "/usr/local/go",
-        "GOPATH": "/usr/local/go",
-        "PATH": "/usr/local/go/bin:${PATH}"
+        "GOPATH": "/go",
+        "PATH": "/usr/local/go/bin:/go/bin:${PATH}"
     },
     "capAdd": [
         "SYS_PTRACE"

--- a/src/go/devcontainer-feature.json
+++ b/src/go/devcontainer-feature.json
@@ -26,6 +26,7 @@
         }
     },
     "containerEnv": {
+        "GOROOT": "/usr/local/go",
         "GOPATH": "/usr/local/go",
         "PATH": "/usr/local/go/bin:${PATH}"
     },

--- a/src/go/install.sh
+++ b/src/go/install.sh
@@ -10,6 +10,7 @@
 TARGET_GO_VERSION=${VERSION:-"latest"}
 
 TARGET_GOROOT=${TARGET_GOROOT:-"/usr/local/go"}
+TARGET_GOPATH=${TARGET_GOPATH:-"/go"}
 USERNAME=${USERNAME:-"automatic"}
 INSTALL_GO_TOOLS=${INSTALL_GO_TOOLS:-"true"}
 
@@ -135,7 +136,7 @@ if ! cat /etc/group | grep -e "^golang:" > /dev/null 2>&1; then
     groupadd -r golang
 fi
 usermod -a -G golang "${USERNAME}"
-mkdir -p "${TARGET_GOROOT}"
+mkdir -p "${TARGET_GOROOT}" "${TARGET_GOPATH}"
 if [ "${TARGET_GO_VERSION}" != "none" ] && ! type go > /dev/null 2>&1; then
     # Use a temporary locaiton for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"
@@ -197,7 +198,7 @@ GO_TOOLS="\
 if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
     echo "Installing common Go tools..."
     export PATH=${TARGET_GOROOT}/bin:${PATH}
-    mkdir -p /tmp/gotools /usr/local/etc/vscode-dev-containers ${TARGET_GOROOT}/bin
+    mkdir -p /tmp/gotools /usr/local/etc/vscode-dev-containers ${TARGET_GOPATH}/bin
     cd /tmp/gotools
     export GOPATH=/tmp/gotools
     export GOCACHE=/tmp/gotools/cache
@@ -213,14 +214,15 @@ if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
     (echo "${GO_TOOLS}" | xargs -n 1 go ${go_install_command} -v )2>&1 | tee -a /usr/local/etc/vscode-dev-containers/go.log
 
     # Move Go tools into path and clean up
-    mv /tmp/gotools/bin/* ${TARGET_GOROOT}/bin/
+    mv /tmp/gotools/bin/* ${TARGET_GOPATH}/bin/
 
     rm -rf /tmp/gotools
 fi
 
 
-chown -R "${USERNAME}:golang" "${TARGET_GOROOT}"
-chmod -R g+r+w "${TARGET_GOROOT}"
+chown -R "${USERNAME}:golang" "${TARGET_GOROOT}" "${TARGET_GOPATH}"
+chmod -R g+r+w "${TARGET_GOROOT}" "${TARGET_GOPATH}"
 find "${TARGET_GOROOT}" -type d -print0 | xargs -n 1 -0 chmod g+s
+find "${TARGET_GOPATH}" -type d -print0 | xargs -n 1 -0 chmod g+s
 
 echo "Done!"

--- a/test/go/install_go_tool_in_postCreate.sh
+++ b/test/go/install_go_tool_in_postCreate.sh
@@ -5,8 +5,7 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
-check "version" go version
-check "revive version" revive --version
+check "mkcert version" mkcert --version | grep "v1.4.2"
 
 # Report result
 reportResults

--- a/test/go/install_go_tool_in_postCreate.sh
+++ b/test/go/install_go_tool_in_postCreate.sh
@@ -6,7 +6,7 @@ set -e
 source dev-container-features-test-lib
 
 check "mkcert version" mkcert --version | grep "v1.4.2"
-check "mkcert is installed at correct path" which mkcert | grep "/usr/local/go/bin/mkcert"
+check "mkcert is installed at correct path" which mkcert | grep "/go/bin/mkcert"
 
 # Report result
 reportResults

--- a/test/go/install_go_tool_in_postCreate.sh
+++ b/test/go/install_go_tool_in_postCreate.sh
@@ -6,6 +6,7 @@ set -e
 source dev-container-features-test-lib
 
 check "mkcert version" mkcert --version | grep "v1.4.2"
+check "mkcert is installed at correct path" which mkcert | grep "/usr/local/go/bin/mkcert"
 
 # Report result
 reportResults

--- a/test/go/scenarios.json
+++ b/test/go/scenarios.json
@@ -1,0 +1,11 @@
+{
+    "install_go_tool_in_postCreate": {
+        "image": "ubuntu:focal",
+        "features": {
+            "go": {
+                "version": "latest"
+            }
+        },
+        "postCreateCommand": "go install filippo.io/mkcert@v1.4.2"
+    }
+}

--- a/test/go/test.sh
+++ b/test/go/test.sh
@@ -7,7 +7,7 @@ source dev-container-features-test-lib
 
 check "version" go version
 check "revive version" revive --version
-check "revive is installed at correct path" which revive | grep "/usr/local/go/bin/revive"
+check "revive is installed at correct path" which revive | grep "/go/bin/revive"
 
 # Report result
 reportResults

--- a/test/go/test.sh
+++ b/test/go/test.sh
@@ -7,6 +7,7 @@ source dev-container-features-test-lib
 
 check "version" go version
 check "revive version" revive --version
+check "revive is installed at correct path" which revive | grep "/usr/local/go/bin/revive"
 
 # Report result
 reportResults


### PR DESCRIPTION
Fixes - https://github.com/devcontainers/features/issues/159

`go` is installed at `/usr/local/go/bin` and the go tools are installed at `/go/bin`. Updated `containerEnv` to reflect the same. 

Also, removed `updateRc` which updated `GOROOT`, `GOPATH` and `PATH` (`containerEnv` already updates that)