### PR TITLE
Install golangci-lint from prebuilt binaries and allow specifying its version

### DIFF
--- a/src/go/devcontainer-feature.json
+++ b/src/go/devcontainer-feature.json
@@ -15,6 +15,14 @@
             ],
             "default": "latest",
             "description": "Select or enter a Go version to install"
+        },
+        "golangciLintVersion": {
+            "type": "string",
+            "proposals": [
+                "latest"
+            ],
+            "default": "latest",
+            "description": "Select or enter a golangci-lint version to install"
         }
     },
     "init": true,

--- a/src/go/devcontainer-feature.json
+++ b/src/go/devcontainer-feature.json
@@ -19,7 +19,7 @@
         "golangciLintVersion": {
             "type": "string",
             "default": "latest",
-            "description": "Enter a golangci-lint version to install or 'latest'"
+            "description": "Version of golangci-lint to install"
         }
     },
     "init": true,

--- a/src/go/devcontainer-feature.json
+++ b/src/go/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "go",
-    "version": "1.0.9",
+    "version": "1.1.0",
     "name": "Go",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/go",
     "description": "Installs Go and common Go utilities. Auto-detects latest version and installs needed dependencies.",
@@ -18,11 +18,8 @@
         },
         "golangciLintVersion": {
             "type": "string",
-            "proposals": [
-                "latest"
-            ],
             "default": "latest",
-            "description": "Select or enter a golangci-lint version to install"
+            "description": "Enter a golangci-lint version to install or 'latest'"
         }
     },
     "init": true,

--- a/src/go/install.sh
+++ b/src/go/install.sh
@@ -8,6 +8,7 @@
 # Maintainer: The VS Code and Codespaces Teams
 
 TARGET_GO_VERSION=${VERSION:-"latest"}
+GOLANGCILINT_VERSION=${GOLANGCILINTVERSION:-"latest"}
 
 TARGET_GOROOT=${TARGET_GOROOT:-"/usr/local/go"}
 TARGET_GOPATH=${TARGET_GOPATH:-"/go"}
@@ -197,8 +198,7 @@ GO_TOOLS="\
     github.com/mgechev/revive@latest \
     github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest \
     github.com/ramya-rao-a/go-outline@latest \
-    github.com/go-delve/delve/cmd/dlv@latest \
-    github.com/golangci/golangci-lint/cmd/golangci-lint@latest"
+    github.com/go-delve/delve/cmd/dlv@latest"
 if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
     echo "Installing common Go tools..."
     export PATH=${TARGET_GOROOT}/bin:${PATH}
@@ -219,8 +219,18 @@ if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
 
     # Move Go tools into path and clean up
     mv /tmp/gotools/bin/* ${TARGET_GOPATH}/bin/
-
     rm -rf /tmp/gotools
+
+    # Install golangci-lint from precompiled binares
+    if [ "$GOLANGCILINT_VERSION" = "latest" ] || [ "$GOLANGCILINT_VERSION" = "" ]; then
+        echo "Installing golangci-lint latest..."
+        curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
+            sh -s -- -b "/usr/local/bin"
+    else
+        echo "Installing golangci-lint ${GOLANGCILINT_VERSION}..."
+        curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
+            sh -s -- -b "/usr/local/bin" "v${GOLANGCILINT_VERSION}"
+    fi
 fi
 
 

--- a/src/go/install.sh
+++ b/src/go/install.sh
@@ -225,11 +225,11 @@ if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
     if [ "$GOLANGCILINT_VERSION" = "latest" ] || [ "$GOLANGCILINT_VERSION" = "" ]; then
         echo "Installing golangci-lint latest..."
         curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-            sh -s -- -b "/usr/local/bin"
+            sh -s -- -b "${TARGET_GOPATH}/bin"
     else
         echo "Installing golangci-lint ${GOLANGCILINT_VERSION}..."
         curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-            sh -s -- -b "/usr/local/bin" "v${GOLANGCILINT_VERSION}"
+            sh -s -- -b "${TARGET_GOPATH}/bin" "v${GOLANGCILINT_VERSION}"
     fi
 fi
 

--- a/test/go/install_go_tool_in_postCreate.sh
+++ b/test/go/install_go_tool_in_postCreate.sh
@@ -7,6 +7,7 @@ source dev-container-features-test-lib
 
 check "mkcert version" mkcert --version | grep "v1.4.2"
 check "mkcert is installed at correct path" which mkcert | grep "/go/bin/mkcert"
+check "golangci-lint version" golangci-lint --version | grep "golangci-lint has version 1.50.0"
 
 # Report result
 reportResults

--- a/test/go/scenarios.json
+++ b/test/go/scenarios.json
@@ -3,7 +3,8 @@
         "image": "ubuntu:focal",
         "features": {
             "go": {
-                "version": "latest"
+                "version": "latest",
+                "golangciLintVersion": "1.50.0"
             }
         },
         "postCreateCommand": "go install filippo.io/mkcert@v1.4.2"


### PR DESCRIPTION
golangci-lint (a linter) should not be installed using `go get`/`go install`, per [official guidance](https://golangci-lint.run/usage/install/#install-from-source).

This PR changes the way the linter is installed, using the official install script that fetches pre-compiled binaries.

Additionally, adds a new option to specify the version of the linter. Many projects (incl. our Dapr) really need to be able to specify the version of the linter.