### PR TITLE
Fix oryx bug - Add PIP_CACHE_DIR

### DIFF
--- a/src/oryx/devcontainer-feature.json
+++ b/src/oryx/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "oryx",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "name": "Oryx",
     "description": "Installs the oryx CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/oryx",

--- a/src/oryx/install.sh
+++ b/src/oryx/install.sh
@@ -157,17 +157,23 @@ chmod a+x ${BUILD_SCRIPT_GENERATOR}/GenerateBuildScript
 
 ln -s ${BUILD_SCRIPT_GENERATOR}/GenerateBuildScript ${ORYX}/oryx
 cp -f $GIT_ORYX/images/build/benv.sh ${ORYX}/benv
+cp -f $GIT_ORYX/images/build/logger.sh ${ORYX}/logger
 
 ORYX_INSTALL_DIR="/opt"
 mkdir -p "${ORYX_INSTALL_DIR}"
 
+# Directory used by the oryx tool to install python packages automatically from `requirements.txt`
+PIP_CACHE_DIR="/usr/local/share/pip-cache/lib"
+mkdir -p ${PIP_CACHE_DIR}
+
 updaterc "export ORYX_SDK_STORAGE_BASE_URL=https://oryx-cdn.microsoft.io && export ENABLE_DYNAMIC_INSTALL=true && DYNAMIC_INSTALL_ROOT_DIR=$ORYX_INSTALL_DIR && ORYX_PREFER_USER_INSTALLED_SDKS=true && export DEBIAN_FLAVOR=focal-scm"
 
-chown -R "${USERNAME}:oryx" "${ORYX_INSTALL_DIR}" "${BUILD_SCRIPT_GENERATOR}" "${ORYX}"
-chmod -R g+r+w "${ORYX_INSTALL_DIR}" "${BUILD_SCRIPT_GENERATOR}" "${ORYX}"
+chown -R "${USERNAME}:oryx" "${ORYX_INSTALL_DIR}" "${BUILD_SCRIPT_GENERATOR}" "${ORYX}" "${PIP_CACHE_DIR}"
+chmod -R g+r+w "${ORYX_INSTALL_DIR}" "${BUILD_SCRIPT_GENERATOR}" "${ORYX}" "${PIP_CACHE_DIR}"
 find "${ORYX_INSTALL_DIR}" -type d -print0 | xargs -n 1 -0 chmod g+s
 find "${BUILD_SCRIPT_GENERATOR}" -type d -print0 | xargs -n 1 -0 chmod g+s
 find "${ORYX}" -type d -print0 | xargs -n 1 -0 chmod g+s
+find "${PIP_CACHE_DIR}" -type d -print0 | xargs -n 1 -0 chmod g+s
 
 # /opt/tmp/build and /opt/tmp/images is required by Oryx for dynamically installing platforms
 cp -rf $GIT_ORYX/build /opt/tmp

--- a/src/oryx/install.sh
+++ b/src/oryx/install.sh
@@ -162,7 +162,7 @@ cp -f $GIT_ORYX/images/build/logger.sh ${ORYX}/logger
 ORYX_INSTALL_DIR="/opt"
 mkdir -p "${ORYX_INSTALL_DIR}"
 
-# Directory used by the oryx tool to install python packages automatically from `requirements.txt`
+# Directory used by the oryx tool to cache the automatically installed python packages from `requirements.txt`
 PIP_CACHE_DIR="/usr/local/share/pip-cache/lib"
 mkdir -p ${PIP_CACHE_DIR}
 


### PR DESCRIPTION
Creates a  "/usr/local/share/pip-cache/lib" directory which is used by the oryx tool to cache installed python packages automatically from `requirements.txt`

Fixes bug 

![image](https://user-images.githubusercontent.com/24955913/198146200-70f2b5e6-40d2-4ca5-b178-5cb7d976cb66.png)
