### PR TITLE
kubectl-helm-minikube - Remove 'ms-kubernetes-tools.vscode-kubernetes-tools' extension

### DIFF
--- a/src/kubectl-helm-minikube/devcontainer-feature.json
+++ b/src/kubectl-helm-minikube/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "kubectl-helm-minikube",
-    "version": "1.0.6",
+    "version": "1.1.0",
     "name": "Kubectl, Helm, and Minikube",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/kubectl-helm-minikube",
     "description": "Installs latest version of kubectl, Helm, and optionally minikube. Auto-detects latest versions and installs needed dependencies.",
@@ -32,13 +32,6 @@
             ],
             "default": "latest",
             "description": "Select or enter a Minikube version to install"
-        }
-    },
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                "ms-kubernetes-tools.vscode-kubernetes-tools"
-            ]
         }
     },
     "mounts": [


### PR DESCRIPTION
When using the `kubectl-helm-minikube` Feature, we are getting a notification from Red Hat's YAML extension. The `ms-kubernetes-tools.vscode-kubernetes-tools` VS Code extension, which has a dependency on the `redhat.vscode-yaml` extension prompts to collect telemetry on install.

![image](https://user-images.githubusercontent.com/24955913/199282618-9ac3be29-c083-4e10-b2c3-d6b2cfbf7412.png)

![image](https://user-images.githubusercontent.com/24955913/199282666-e4353de1-e843-4d1f-a35b-758ee0b7fa4d.png)

Hence, removing the 'ms-kubernetes-tools.vscode-kubernetes-tools' extension