### PR TITLE
Go: bump version

### DIFF
--- a/src/go/devcontainer-feature.json
+++ b/src/go/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "go",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "name": "Go",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/go",
     "description": "Installs Go and common Go utilities. Auto-detects latest version and installs needed dependencies.",


### PR DESCRIPTION
Missed that in https://github.com/devcontainers/features/pull/162