### PR TITLE
features/node: `NVM_VERSION` to get the latest

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -9,8 +9,7 @@
         }
     },
     "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:1": {},
-        "./src/node": {}
+        "ghcr.io/devcontainers/features/docker-in-docker:1": {}
     },
     "postCreateCommand": "npm install -g @devcontainers/cli"
 }

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -9,7 +9,8 @@
         }
     },
     "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:1": {}
+        "ghcr.io/devcontainers/features/docker-in-docker:1": {},
+        "./src/node": {}
     },
     "postCreateCommand": "npm install -g @devcontainers/cli"
 }

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -18,7 +18,8 @@ ADDITIONAL_VERSIONS=${ADDITIONALVERSIONS:-""}
 USERNAME=${USERNAME:-"automatic"}
 UPDATE_RC=${UPDATE_RC:-"true"}
 
-export NVM_VERSION="0.38.0"
+export NVM_VERSION=$(curl -H "Accept: application/vnd.github.v3+json" \
+    https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r '.tag_name')
 
 set -e
 
@@ -126,7 +127,7 @@ su ${USERNAME} -c "$(cat << EOF
     umask 0002
     # Do not update profile - we'll do this manually
     export PROFILE=/dev/null
-    curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh | bash 
+    curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh | bash 
     source ${NVM_DIR}/nvm.sh
     if [ "${NODE_VERSION}" != "" ]; then
         nvm alias default ${NODE_VERSION}


### PR DESCRIPTION
Related to #190

As discussed in the issue, I'd like to create this PR to get the latest version of NVM, instead of pinning `v0.38.0`.

As a non-bash-expert, I think it's as simple as changing the two lines. But if there are other places for me to look at, please let me know.