### PR TITLE
Add support for CUDA 11.8 in nvidia-cuda

### DIFF
--- a/src/nvidia-cuda/devcontainer-feature.json
+++ b/src/nvidia-cuda/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "nvidia-cuda",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "name": "NVIDIA CUDA",
   "description": "Installs shared libraries for NVIDIA CUDA.",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/nvidia-cuda",
@@ -18,6 +18,7 @@
     "cudaVersion": {
       "type": "string",
       "enum": [
+        "11.8",
         "11.7",
         "11.6",
         "11.5",
@@ -25,12 +26,13 @@
         "11.3",
         "11.2"
       ],
-      "default": "11.7",
+      "default": "11.8",
       "description": "Version of CUDA to install"
     },
     "cudnnVersion": {
       "type": "string",
       "enum": [
+        "8.6.0.163",
         "8.5.0.96",
         "8.4.1.50",
         "8.4.0.27",
@@ -45,7 +47,7 @@
         "8.1.1.33",
         "8.1.0.77"
       ],
-      "default": "8.5.0.96",
+      "default": "8.6.0.163",
       "description": "Version of cuDNN to install"
     }
   },

--- a/src/nvidia-cuda/install.sh
+++ b/src/nvidia-cuda/install.sh
@@ -52,17 +52,17 @@ if ! apt-cache show "$cuda_pkg"; then
     exit 1
 fi
 
-# Ensure that the requested version of cuDNN is available AND compatible
-cudnn_pkg_version="libcudnn8=${CUDNN_VERSION}-1+cuda${CUDA_VERSION}"
-if ! apt-cache show "$cudnn_pkg_version"; then
-    echo "The requested version of cuDNN is not available: cuDNN $CUDNN_VERSION for CUDA $CUDA_VERSION"
-    exit 1
-fi
-
 echo "Installing CUDA libraries..."
 apt-get install -yq "$cuda_pkg"
 
 if [ "$INSTALL_CUDNN" = "true" ]; then
+    # Ensure that the requested version of cuDNN is available AND compatible
+    cudnn_pkg_version="libcudnn8=${CUDNN_VERSION}-1+cuda${CUDA_VERSION}"
+    if ! apt-cache show "$cudnn_pkg_version"; then
+        echo "The requested version of cuDNN is not available: cuDNN $CUDNN_VERSION for CUDA $CUDA_VERSION"
+        exit 1
+    fi
+
     echo "Installing cuDNN libraries..."
     apt-get install -yq "$cudnn_pkg_version"
 fi

--- a/test/nvidia-cuda/test.sh
+++ b/test/nvidia-cuda/test.sh
@@ -5,6 +5,8 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
+check "cuda version" test -d /usr/local/cuda-11.8
+
 # Check installation of cuda-libraries-11-<version>
 check "libcudart.so.11.0" test 1 -eq "$(find /usr -name 'libcudart.so.11.0' | wc -l)"
 check "libcublas.so.11" test 1 -eq "$(find /usr -name 'libcublas.so.11' | wc -l)"


### PR DESCRIPTION
Related: https://github.com/devcontainers/features/issues/266

Changes

- Adds support for the latest versions of CUDA (11.8) and cuDNN (8.5.0.96).
- Moves the cuDNN version check to the cuDNN install block. If the feature isn't installing cuDNN, then there's no need to check for a valid cuDNN version. We only need to check for a valid cuDNN version before we install it.