### PR TITLE
Rename cudaVersion option to version

### DIFF
--- a/src/nvidia-cuda/devcontainer-feature.json
+++ b/src/nvidia-cuda/devcontainer-feature.json
@@ -15,7 +15,7 @@
       "default": false,
       "description": "Additionally install NVIDIA Tools Extension (NVTX)"
     },
-    "cudaVersion": {
+    "version": {
       "type": "string",
       "enum": [
         "11.7",

--- a/src/nvidia-cuda/install.sh
+++ b/src/nvidia-cuda/install.sh
@@ -5,10 +5,10 @@ set -e
 # Clean up
 rm -rf /var/lib/apt/lists/*
 
-INSTALL_CUDNN=${INSTALLCUDNN}
-INSTALL_NVTX=${INSTALLNVTX}
-CUDA_VERSION=${CUDAVERSION}
-CUDNN_VERSION=${CUDNNVERSION}
+INSTALL_CUDNN="${INSTALLCUDNN}"
+INSTALL_NVTX="${INSTALLNVTX}"
+CUDA_VERSION="${VERSION:-"${CUDAVERSION}"}"
+CUDNN_VERSION="${CUDNNVERSION}"
 
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'

--- a/test/nvidia-cuda/scenarios.json
+++ b/test/nvidia-cuda/scenarios.json
@@ -14,7 +14,7 @@
             "nvidia-cuda": {
                 "installCudnn": true,
                 "installNvtx": true,
-                "cudaVersion": "11.5",
+                "version": "11.5",
                 "cudnnVersion": "8.3.2.44"
             }
         }


### PR DESCRIPTION
Related: https://github.com/devcontainers/features/issues/266

Changes

- Renames the `cudaVersion` option to `version` without breaking the `cudaVersion` route.

History

I named this option `cudaVersion` instead of `version` because it doesn't support `latest`. Unfortunately, our auto-generated Example Usage doesn't understand this and recommends `"version": "latest"`: https://github.com/devcontainers/features/tree/main/src/nvidia-cuda