### PR TITLE
(GH-198) Add `extended` option to hugo feature

### DIFF
--- a/src/hugo/devcontainer-feature.json
+++ b/src/hugo/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "hugo",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "name": "Hugo",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/hugo",
   "options": {
@@ -11,6 +11,11 @@
       ],
       "default": "latest",
       "description": "Select or enter a version."
+    },
+    "extended": {
+      "type": "boolean",
+      "default": false,
+      "description": "Install Hugo extended for SASS/SCSS changes"
     }
   },
   "containerEnv": {

--- a/src/hugo/install.sh
+++ b/src/hugo/install.sh
@@ -106,7 +106,14 @@ if ! hugo version &> /dev/null ; then
         arch="64bit"
     fi
 
-    hugo_filename="hugo_${VERSION}_Linux-${arch}.tar.gz"
+    # Install extended version of hugo if desired
+    if [ "${EXTENDED}" = "true" ]; then
+        extended="extended_"
+    else
+        extended=""
+    fi
+
+    hugo_filename="hugo_${extended}${VERSION}_Linux-${arch}.tar.gz"
 
     curl -fsSLO --compressed "https://github.com/gohugoio/hugo/releases/download/v${VERSION}/${hugo_filename}"
     tar -xzf "$hugo_filename" -C "$installation_dir"

--- a/test/hugo/install_hugo_extended.sh
+++ b/test/hugo/install_hugo_extended.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Ensure extended version is installed
+check "extended_installed"  bash -c "hugo version | grep extended"
+
+# Report result
+reportResults

--- a/test/hugo/scenarios.json
+++ b/test/hugo/scenarios.json
@@ -1,0 +1,11 @@
+{
+    "install_hugo_extended": {
+        "image": "mcr.microsoft.com/devcontainers/base",
+        "features": {
+            "hugo": {
+                "version": "latest",
+                "extended": true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Prior to this change, the hugo feature only supported specifying the version of Hugo to install. Hugo is available in two builds: standard, which the feature already installs, and extended, which includes functionality for post-processing CSS/SCSS/SASS and JavaScript.

This change adds a new `extended` option to the hugo feature, allowing users to specify that they require the extended build of Hugo. It defaults to `false` and installs the standard build of Hugo.

- Resolves #198