### PR TITLE
Test actions - Add more base images

### DIFF
--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -43,7 +43,10 @@ jobs:
           [
             "ubuntu:focal",
             "ubuntu:jammy",
+            "ubuntu:bionic",
             "debian:11",
+            "debian:10",
+            "debian:9",
             "mcr.microsoft.com/devcontainers/base:ubuntu",
             "mcr.microsoft.com/devcontainers/base:debian",
           ]

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -50,7 +50,10 @@ jobs:
           [
             "ubuntu:focal",
             "ubuntu:jammy",
+            "ubuntu:bionic",
             "debian:11",
+            "debian:10",
+            "debian:9",
             "mcr.microsoft.com/devcontainers/base:ubuntu",
             "mcr.microsoft.com/devcontainers/base:debian",
           ]


### PR DESCRIPTION
Adds new `baseImage`, so that we can ensure the PR changes works with MCR [base:debian](https://github.com/devcontainers/images/blob/main/src/base-debian/manifest.json#L3-L6) and [base:ubuntu](https://github.com/devcontainers/images/blob/main/src/base-ubuntu/manifest.json#L3-L6) images (all variants).

https://github.com/devcontainers/features/pull/234 adds a new util, it would be nice to validate that it exists for all the debian and ubuntu variants.