### PR TITLE
Git: change git source location

### DIFF
--- a/src/git/devcontainer-feature.json
+++ b/src/git/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "git",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "name": "Git (from source)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/git",
     "description": "Install an up-to-date version of Git, built from source as needed. Useful for when you want the latest and greatest features. Auto-detects latest stable version and installs needed dependencies.",

--- a/src/git/install.sh
+++ b/src/git/install.sh
@@ -151,7 +151,7 @@ echo "Downloading source for ${GIT_VERSION}..."
 curl -sL https://github.com/git/git/archive/v${GIT_VERSION}.tar.gz | tar -xzC /tmp 2>&1
 echo "Building..."
 cd /tmp/git-${GIT_VERSION}
-make -s prefix=/usr/local all && make -s prefix=/usr/local install 2>&1
+make -s prefix=/usr all && make -s prefix=/usr install 2>&1
 rm -rf /tmp/git-${GIT_VERSION}
 rm -rf /var/lib/apt/lists/*
 echo "Done!"

--- a/test/git/install_git_from_src.sh
+++ b/test/git/install_git_from_src.sh
@@ -5,6 +5,7 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
+check "source-dir" bash -c "which git | grep /usr/bin/git"
 check "version" git  --version
 check "gettext" dpkg-query -l gettext
 

--- a/test/git/install_git_from_src.sh
+++ b/test/git/install_git_from_src.sh
@@ -6,6 +6,7 @@ set -e
 source dev-container-features-test-lib
 
 check "source-dir" bash -c "which git | grep /usr/bin/git"
+check "gitconfig-location" bash -c "git config --system user.name devcontainer && ls /etc | grep gitconfig"
 check "version" git  --version
 check "gettext" dpkg-query -l gettext
 


### PR DESCRIPTION
When `git` is installed from source, change the location from `/usr/local/bin/git` to `/usr/bin` to match with the os provided git location.