### PR TITLE
add installsAfter: common-utils to all Features

### DIFF
--- a/src/anaconda/devcontainer-feature.json
+++ b/src/anaconda/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "anaconda",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "name": "Anaconda",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/anaconda",
     "options": {
@@ -16,5 +16,8 @@
     "containerEnv": {
         "CONDA_DIR": "/usr/local/conda",
         "PATH": "/usr/local/conda/bin:${PATH}"
-    }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
 }

--- a/src/aws-cli/devcontainer-feature.json
+++ b/src/aws-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "aws-cli",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "name": "AWS CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/aws-cli",
     "description": "Installs the AWS CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",
@@ -20,5 +20,8 @@
                 "AmazonWebServices.aws-toolkit-vscode"
             ]
         }
-    }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
 }

--- a/src/azure-cli/devcontainer-feature.json
+++ b/src/azure-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-cli",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "name": "Azure CLI",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/azure-cli",
   "description": "Installs the Azure CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",
@@ -20,5 +20,8 @@
             "ms-vscode.azurecli"
           ]
       }
-  }
+  },
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/common-utils"
+  ]
 }

--- a/src/conda/devcontainer-feature.json
+++ b/src/conda/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "conda",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "name": "Conda",
     "description": "A cross-platform, language-agnostic binary package manager",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/conda",
@@ -25,5 +25,8 @@
         "CONDA_DIR": "/opt/conda",
         "CONDA_SCRIPT":"/opt/conda/etc/profile.d/conda.sh",
         "PATH": "/opt/conda/bin:${PATH}"
-    }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
 }

--- a/src/desktop-lite/devcontainer-feature.json
+++ b/src/desktop-lite/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "desktop-lite",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "name": "Light-weight Desktop",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/desktop-lite",
     "description": "Adds a lightweight Fluxbox based desktop to the container that can be accessed using a VNC viewer or the web. GUI-based commands executed from the built-in VS code terminal will open on the desktop automatically.",
@@ -52,5 +52,8 @@
     "entrypoint": "/usr/local/share/desktop-init.sh",
     "containerEnv": {
         "DISPLAY": ":1"
-    }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
 }

--- a/src/docker-from-docker/devcontainer-feature.json
+++ b/src/docker-from-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-from-docker",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "name": "Docker (Docker-from-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-from-docker",
     "descripton": "Re-use the host docker socket, adding the Docker CLI to a container. Feature invokes a script to enable using a forwarded Docker socket within a container to run Docker commands.",
@@ -47,5 +47,8 @@
             "target": "/var/run/docker-host.sock",
             "type": "bind"
         }
+    ],
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
     ]
 }

--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "name": "Docker (Docker-in-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
     "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",
@@ -53,5 +53,8 @@
             "target": "/var/lib/docker",
             "type": "volume"
         }
+    ],
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
     ]
 }

--- a/src/dotnet/devcontainer-feature.json
+++ b/src/dotnet/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "dotnet",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "name": "Dotnet CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/dotnet",
     "description": "Installs the .NET CLI. Provides option of installing sdk or runtime, and option of versions to install. Uses latest version of .NET sdk as defaults to install.",
@@ -37,5 +37,8 @@
                 "ms-dotnettools.csharp"
             ]
         }
-    }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
 }

--- a/src/git-lfs/devcontainer-feature.json
+++ b/src/git-lfs/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "git-lfs",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "name": "Git Large File Support (LFS)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/git-lfs",
     "description": "Installs Git Large File Support (Git LFS) along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like git and curl.",
@@ -14,5 +14,8 @@
             "default": "latest",
             "description": "Select version of Git LFS to install"
         }
-    }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
 }

--- a/src/git/devcontainer-feature.json
+++ b/src/git/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "git",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "name": "Git (from source)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/git",
     "description": "Install an up-to-date version of Git, built from source as needed. Useful for when you want the latest and greatest features. Auto-detects latest stable version and installs needed dependencies.",
@@ -19,5 +19,8 @@
             "default": true,
             "description": "Install from PPA if available"
         }
-    }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
 }

--- a/src/github-cli/devcontainer-feature.json
+++ b/src/github-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "github-cli",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "name": "GitHub CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/github-cli",
     "description": "Installs the GitHub CLI. Auto-detects latest version and installs needed dependencies.",
@@ -18,6 +18,9 @@
             "type": "boolean",
             "default": true
         }
-    }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
 }
 

--- a/src/go/devcontainer-feature.json
+++ b/src/go/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "go",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "name": "Go",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/go",
     "description": "Installs Go and common Go utilities. Auto-detects latest version and installs needed dependencies.",
@@ -35,5 +35,8 @@
     ],
     "securityOpt": [
         "seccomp=unconfined"
+    ],
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
     ]
 }

--- a/src/hugo/devcontainer-feature.json
+++ b/src/hugo/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "hugo",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "name": "Hugo",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/hugo",
   "options": {
@@ -16,5 +16,8 @@
   "containerEnv": {
     "HUGO_DIR": "/usr/local/hugo",
     "PATH": "/usr/local/hugo/bin:${PATH}"
-  }
+  },
+  "installsAfter": [
+      "ghcr.io/devcontainers/features/common-utils"
+  ]
 }

--- a/src/java/devcontainer-feature.json
+++ b/src/java/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "java",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "name": "Java (via SDKMAN!)",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/java",
   "description": "Installs Java, SDKMAN! (if not installed), and needed dependencies.",
@@ -54,5 +54,8 @@
     "SDKMAN_DIR": "/usr/local/sdkman",
     "JAVA_HOME": "/usr/local/sdkman/candidates/java/current",
     "PATH": "/usr/local/sdkman/bin:/usr/local/sdkman/candidates/java/current/bin:/usr/local/sdkman/candidates/gradle/current/bin:/usr/local/sdkman/candidates/maven/current/bin:${PATH}"
-  }
+  },
+  "installsAfter": [
+      "ghcr.io/devcontainers/features/common-utils"
+  ]
 }

--- a/src/kubectl-helm-minikube/devcontainer-feature.json
+++ b/src/kubectl-helm-minikube/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "kubectl-helm-minikube",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "name": "Kubectl, Helm, and Minkube",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/kubectl-helm-minikube",
     "description": "Installs latest version of kubectl, Helm, and optionally minikube. Auto-detects latest versions and installs needed dependencies.",
@@ -47,5 +47,8 @@
             "target": "/home/vscode/.minikube",
             "type": "volume"
         }
+    ],
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
     ]
 }

--- a/src/node/devcontainer-feature.json
+++ b/src/node/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "node",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "name": "Node.js (via nvm) and yarn",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/node",
     "description": "Installs Node.js, nvm, yarn, and needed dependencies.",
@@ -40,5 +40,8 @@
         "NVM_DIR": "/usr/local/share/nvm",
         "NVM_SYMLINK_CURRENT": "true",
         "PATH": "/usr/local/share/nvm/current/bin:${PATH}"
-    }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
 }

--- a/src/nvidia-cuda/devcontainer-feature.json
+++ b/src/nvidia-cuda/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "nvidia-cuda",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "name": "NVIDIA CUDA",
   "description": "Installs shared libraries for NVIDIA CUDA.",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/nvidia-cuda",
@@ -48,5 +48,8 @@
       "default": "8.5.0.96",
       "description": "Version of cuDNN to install"
     }
-  }
+  },
+  "installsAfter": [
+      "ghcr.io/devcontainers/features/common-utils"
+  ]
 }

--- a/src/oryx/devcontainer-feature.json
+++ b/src/oryx/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "oryx",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "name": "Oryx",
     "description": "Installs the oryx CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/oryx",
@@ -12,5 +12,8 @@
         "ORYX_DIR": "/usr/local/oryx",
         "DEBIAN_FLAVOR": "focal-scm",
         "PATH": "/usr/local/oryx:${PATH}"
-    }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
 }

--- a/src/php/devcontainer-feature.json
+++ b/src/php/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "php",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "name": "PHP",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/php",
     "options": {
@@ -32,5 +32,8 @@
     "containerEnv": {
         "PHP_PATH": "/usr/local/php/current",
         "PATH": "/usr/local/php/current/bin:${PATH}"
-    }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
 }

--- a/src/powershell/devcontainer-feature.json
+++ b/src/powershell/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "powershell",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "name": "PowerShell",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/powershell",
     "description": "Installs PowerShell along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",
@@ -15,5 +15,8 @@
             "default": "latest",
             "description": "Select or enter a version of PowerShell."
         }
-    }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
 }

--- a/src/python/devcontainer-feature.json
+++ b/src/python/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "python",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "name": "Python",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/python",
   "description": "Installs the provided version of Python, as well as PIPX, and other common Python utilities.  JupyterLab is conditionally installed with the python feature. Note: May require source code compilation.",
@@ -71,5 +71,8 @@
         "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
       }
     }
-  }
+  },
+  "installsAfter": [
+      "ghcr.io/devcontainers/features/common-utils"
+  ]
 }

--- a/src/ruby/devcontainer-feature.json
+++ b/src/ruby/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "name": "Ruby (via rvm)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/ruby",
     "description": "Installs Ruby, rvm, rbenv, common Ruby utilities, and needed dependencies.",
@@ -30,5 +30,8 @@
         "GEM_HOME": "/usr/local/rvm/gems/default",
         "MY_RUBY_HOME": "/usr/local/rvm/rubies/default",
         "PATH": "/usr/local/rvm/gems/default/bin:/usr/local/rvm/gems/default@global/bin:/usr/local/rvm/rubies/default/bin:/usr/local/share/rbenv/bin:${PATH}"
-    }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
 }

--- a/src/rust/devcontainer-feature.json
+++ b/src/rust/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "rust",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "name": "Rust",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/rust",
     "description": "Installs Rust, common Rust utilities, and their required dependencies",
@@ -56,5 +56,8 @@
     ],
     "securityOpt": [
         "seccomp=unconfined"
+    ],
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
     ]
 }

--- a/src/sshd/devcontainer-feature.json
+++ b/src/sshd/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "sshd",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "name": "SSH server",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/sshd",
     "description": "Adds a SSH server into a container so that you can use an external terminal, sftp, or SSHFS to interact with it.",
@@ -14,5 +14,8 @@
             "description": "Currently unused."
         }
     },
-    "entrypoint": "/usr/local/share/ssh-init.sh"
+    "entrypoint": "/usr/local/share/ssh-init.sh",
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
 }

--- a/src/terraform/devcontainer-feature.json
+++ b/src/terraform/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "terraform",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "name": "Terraform, tflint, and TFGrunt",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/terraform",
     "description": "Installs the Terraform CLI and optionally TFLint and Terragrunt. Auto-detects latest version and installs needed dependencies.",
@@ -48,5 +48,8 @@
                 "azureTerraform.terminal": "integrated"
             }
         }
-    }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
 }


### PR DESCRIPTION
closes https://github.com/devcontainers/features/issues/195

Utilizes the [installsAfter](https://containers.dev/implementors/features/#installsAfter) property to install `common-utils` before any other Feature.