### PR TITLE
Ensure remove apt-update cache at the beginning and end of the scripts

### DIFF
--- a/src/anaconda/devcontainer-feature.json
+++ b/src/anaconda/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "anaconda",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "name": "Anaconda",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/anaconda",
     "options": {

--- a/src/anaconda/install.sh
+++ b/src/anaconda/install.sh
@@ -16,6 +16,9 @@ CONDA_DIR=${CONDA_DIR:-"/usr/local/conda"}
 set -eux
 export DEBIAN_FRONTEND=noninteractive
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
@@ -64,7 +67,10 @@ updaterc() {
 # Checks if packages are installed and installs them if not
 check_packages() {
     if ! dpkg -s "$@" > /dev/null 2>&1; then
-        apt-get update -y
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
         apt-get -y install --no-install-recommends "$@"
     fi
 }
@@ -127,5 +133,8 @@ fi
 if [ -f "/etc/bash.bashrc" ]; then
     echo "${notice_script}" | tee -a /etc/bash.bashrc
 fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
 
 echo "Done!"

--- a/src/aws-cli/devcontainer-feature.json
+++ b/src/aws-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "aws-cli",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "name": "AWS CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/aws-cli",
     "description": "Installs the AWS CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",

--- a/src/aws-cli/install.sh
+++ b/src/aws-cli/install.sh
@@ -9,6 +9,9 @@
 
 set -e
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 VERSION=${VERSION:-"latest"}
 
 AWSCLI_GPG_KEY=FB5DB77FD5C118B80511ADA8A6310ACC4672475C
@@ -71,7 +74,10 @@ apt_get_update()
 # Checks if packages are installed and installs them if not
 check_packages() {
     if ! dpkg -s "$@" > /dev/null 2>&1; then
-        apt_get_update
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
         apt-get -y install --no-install-recommends "$@"
     fi
 }
@@ -132,5 +138,8 @@ install() {
 echo "(*) Installing AWS CLI..."
 
 install
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
 
 echo "Done!"

--- a/src/azure-cli/devcontainer-feature.json
+++ b/src/azure-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-cli",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "name": "Azure CLI",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/azure-cli",
   "description": "Installs the Azure CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",

--- a/src/azure-cli/install.sh
+++ b/src/azure-cli/install.sh
@@ -9,6 +9,9 @@
 
 set -e
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 AZ_VERSION=${VERSION:-"latest"}
 
 MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
@@ -44,7 +47,10 @@ apt_get_update()
 # Checks if packages are installed and installs them if not
 check_packages() {
     if ! dpkg -s "$@" > /dev/null 2>&1; then
-        apt_get_update
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
         apt-get -y install --no-install-recommends "$@"
     fi
 }
@@ -178,5 +184,8 @@ if [ "${use_pip}" = "true" ]; then
         exit 1
     fi
 fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
 
 echo "Done!"

--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "common-utils",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "name": "Common Debian Utilities",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/common-utils",
     "description": "Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.",

--- a/src/common-utils/install.sh
+++ b/src/common-utils/install.sh
@@ -9,6 +9,9 @@
 
 set -e
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 INSTALL_ZSH=${INSTALLZSH:-"true"}
 INSTALL_OH_MY_ZSH=${INSTALLOHMYZSH:-"true"}
 UPGRADE_PACKAGES=${UPGRADEPACKAGES:-"true"}
@@ -60,8 +63,10 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt_get_update()
 {
-    echo "Running apt-get update..."
-    apt-get update -y
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
 }
 
 # Run install apt-utils to avoid debconf warning then verify presence of other common developer tools and dependencies
@@ -446,5 +451,8 @@ echo -e "\
     EXISTING_NON_ROOT_USER=${EXISTING_NON_ROOT_USER}\n\
     RC_SNIPPET_ALREADY_ADDED=${RC_SNIPPET_ALREADY_ADDED}\n\
     ZSH_ALREADY_INSTALLED=${ZSH_ALREADY_INSTALLED}" > "${MARKER_FILE}"
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
 
 echo "Done!"

--- a/src/conda/devcontainer-feature.json
+++ b/src/conda/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "conda",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "name": "Conda",
     "description": "A cross-platform, language-agnostic binary package manager",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/conda",

--- a/src/desktop-lite/devcontainer-feature.json
+++ b/src/desktop-lite/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "desktop-lite",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "name": "Light-weight Desktop",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/desktop-lite",
     "description": "Adds a lightweight Fluxbox based desktop to the container that can be accessed using a VNC viewer or the web. GUI-based commands executed from the built-in VS code terminal will open on the desktop automatically.",

--- a/src/docker-from-docker/devcontainer-feature.json
+++ b/src/docker-from-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-from-docker",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "name": "Docker (Docker-from-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-from-docker",
     "descripton": "Re-use the host docker socket, adding the Docker CLI to a container. Feature invokes a script to enable using a forwarded Docker socket within a container to run Docker commands.",

--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "name": "Docker (Docker-in-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
     "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",

--- a/src/dotnet/devcontainer-feature.json
+++ b/src/dotnet/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "dotnet",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "name": "Dotnet CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/dotnet",
     "description": "Installs the .NET CLI. Provides option of installing sdk or runtime, and option of versions to install. Uses latest version of .NET sdk as defaults to install.",

--- a/src/dotnet/install.sh
+++ b/src/dotnet/install.sh
@@ -30,6 +30,11 @@ DOTNET_VERSION_CODENAMES_REQUIRE_OLDER_LIBSSL_1="buster bullseye bionic focal hi
 # alongside DOTNET_VERSION, but not set as default.
 ADDITIONAL_VERSIONS=${ADDITIONALVERSIONS:-""}
 
+set -e
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 # Setup STDERR.
 err() {
     echo "(!) $*" >&2
@@ -109,8 +114,10 @@ updaterc() {
 
 apt_get_update()
 {
-    echo "Running apt-get update..."
-    apt-get update -y
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
 }
 
 # Check if packages are installed and installs them if not.
@@ -462,5 +469,8 @@ if [ "${CHANGE_OWNERSHIP}" = "true" ]; then
     chmod -R g+r+w "${TARGET_DOTNET_ROOT}"
     find "${TARGET_DOTNET_ROOT}" -type d -print0 | xargs -n 1 -0 chmod g+s
 fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
 
 echo "Done!"

--- a/src/git-lfs/devcontainer-feature.json
+++ b/src/git-lfs/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "git-lfs",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "name": "Git Large File Support (LFS)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/git-lfs",
     "description": "Installs Git Large File Support (Git LFS) along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like git and curl.",

--- a/src/git/devcontainer-feature.json
+++ b/src/git/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "git",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "name": "Git (from source)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/git",
     "description": "Install an up-to-date version of Git, built from source as needed. Useful for when you want the latest and greatest features. Auto-detects latest stable version and installs needed dependencies.",

--- a/src/github-cli/devcontainer-feature.json
+++ b/src/github-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "github-cli",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "name": "GitHub CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/github-cli",
     "description": "Installs the GitHub CLI. Auto-detects latest version and installs needed dependencies.",

--- a/src/github-cli/install.sh
+++ b/src/github-cli/install.sh
@@ -17,6 +17,9 @@ keyserver hkp://keyserver.pgp.com"
 
 set -e
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
@@ -141,8 +144,10 @@ receive_gpg_keys() {
 
 apt_get_update()
 {
-    echo "Running apt-get update..."
-    apt-get update -y
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
 }
 
 # Checks if packages are installed and installs them if not
@@ -209,8 +214,7 @@ export DEBIAN_FRONTEND=noninteractive
 # Install curl, apt-transport-https, curl, gpg, or dirmngr, git if missing
 check_packages curl ca-certificates apt-transport-https dirmngr gnupg2
 if ! type git > /dev/null 2>&1; then
-    apt_get_update
-    apt-get -y install --no-install-recommends git
+    check_packages git
 fi
 
 # Soft version matching
@@ -236,3 +240,6 @@ else
     rm -rf "/tmp/gh/gnupg"
     echo "Done!"
 fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*

--- a/src/go/devcontainer-feature.json
+++ b/src/go/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "go",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "name": "Go",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/go",
     "description": "Installs Go and common Go utilities. Auto-detects latest version and installs needed dependencies.",

--- a/src/hugo/devcontainer-feature.json
+++ b/src/hugo/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "hugo",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "name": "Hugo",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/hugo",
   "options": {

--- a/src/hugo/install.sh
+++ b/src/hugo/install.sh
@@ -16,6 +16,9 @@ HUGO_DIR=${HUGO_DIR:-"/usr/local/hugo"}
 
 set -e
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
@@ -63,8 +66,10 @@ updaterc() {
 
 apt_get_update()
 {
-    echo "Running apt-get update..."
-    apt-get update -y
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
 }
 
 # Checks if packages are installed and installs them if not
@@ -113,5 +118,8 @@ if ! hugo version &> /dev/null ; then
     chmod -R g+r+w "${HUGO_DIR}"
     find "${HUGO_DIR}" -type d -print0 | xargs -n 1 -0 chmod g+s
 fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
 
 echo "Done!"

--- a/src/java/devcontainer-feature.json
+++ b/src/java/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "java",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "name": "Java (via SDKMAN!)",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/java",
   "description": "Installs Java, SDKMAN! (if not installed), and needed dependencies.",

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -24,6 +24,9 @@ ADDITIONAL_VERSIONS=${ADDITIONALVERSIONS:-""}
 
 set -e
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
@@ -65,8 +68,10 @@ updaterc() {
 
 apt_get_update()
 {
-    echo "Running apt-get update..."
-    apt-get update -y
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
 }
 
 # Checks if packages are installed and installs them if not
@@ -175,5 +180,8 @@ fi
 if [[ "${INSTALL_MAVEN}" = "true" ]] && ! mvn --version > /dev/null; then
     sdk_install maven latest
 fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
 
 echo "Done!"

--- a/src/kubectl-helm-minikube/devcontainer-feature.json
+++ b/src/kubectl-helm-minikube/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "kubectl-helm-minikube",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "name": "Kubectl, Helm, and Minkube",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/kubectl-helm-minikube",
     "description": "Installs latest version of kubectl, Helm, and optionally minikube. Auto-detects latest versions and installs needed dependencies.",

--- a/src/kubectl-helm-minikube/install.sh
+++ b/src/kubectl-helm-minikube/install.sh
@@ -9,6 +9,9 @@
 
 set -e
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 KUBECTL_VERSION="${VERSION:-"latest"}"
 HELM_VERSION="${HELM:-"latest"}"
 MINIKUBE_VERSION="${MINIKUBE:-"none"}" # latest is also valid
@@ -102,8 +105,10 @@ find_version_from_git_tags() {
 
 apt_get_update()
 {
-    echo "Running apt-get update..."
-    apt-get update -y
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
 }
 
 # Checks if packages are installed and installs them if not
@@ -120,8 +125,7 @@ export DEBIAN_FRONTEND=noninteractive
 # Install dependencies
 check_packages curl ca-certificates coreutils gnupg2 dirmngr bash-completion
 if ! type git > /dev/null 2>&1; then
-    apt_get_update
-    apt-get -y install --no-install-recommends git
+    check_packages git
 fi
 
 architecture="$(uname -m)"
@@ -239,5 +243,8 @@ fi
 if ! type docker > /dev/null 2>&1; then
     echo -e '\n(*) Warning: The docker command was not found.\n\nYou can use one of the following scripts to install it:\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker-in-docker.md\n\nor\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md'
 fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
 
 echo -e "\nDone!"

--- a/src/node/devcontainer-feature.json
+++ b/src/node/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "node",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "name": "Node.js (via nvm) and yarn",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/node",
     "description": "Installs Node.js, nvm, yarn, and needed dependencies.",

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -22,6 +22,9 @@ export NVM_VERSION="0.38.0"
 
 set -e
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
@@ -62,8 +65,10 @@ updaterc() {
 }
 
 apt_get_update() {
-    echo "Running apt-get update..."
-    apt-get update -y
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
 }
 
 # Checks if packages are installed and installs them if not
@@ -109,6 +114,8 @@ if [ -d "${NVM_DIR}" ]; then
     if [ "${NODE_VERSION}" != "" ]; then
        su ${USERNAME} -c ". $NVM_DIR/nvm.sh && nvm install ${NODE_VERSION} && nvm clear-cache"
     fi
+    # Clean up
+    rm -rf /var/lib/apt/lists/*
     exit 0
 fi
 
@@ -186,5 +193,8 @@ if [ "${INSTALL_TOOLS_FOR_NODE_GYP}" = "true" ]; then
 fi
 
 find "${NVM_DIR}" -type d -print0 | xargs -n 1 -0 chmod g+s
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
 
 echo "Done!"

--- a/src/nvidia-cuda/devcontainer-feature.json
+++ b/src/nvidia-cuda/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "nvidia-cuda",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "name": "NVIDIA CUDA",
   "description": "Installs shared libraries for NVIDIA CUDA.",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/nvidia-cuda",

--- a/src/oryx/devcontainer-feature.json
+++ b/src/oryx/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "oryx",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "name": "Oryx",
     "description": "Installs the oryx CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/oryx",

--- a/src/php/devcontainer-feature.json
+++ b/src/php/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "php",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "name": "PHP",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/php",
     "options": {

--- a/src/php/install.sh
+++ b/src/php/install.sh
@@ -8,6 +8,9 @@
 
 set -eux
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 VERSION=${VERSION:-"latest"}
 INSTALL_COMPOSER=${INSTALLCOMPOSER:-"true"}
 OVERRIDE_DEFAULT_VERSION=${OVERRIDEDEFAULTVERSION:-"true"}
@@ -73,7 +76,10 @@ updaterc() {
 # Checks if packages are installed and installs them if not
 check_packages() {
     if ! dpkg -s "$@" > /dev/null 2>&1; then
-        apt-get update
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
         apt-get -y install --no-install-recommends "$@"
     fi
 }
@@ -221,5 +227,8 @@ fi
 chown -R "${USERNAME}:php" "${PHP_DIR}"
 chmod -R g+r+w "${PHP_DIR}"
 find "${PHP_DIR}" -type d -print0 | xargs -n 1 -0 chmod g+s
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
 
 echo "Done!"

--- a/src/powershell/devcontainer-feature.json
+++ b/src/powershell/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "powershell",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "name": "PowerShell",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/powershell",
     "description": "Installs PowerShell along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",

--- a/src/powershell/install.sh
+++ b/src/powershell/install.sh
@@ -9,6 +9,9 @@
 
 set -e
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 POWERSHELL_VERSION=${VERSION:-"latest"}
 
 MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
@@ -74,8 +77,10 @@ get_common_setting() {
 
 apt_get_update()
 {
-    echo "Running apt-get update..."
-    apt-get update -y
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
 }
 
 # Checks if packages are installed and installs them if not
@@ -118,8 +123,7 @@ install_using_github() {
     # Fall back on direct download if no apt package exists in microsoft pool
     check_packages curl ca-certificates gnupg2 dirmngr libc6 libgcc1 libgssapi-krb5-2 libstdc++6 libunwind8 libuuid1 zlib1g libicu[0-9][0-9]
     if ! type git > /dev/null 2>&1; then
-        apt_get_update
-        apt-get install -y --no-install-recommends git
+        check_packages git
     fi
     if [ "${architecture}" = "amd64" ]; then
         architecture="x64"
@@ -160,5 +164,8 @@ if [ "${use_github}" = "true" ]; then
     echo "Attempting install from GitHub release..."
     install_using_github
 fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
 
 echo "Done!"

--- a/src/python/devcontainer-feature.json
+++ b/src/python/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "python",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "name": "Python",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/python",
   "description": "Installs the provided version of Python, as well as PIPX, and other common Python utilities.  JupyterLab is conditionally installed with the python feature. Note: May require source code compilation.",

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -34,6 +34,9 @@ keyserver hkp://keyserver.pgp.com"
 
 set -e
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
@@ -199,8 +202,10 @@ oryx_install() {
 
 apt_get_update()
 {
-    echo "Running apt-get update..."
-    apt-get update -y
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
 }
 
 # Checks if packages are installed and installs them if not
@@ -232,8 +237,7 @@ install_from_source() {
                 libbz2-dev libreadline-dev libxml2-dev xz-utils libgdbm-dev tk-dev dirmngr \
                 libxmlsec1-dev libsqlite3-dev libffi-dev liblzma-dev uuid-dev 
     if ! type git > /dev/null 2>&1; then
-        apt_get_update
-        apt-get -y install --no-install-recommends git
+        check_packages git
     fi
 
     # Find version using soft match
@@ -453,5 +457,8 @@ if [ "${INSTALL_JUPYTERLAB}" = "true" ]; then
         add_user_jupyter_config "c.NotebookApp.allow_origin = '${CONFIGURE_JUPYTERLAB_ALLOW_ORIGIN}'"
     fi
 fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
 
 echo "Done!"

--- a/src/ruby/devcontainer-feature.json
+++ b/src/ruby/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "name": "Ruby (via rvm)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/ruby",
     "description": "Installs Ruby, rvm, rbenv, common Ruby utilities, and needed dependencies.",

--- a/src/ruby/install.sh
+++ b/src/ruby/install.sh
@@ -28,6 +28,9 @@ keyserver hkp://keyserver.pgp.com"
 
 set -e
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
@@ -154,8 +157,10 @@ find_version_from_git_tags() {
 
 apt_get_update()
 {
-    echo "Running apt-get update..."
-    apt-get update -y
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
 }
 
 # Checks if packages are installed and installs them if not
@@ -180,8 +185,7 @@ check_packages curl ca-certificates software-properties-common build-essential g
     procps dirmngr gawk autoconf automake bison libffi-dev libgdbm-dev libncurses5-dev \
     libsqlite3-dev libtool libyaml-dev pkg-config sqlite3 zlib1g-dev libgmp-dev libssl-dev
 if ! type git > /dev/null 2>&1; then
-    apt_get_update
-    apt-get -y install --no-install-recommends git
+    check_packages git
 fi
 
 
@@ -300,5 +304,8 @@ find "/usr/local/rvm/" -type d | xargs -n 1 chmod g+s
 # Clean up
 rvm cleanup all
 ${ROOT_GEM} cleanup
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
 
 echo "Done!"

--- a/src/rust/devcontainer-feature.json
+++ b/src/rust/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "rust",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "name": "Rust",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/rust",
     "description": "Installs Rust, common Rust utilities, and their required dependencies",

--- a/src/sshd/devcontainer-feature.json
+++ b/src/sshd/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "sshd",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "name": "SSH server",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/sshd",
     "description": "Adds a SSH server into a container so that you can use an external terminal, sftp, or SSHFS to interact with it.",

--- a/src/sshd/install.sh
+++ b/src/sshd/install.sh
@@ -17,6 +17,9 @@ FIX_ENVIRONMENT=${FIX_ENVIRONMENT:-"true"}
 
 set -e
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
@@ -41,8 +44,10 @@ fi
 
 apt_get_update()
 {
-    echo "Running apt-get update..."
-    apt-get update -y
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
 }
 
 # Checks if packages are installed and installs them if not
@@ -166,4 +171,8 @@ echo -e "Done!\n\n- Port: ${SSHD_PORT}\n- User: ${USERNAME}"
 if [ "${EMIT_PASSWORD}" = "true" ]; then
     echo "- Password: ${NEW_PASSWORD}"
 fi
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 echo -e "\nForward port ${SSHD_PORT} to your local machine and run:\n\n  ssh -p ${SSHD_PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o GlobalKnownHostsFile=/dev/null ${USERNAME}@localhost\n"

--- a/src/terraform/devcontainer-feature.json
+++ b/src/terraform/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "terraform",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "name": "Terraform, tflint, and TFGrunt",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/terraform",
     "description": "Installs the Terraform CLI and optionally TFLint and Terragrunt. Auto-detects latest version and installs needed dependencies.",

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -9,6 +9,9 @@
 
 set -e
 
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 TERRAFORM_VERSION="${VERSION:-"latest"}"
 TFLINT_VERSION="${TFLINT:-"latest"}"
 TERRAGRUNT_VERSION="${TERRAGRUNT:-"latest"}"
@@ -124,8 +127,10 @@ find_version_from_git_tags() {
 
 apt_get_update()
 {
-    echo "Running apt-get update..."
-    apt-get update -y
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update -y
+    fi
 }
 
 # Checks if packages are installed and installs them if not
@@ -142,8 +147,7 @@ export DEBIAN_FRONTEND=noninteractive
 # Install dependencies if missing
 check_packages curl ca-certificates gnupg2 dirmngr coreutils unzip
 if ! type git > /dev/null 2>&1; then
-    apt_get_update
-    apt-get -y install --no-install-recommends git
+    check_packages git
 fi
 
 # Verify requested version is available, convert latest
@@ -209,4 +213,8 @@ if [ "${TERRAGRUNT_VERSION}" != "none" ]; then
 fi
 
 rm -rf /tmp/tf-downloads ${GNUPGHOME}
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
 echo "Done!"


### PR DESCRIPTION
Fix #191

This PR re-implement the mechanism to skip `apt-get update` if it is already cached.
Deleting the cache at the beginning as well as at the end of a script avoids old caches.

I thought I checked all the scripts, but I could be missing something!