### PR TITLE
Rename JupyterLab config file

### DIFF
--- a/src/python/devcontainer-feature.json
+++ b/src/python/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "python",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "name": "Python",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/python",
   "description": "Installs the provided version of Python, as well as PIPX, and other common Python utilities.  JupyterLab is conditionally installed with the python feature. Note: May require source code compilation.",

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -320,7 +320,7 @@ install_user_package() {
 
 add_user_jupyter_config() {
     CONFIG_DIR="/home/$USERNAME/.jupyter"
-    CONFIG_FILE="$CONFIG_DIR/jupyter_notebook_config.py"
+    CONFIG_FILE="$CONFIG_DIR/jupyter_server_config.py"
 
     # Make sure the config file exists or create it with proper permissions
     test -d "$CONFIG_DIR" || sudo_if mkdir "$CONFIG_DIR"

--- a/test/python/install_jupyterlab.sh
+++ b/test/python/install_jupyterlab.sh
@@ -6,7 +6,7 @@ set -e
 source dev-container-features-test-lib
 
 check "version" jupyter lab --version
-check "config" grep ".*.allow_origin = '*'" /home/vscode/.jupyter/jupyter_notebook_config.py
+check "config" grep ".*.allow_origin = '*'" /home/vscode/.jupyter/jupyter_server_config.py
 
 check "user" whoami | grep vscode
 check "zsh" zsh --version


### PR DESCRIPTION
Jupyter recently changed the name of the file used to configure JupyterLab. It's now `jupyter_server_config.py` instead of `jupyter_notebook_config.py`. This PR updates the name of the file authored by the Python feature.

https://jupyter-server.readthedocs.io/en/latest/users/configuration.html

I'm not the biggest fan of the Python feature managing this config file, but I think we should correct this filename ASAP while we work on refactoring the feature.