### PR TITLE
Use asc format instead of gpg for not to install gnupg2

### DIFF
--- a/src/conda/install.sh
+++ b/src/conda/install.sh
@@ -69,12 +69,12 @@ if ! conda --version &> /dev/null ; then
     usermod -a -G conda "${USERNAME}"
 
     # Install dependencies
-    check_packages curl ca-certificates gnupg2
+    check_packages curl ca-certificates
 
     echo "Installing Conda..."
 
-    curl -sS https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc | gpg --dearmor > /usr/share/keyrings/conda-archive-keyring.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/conda-archive-keyring.gpg] https://repo.anaconda.com/pkgs/misc/debrepo/conda stable main" > /etc/apt/sources.list.d/conda.list
+    curl -sS https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc | tee -a /usr/share/keyrings/conda-archive-keyring.asc
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/conda-archive-keyring.asc] https://repo.anaconda.com/pkgs/misc/debrepo/conda stable main" > /etc/apt/sources.list.d/conda.list
     apt-get update -y
 
     CONDA_PKG="conda=${VERSION}-0"

--- a/src/docker-from-docker/install.sh
+++ b/src/docker-from-docker/install.sh
@@ -153,15 +153,15 @@ if [ "${USE_MOBY}" = "true" ]; then
 
     # Import key safely and import Microsoft apt repo
     get_common_setting MICROSOFT_GPG_KEYS_URI
-    curl -sSL ${MICROSOFT_GPG_KEYS_URI} | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg
-    echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/microsoft-${ID}-${VERSION_CODENAME}-prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
+    curl -sSL ${MICROSOFT_GPG_KEYS_URI} | tee -a /usr/share/keyrings/microsoft-archive-keyring.asc
+    echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-archive-keyring.asc] https://packages.microsoft.com/repos/microsoft-${ID}-${VERSION_CODENAME}-prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
 else
     # Name of proprietary engine package
     cli_package_name="docker-ce-cli"
 
     # Import key safely and import Docker apt repo
-    curl -fsSL https://download.docker.com/linux/${ID}/gpg | gpg --dearmor > /usr/share/keyrings/docker-archive-keyring.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list
+    curl -fsSL https://download.docker.com/linux/${ID}/gpg | tee -a /usr/share/keyrings/docker-archive-keyring.asc
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list
 fi
 
 # Refresh apt lists

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -158,7 +158,7 @@ else
 fi
 
 # Install dependencies
-check_packages apt-transport-https curl ca-certificates pigz iptables gnupg2 dirmngr
+check_packages apt-transport-https curl ca-certificates pigz iptables
 if ! type git > /dev/null 2>&1; then
     check_packages git
 fi
@@ -180,16 +180,16 @@ if [ "${USE_MOBY}" = "true" ]; then
 
     # Import key safely and import Microsoft apt repo
     get_common_setting MICROSOFT_GPG_KEYS_URI
-    curl -sSL ${MICROSOFT_GPG_KEYS_URI} | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg
-    echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/microsoft-${ID}-${VERSION_CODENAME}-prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
+    curl -sSL ${MICROSOFT_GPG_KEYS_URI} | tee -a /usr/share/keyrings/microsoft-archive-keyring.asc
+    echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-archive-keyring.asc] https://packages.microsoft.com/repos/microsoft-${ID}-${VERSION_CODENAME}-prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
 else
     # Name of licensed engine/cli
     engine_package_name="docker-ce"
     cli_package_name="docker-ce-cli"
 
     # Import key safely and import Docker apt repo
-    curl -fsSL https://download.docker.com/linux/${ID}/gpg | gpg --dearmor > /usr/share/keyrings/docker-archive-keyring.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list
+    curl -fsSL https://download.docker.com/linux/${ID}/gpg | tee -a /usr/share/keyrings/docker-archive-keyring.asc
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list
 fi
 
 # Refresh apt lists

--- a/src/dotnet/install.sh
+++ b/src/dotnet/install.sh
@@ -200,12 +200,12 @@ install_using_apt_from_microsoft_repo() {
     export DOTNET_PACKAGE="dotnet-${sdk_or_runtime}"
 
     # Install dependencies
-    check_packages apt-transport-https curl ca-certificates gnupg2 dirmngr
+    check_packages apt-transport-https curl ca-certificates
 
     # Import key safely and import Microsoft apt repo
     get_common_setting MICROSOFT_GPG_KEYS_URI
-    curl -sSL ${MICROSOFT_GPG_KEYS_URI} | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg
-    echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/microsoft-${ID}-${VERSION_CODENAME}-prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
+    curl -sSL ${MICROSOFT_GPG_KEYS_URI} | tee -a /usr/share/keyrings/microsoft-archive-keyring.asc
+    echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-archive-keyring.asc] https://packages.microsoft.com/repos/microsoft-${ID}-${VERSION_CODENAME}-prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
     apt-get update -y
 
     if [ "${DOTNET_VERSION}" = "latest" ] || [ "${DOTNET_VERSION}" = "lts" ]; then

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -82,15 +82,15 @@ check_packages() {
 export DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
-check_packages apt-transport-https curl ca-certificates tar gnupg2 dirmngr
+check_packages apt-transport-https curl ca-certificates tar
 
 # Install yarn
 if type yarn > /dev/null 2>&1; then
     echo "Yarn already installed."
 else
     # Import key safely (new method rather than deprecated apt-key approach) and install
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarn-archive-keyring.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/yarn-archive-keyring.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | tee -a /usr/share/keyrings/yarn-archive-keyring.asc
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/yarn-archive-keyring.asc] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
     apt-get update
     apt-get -y install --no-install-recommends yarn
 fi

--- a/src/oryx/install.sh
+++ b/src/oryx/install.sh
@@ -79,8 +79,8 @@ install_dotnet_using_apt() {
 
     if [ "${install_from_microsoft_feed}" = "true" ]; then
         echo "Attempting install from microsoft apt feed..."
-        curl -sSL ${MICROSOFT_GPG_KEYS_URI} | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg
-        echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/microsoft-${ID}-${VERSION_CODENAME}-prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
+        curl -sSL ${MICROSOFT_GPG_KEYS_URI} | tee -a /usr/share/keyrings/microsoft-archive-keyring.asc
+        echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-archive-keyring.asc] https://packages.microsoft.com/repos/microsoft-${ID}-${VERSION_CODENAME}-prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
         apt-get update -y
         DOTNET_INSTALLATION_PACKAGE="dotnet-sdk-6.0"
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE="true" apt-get install -yq $DOTNET_INSTALLATION_PACKAGE
@@ -118,7 +118,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 
 # Install dependencies
-check_packages git sudo curl ca-certificates apt-transport-https gnupg2 dirmngr libc-bin
+check_packages git sudo curl ca-certificates apt-transport-https libc-bin
 
 if ! cat /etc/group | grep -e "^oryx:" > /dev/null 2>&1; then
     groupadd -r oryx

--- a/src/powershell/install.sh
+++ b/src/powershell/install.sh
@@ -93,11 +93,11 @@ check_packages() {
 
 install_using_apt() {
     # Install dependencies
-    check_packages apt-transport-https curl ca-certificates gnupg2 dirmngr
+    check_packages apt-transport-https curl ca-certificates
     # Import key safely (new 'signed-by' method rather than deprecated apt-key approach) and install
     get_common_setting MICROSOFT_GPG_KEYS_URI
-    curl -sSL ${MICROSOFT_GPG_KEYS_URI} | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/microsoft-${ID}-${VERSION_CODENAME}-prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
+    curl -sSL ${MICROSOFT_GPG_KEYS_URI} | tee -a /usr/share/keyrings/microsoft-archive-keyring.asc
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/microsoft-archive-keyring.asc] https://packages.microsoft.com/repos/microsoft-${ID}-${VERSION_CODENAME}-prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
 
     # Update lists
     apt-get update -yq


### PR DESCRIPTION
This change may reduce the installation of unnecessary packages.