### PR TITLE
Add docker-in-docker azure_dns_override flag

### DIFF
--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -28,6 +28,11 @@
             ],
             "default": "v1",
             "description": "Default version of Docker Compose (v1 or v2)"
+        },
+        "azureDnsOverride": {
+            "type": "boolean",
+            "default": true,
+            "description": "Override docker daemon DNS settings to use Azure DNS"
         }
     },
     "entrypoint": "/usr/local/share/docker-init.sh",

--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -29,10 +29,10 @@
             "default": "v1",
             "description": "Default version of Docker Compose (v1 or v2)"
         },
-        "azureDnsOverride": {
+        "azureDnsAutoDetection": {
             "type": "boolean",
             "default": true,
-            "description": "Override docker daemon DNS settings to use Azure DNS"
+            "description": "Allow automatically setting the dockerd DNS server when the installation script detects it is running in Azure"
         }
     },
     "entrypoint": "/usr/local/share/docker-init.sh",

--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "name": "Docker (Docker-in-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
     "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -11,7 +11,7 @@
 DOCKER_VERSION=${VERSION:-"latest"} # The Docker/Moby Engine + CLI should match in version
 USE_MOBY=${MOBY:-"true"}
 DOCKER_DASH_COMPOSE_VERSION=${DOCKERDASHCOMPOSEVERSION:-"v1"} # v1 or v2
-AZURE_DNS_OVERRIDE=${AZUREDNSOVERRIDE:-"true"}
+AZURE_DNS_AUTO_DETECTION=${AZUREDNSAUTODETECTION:-"true"}
 
 ENABLE_NONROOT_DOCKER=${ENABLE_NONROOT_DOCKER:-"true"}
 USERNAME=${USERNAME:-"automatic"}
@@ -322,7 +322,7 @@ tee /usr/local/share/docker-init.sh > /dev/null \
 
 set -e
 
-AZURE_DNS_OVERRIDE=$AZURE_DNS_OVERRIDE
+AZURE_DNS_AUTO_DETECTION=$AZURE_DNS_AUTO_DETECTION
 EOF
 
 tee -a /usr/local/share/docker-init.sh > /dev/null \
@@ -366,7 +366,7 @@ dockerd_start="$(cat << 'INNEREOF'
     # Handle DNS
     set +e
     cat /etc/resolv.conf | grep -i 'internal.cloudapp.net'
-    if [ $? -eq 0 ] && [ ${AZURE_DNS_OVERRIDE} = "true" ]
+    if [ $? -eq 0 ] && [ ${AZURE_DNS_AUTO_DETECTION} = "true" ]
     then
         echo "Setting dockerd Azure DNS."
         CUSTOMDNS="--dns 168.63.129.16"

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -11,6 +11,7 @@
 DOCKER_VERSION=${VERSION:-"latest"} # The Docker/Moby Engine + CLI should match in version
 USE_MOBY=${MOBY:-"true"}
 DOCKER_DASH_COMPOSE_VERSION=${DOCKERDASHCOMPOSEVERSION:-"v1"} # v1 or v2
+AZURE_DNS_OVERRIDE=${AZUREDNSOVERRIDE:-"true"}
 
 ENABLE_NONROOT_DOCKER=${ENABLE_NONROOT_DOCKER:-"true"}
 USERNAME=${USERNAME:-"automatic"}
@@ -312,7 +313,7 @@ if [ "${ENABLE_NONROOT_DOCKER}" = "true" ]; then
 fi
 
 tee /usr/local/share/docker-init.sh > /dev/null \
-<< 'EOF'
+<< EOF
 #!/bin/sh
 #-------------------------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -321,6 +322,10 @@ tee /usr/local/share/docker-init.sh > /dev/null \
 
 set -e
 
+AZURE_DNS_OVERRIDE=$AZURE_DNS_OVERRIDE
+EOF
+
+tee -a ./docker-init.sh > /dev/null << 'EOF'
 dockerd_start="$(cat << 'INNEREOF'
     # explicitly remove dockerd and containerd PID file to ensure that it can start properly if it was stopped uncleanly
     # ie: docker kill <ID>
@@ -360,7 +365,7 @@ dockerd_start="$(cat << 'INNEREOF'
     # Handle DNS
     set +e
     cat /etc/resolv.conf | grep -i 'internal.cloudapp.net'
-    if [ $? -eq 0 ]
+    if [ $? -eq 0 ] && [ ${AZURE_DNS_OVERRIDE} = "true" ]
     then
         echo "Setting dockerd Azure DNS."
         CUSTOMDNS="--dns 168.63.129.16"

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -325,7 +325,8 @@ set -e
 AZURE_DNS_OVERRIDE=$AZURE_DNS_OVERRIDE
 EOF
 
-tee -a ./docker-init.sh > /dev/null << 'EOF'
+tee -a /usr/local/share/docker-init.sh > /dev/null \
+<< 'EOF'
 dockerd_start="$(cat << 'INNEREOF'
     # explicitly remove dockerd and containerd PID file to ensure that it can start properly if it was stopped uncleanly
     # ie: docker kill <ID>


### PR DESCRIPTION
Add a flag (defaulted to `true`) to toggle passing the Azure DNS ip address to dockerd at startup.