### PR TITLE
Add new option to install azure-cli extensions

### DIFF
--- a/src/azure-cli/devcontainer-feature.json
+++ b/src/azure-cli/devcontainer-feature.json
@@ -14,9 +14,9 @@
       "description": "Select or enter an Azure CLI version. (Available versions may vary by Linux distribution.)"
     },
     "extensions": {
-      "type": "array",
-      "default": [],
-      "description": "Enter Azure CLI extension names you wish to include."
+      "type": "string",
+      "default": "",
+      "description": "Optional comma separated list of Azure CLI extensions to install in profile."
     }
   },
   "customizations": {

--- a/src/azure-cli/devcontainer-feature.json
+++ b/src/azure-cli/devcontainer-feature.json
@@ -12,14 +12,19 @@
       ],
       "default": "latest",
       "description": "Select or enter an Azure CLI version. (Available versions may vary by Linux distribution.)"
+    },
+    "extensions": {
+      "type": "array",
+      "default": [],
+      "description": "Enter Azure CLI extension names you wish to include."
     }
   },
   "customizations": {
-      "vscode": {
-          "extensions": [
-            "ms-vscode.azurecli"
-          ]
-      }
+    "vscode": {
+      "extensions": [
+        "ms-vscode.azurecli"
+      ]
+    }
   },
   "installsAfter": [
     "ghcr.io/devcontainers/features/common-utils"

--- a/src/azure-cli/devcontainer-feature.json
+++ b/src/azure-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-cli",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "name": "Azure CLI",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/azure-cli",
   "description": "Installs the Azure CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",

--- a/src/azure-cli/install.sh
+++ b/src/azure-cli/install.sh
@@ -13,6 +13,7 @@ set -e
 rm -rf /var/lib/apt/lists/*
 
 AZ_VERSION=${VERSION:-"latest"}
+AZ_EXTENSIONS=${EXTENSIONS}
 
 MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
 AZCLI_ARCHIVE_ARCHITECTURES="amd64"
@@ -183,6 +184,17 @@ if [ "${use_pip}" = "true" ]; then
         apt-cache madison azure-cli | awk -F"|" '{print $2}' | grep -oP '^(.+:)?\K.+'
         exit 1
     fi
+fi
+
+# If Azure CLI extensions are requested, loop through and install 
+if [ ${#AZ_EXTENSIONS[@]} -gt 0 ]; then
+    echo "Installing Azure CLI extensions: ${AZ_EXTENSIONS}"
+    extensions=(`echo ${AZ_EXTENSIONS} | tr ',' ' '`)
+    for i in "${extensions[@]}"
+    do
+        echo "Installing ${i}"
+        su $(getent passwd "1000" | cut -d: -f1) -c "az extension add --name ${i} -y"
+    done
 fi
 
 # Clean up

--- a/src/azure-cli/install.sh
+++ b/src/azure-cli/install.sh
@@ -193,7 +193,7 @@ if [ ${#AZ_EXTENSIONS[@]} -gt 0 ]; then
     for i in "${extensions[@]}"
     do
         echo "Installing ${i}"
-        su ${_REMOTE_USER} -c "az extension add --name ${i} -y"
+        su ${_REMOTE_USER} -c "az extension add --name ${i} -y" || continue
     done
 fi
 

--- a/src/azure-cli/install.sh
+++ b/src/azure-cli/install.sh
@@ -193,7 +193,7 @@ if [ ${#AZ_EXTENSIONS[@]} -gt 0 ]; then
     for i in "${extensions[@]}"
     do
         echo "Installing ${i}"
-        su $(getent passwd "1000" | cut -d: -f1) -c "az extension add --name ${i} -y"
+        su ${_REMOTE_USER} -c "az extension add --name ${i} -y"
     done
 fi
 

--- a/test/azure-cli/install_extensions.sh
+++ b/test/azure-cli/install_extensions.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+# Import test library for `check` command
+source dev-container-features-test-lib
+
+# Check to make sure the user is vscode
+check "user is vscode" whoami | grep vscode
+
+# Extension-specific tests
+check "aks-preview" az extension show --name aks-preview
+check "amg" az extension show --name amg
+check "containerapp" az extension show --name containerapp
+
+# Report result
+reportResults

--- a/test/azure-cli/scenarios.json
+++ b/test/azure-cli/scenarios.json
@@ -1,0 +1,12 @@
+{
+  "install_extensions": {
+    "image": "ubuntu:focal",
+    "user": "vscode",
+    "features": {
+      "azure-cli": {
+        "version": "latest",
+        "extensions": "aks-preview,amg,containerapp"
+      }
+    }
+  }
+}


### PR DESCRIPTION
@jkeech and @asaikali - I have the code working which would resolve #149 but my solution for obtaining the `remoteUser` is a bit of a hack (for now). Will keep this as a draft PR until [devcontainers/spec#91](https://github.com/devcontainers/spec/issues/91) is sorted out. 