### PR TITLE
Fix additional Python and JupyterLab edge case

### DIFF
--- a/test/python/install_additional_jupyterlab.sh
+++ b/test/python/install_additional_jupyterlab.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Always run these checks as the non-root user
+user="$(whoami)"
+check "user" grep vscode <<< "$user"
+
+# Check for an installation of JupyterLab
+check "version" jupyter lab --version
+
+# Check location of JupyterLab installation
+packages="$(python3 -m pip list)"
+check "location" grep jupyter <<< "$packages"
+
+# Check for correct JupyterLab configuration
+check "config" grep ".*.allow_origin = '*'" /home/vscode/.jupyter/jupyter_server_config.py
+
+# Report result
+reportResults

--- a/test/python/install_jupyterlab.sh
+++ b/test/python/install_jupyterlab.sh
@@ -5,12 +5,17 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
-check "version" jupyter lab --version
-check "config" grep ".*.allow_origin = '*'" /home/vscode/.jupyter/jupyter_server_config.py
-
+# Run these checks as the non-root user
 check "user" whoami | grep vscode
-check "zsh" zsh --version
-check "wget" wget -V
+
+# Check for an installation of JupyterLab
+check "version" jupyter lab --version
+
+# Check location of JupyterLab installation
+# check "location" /usr/local/python/current/bin/python3 -m pip list | grep jupyter
+
+# Check for correct JupyterLab configuration
+check "config" grep ".*.allow_origin = '*'" /home/vscode/.jupyter/jupyter_server_config.py
 
 # Report result
 reportResults

--- a/test/python/install_jupyterlab.sh
+++ b/test/python/install_jupyterlab.sh
@@ -5,14 +5,16 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
-# Run these checks as the non-root user
-check "user" whoami | grep vscode
+# Always run these checks as the non-root user
+user="$(whoami)"
+check "user" grep vscode <<< "$user"
 
 # Check for an installation of JupyterLab
 check "version" jupyter lab --version
 
 # Check location of JupyterLab installation
-# check "location" /usr/local/python/current/bin/python3 -m pip list | grep jupyter
+packages="$(python3 -m pip list)"
+check "location" grep jupyter <<< "$packages"
 
 # Check for correct JupyterLab configuration
 check "config" grep ".*.allow_origin = '*'" /home/vscode/.jupyter/jupyter_server_config.py

--- a/test/python/scenarios.json
+++ b/test/python/scenarios.json
@@ -12,9 +12,6 @@
         "image": "mcr.microsoft.com/vscode/devcontainers/base:focal",
         "remoteUser": "vscode",
         "features": {
-            "common-utils": {
-                "username": "vscode"
-            },
             "python": {
                 "installJupyterlab": true,
                 "configureJupyterlabAllowOrigin": "*"

--- a/test/python/scenarios.json
+++ b/test/python/scenarios.json
@@ -18,6 +18,18 @@
             }
         }
     },
+    "install_additional_jupyterlab": {
+        "image": "mcr.microsoft.com/vscode/devcontainers/base:focal",
+        "remoteUser": "vscode",
+        "features": {
+            "python": {
+                "version": "latest",
+                "additionalVersions": "3.9",
+                "installJupyterlab": true,
+                "configureJupyterlabAllowOrigin": "*"
+            }
+        }
+    },
     "install_os_provided_python": {
         "image": "mcr.microsoft.com/devcontainers/base:0-bullseye",
         "features": {


### PR DESCRIPTION
Related: https://github.com/devcontainers/images/issues/125

Fixes an edge case in the Python feature that installs JupyterLab to the `additionalVersions` of Python instead of the primary `version` of Python.

This PR also removes junk from our JupyterLab test and adds a new test that would have caught this bug.

### Edge Case Details

`install_user_package` installs packages to whatever Python installation is specified by `$INSTALL_PATH`. Both `install_from_source` and `install_using_oryx` overwrite this variable. When we use `install_python` to install an extra version of Python, we overwrite `$INSTALL_PATH` to that installation.

When we install JupyterLab at the end of the script, it uses the `$INSTALL_PATH` set by the most recent `additionalVersions` instead of `version`.