### PR TITLE
github-cli: Remove duplicated find_version_from_git_tags ()

### DIFF
--- a/src/github-cli/install.sh
+++ b/src/github-cli/install.sh
@@ -72,40 +72,6 @@ receive_gpg_keys() {
     fi
 }
 
-# Figure out correct version of a three part version number is not passed
-find_version_from_git_tags() {
-    local variable_name=$1
-    local requested_version=${!variable_name}
-    if [ "${requested_version}" = "none" ]; then return; fi
-    local repository=$2
-    local prefix=${3:-"tags/v"}
-    local separator=${4:-"."}
-    local last_part_optional=${5:-"false"}    
-    if [ "$(echo "${requested_version}" | grep -o "." | wc -l)" != "2" ]; then
-        local escaped_separator=${separator//./\\.}
-        local last_part
-        if [ "${last_part_optional}" = "true" ]; then
-            last_part="(${escaped_separator}[0-9]+)?"
-        else
-            last_part="${escaped_separator}[0-9]+"
-        fi
-        local regex="${prefix}\\K[0-9]+${escaped_separator}[0-9]+${last_part}$"
-        local version_list="$(git ls-remote --tags ${repository} | grep -oP "${regex}" | tr -d ' ' | tr "${separator}" "." | sort -rV)"
-        if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "current" ] || [ "${requested_version}" = "lts" ]; then
-            declare -g ${variable_name}="$(echo "${version_list}" | head -n 1)"
-        else
-            set +e
-            declare -g ${variable_name}="$(echo "${version_list}" | grep -E -m 1 "^${requested_version//./\\.}([\\.\\s]|$)")"
-            set -e
-        fi
-    fi
-    if [ -z "${!variable_name}" ] || ! echo "${version_list}" | grep "^${!variable_name//./\\.}$" > /dev/null 2>&1; then
-        echo -e "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
-        exit 1
-    fi
-    echo "${variable_name}=${!variable_name}"
-}
-
 # Import the specified key in a variable name passed in as 
 receive_gpg_keys() {
     get_common_setting $1
@@ -158,6 +124,7 @@ check_packages() {
     fi
 }
 
+# Figure out correct version of a three part version number is not passed
 find_version_from_git_tags() {
     local variable_name=$1
     local requested_version=${!variable_name}


### PR DESCRIPTION
This function was defined twice in the install script for GitHub CLI, in old lines 76 and 161. This commit removes the first definition.

The only function calls were on old lines 201 and 222. Since they appear after the second function definition at line 161, the first one at line 76 never got called, so it's safe to remove it.

I confirmed that this was the only file in this repository where this function was duplicated:  

```console
$ git grep '^ *find_version_from_git_tags *('
src/docker-from-docker/install.sh:find_version_from_git_tags() {
src/docker-in-docker/install.sh:find_version_from_git_tags() {
src/git-lfs/install.sh:find_version_from_git_tags() {
src/github-cli/install.sh:find_version_from_git_tags() {
src/github-cli/install.sh:find_version_from_git_tags() {
src/go/install.sh:find_version_from_git_tags() {
src/kubectl-helm-minikube/install.sh:find_version_from_git_tags() {
src/php/install.sh:find_version_from_git_tags() {
src/powershell/install.sh:find_version_from_git_tags() {
src/python/install.sh:find_version_from_git_tags() {
src/ruby/install.sh:find_version_from_git_tags() {
src/rust/install.sh:find_version_from_git_tags() {
src/terraform/install.sh:find_version_from_git_tags() {
$
```