### PR TITLE
Quote var in comparison in docker-in-docker install script

### DIFF
--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -369,7 +369,7 @@ dockerd_start="$(cat << 'INNEREOF'
     # Handle DNS
     set +e
     cat /etc/resolv.conf | grep -i 'internal.cloudapp.net'
-    if [ $? -eq 0 ] && [ ${AZURE_DNS_AUTO_DETECTION} = "true" ]
+    if [ $? -eq 0 ] && [ "${AZURE_DNS_AUTO_DETECTION}" = "true" ]
     then
         echo "Setting dockerd Azure DNS."
         CUSTOMDNS="--dns 168.63.129.16"


### PR DESCRIPTION
This is the same bug that was fixed in https://github.com/microsoft/vscode-dev-containers/pull/1670. 