### PR TITLE
Add remoteUser to devcontainer

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,5 +1,6 @@
 {
     "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:0-18",
+    "remoteUser": "node",
     "customizations": {
         "vscode": {
             "extensions": [


### PR DESCRIPTION
Adds `"remoteUser": "node"` to this repo's `devcontainer.json` to fix permissions issues.

I often encounter permissions issues running `devcontainer features test` with the existing devcontainer configuration. Does anyone else? Setting this `remoteUser` property seems to fix things.

### Output Without `remoteUser`

```sh
devcontainer features test . -f python --skip-autogenerated
```
```sh
chmod: cannot access './install_jupyterlab-test-1663972727629.sh': Permission denied
chmod: cannot access './dev-container-features-test-lib': Permission denied
OCI runtime exec failed: exec failed: unable to start container process: exec: "./install_jupyterlab-test-1663972727629.sh": permission denied: unknown
```

<img width="1103" alt="chmod: cannot access: Permission denied" src="https://user-images.githubusercontent.com/19893438/192065720-c3f0faa9-8631-413e-9eea-2dd04ecff612.png">

### Output With `remoteUser`

```sh
devcontainer features test . -f python --skip-autogenerated
```
```sh
Test Passed!
```

(As expected)