### PR TITLE
Fix regression with Azure CLI, privs

### DIFF
--- a/src/python/devcontainer-feature.json
+++ b/src/python/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "python",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "name": "Python",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/python",
   "description": "Installs the provided version of Python, as well as PIPX, and other common Python utilities.  JupyterLab is conditionally installed with the python feature. Note: May require source code compilation.",

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -406,12 +406,13 @@ if [ "${PYTHON_VERSION}" != "none" ]; then
 
     if [ ${PYTHON_VERSION} != "os-provided" ] && [ ${PYTHON_VERSION} != "system" ]; then
         updaterc "if [[ \"\${PATH}\" != *\"${CURRENT_PATH}/bin\"* ]]; then export PATH=${CURRENT_PATH}/bin:\${PATH}; fi"
-        chown -R "${USERNAME}:python" "${PYTHON_INSTALL_PATH}"
-        chmod -R g+r+w "${PYTHON_INSTALL_PATH}"
-        find "${PYTHON_INSTALL_PATH}" -type d -print0 | xargs -0 -n 1 chmod g+s
-
         PATH="${INSTALL_PATH}/bin:${PATH}"
     fi
+
+    # Updates the symlinks for os-provided, or the installed python version in other cases
+    chown -R "${USERNAME}:python" "${PYTHON_INSTALL_PATH}"
+    chmod -R g+r+w "${PYTHON_INSTALL_PATH}"
+    find "${PYTHON_INSTALL_PATH}" -type d -print0 | xargs -0 -n 1 chmod g+s
 fi
 
 # Install Python tools if needed

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -351,9 +351,12 @@ install_python() {
         if [ ! -d "${current_bin_path}" ] ; then
             mkdir -p "${current_bin_path}"
             # Add an interpreter symlink but point it to "/usr" since python is at /usr/bin/python, add other alises
+            ln -s "${INSTALL_PATH}/bin/python3" "${current_bin_path}/python3"
             ln -s "${INSTALL_PATH}/bin/python3" "${current_bin_path}/python"
+            ln -s "${INSTALL_PATH}/bin/pydoc3" "${current_bin_path}/pydoc3"
             ln -s "${INSTALL_PATH}/bin/pydoc3" "${current_bin_path}/pydoc"
             ln -s "${INSTALL_PATH}/bin/python3-config" "${current_bin_path}/python3-config"
+            ln -s "${INSTALL_PATH}/bin/python3-config" "${current_bin_path}/python-config"
         fi
 
         should_install_from_source=false

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -345,16 +345,15 @@ install_python() {
         INSTALL_PATH="/usr"
 
         local current_bin_path="${CURRENT_PATH}/bin"
-        if [ ! -d "${current_bin_path}" ]; then
+        if [ "${OVERRIDE_DEFAULT_VERSION}" = "true" ]; then
+            rm -rf "${current_bin_path}"
+        fi
+        if [ ! -d "${current_bin_path}" ] ; then
             mkdir -p "${current_bin_path}"
-
             # Add an interpreter symlink but point it to "/usr" since python is at /usr/bin/python, add other alises
-            ln -s "${INSTALL_PATH}/bin/python3" "${current_bin_path}/python3"
             ln -s "${INSTALL_PATH}/bin/python3" "${current_bin_path}/python"
-            ln -s "${INSTALL_PATH}/bin/pydoc3" "${current_bin_path}/pydoc3"
             ln -s "${INSTALL_PATH}/bin/pydoc3" "${current_bin_path}/pydoc"
             ln -s "${INSTALL_PATH}/bin/python3-config" "${current_bin_path}/python3-config"
-            ln -s "${INSTALL_PATH}/bin/python3-config" "${current_bin_path}/python-config"
         fi
 
         should_install_from_source=false

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -340,7 +340,7 @@ add_user_jupyter_config() {
 install_python() {
     version=$1
     # If the os-provided versions are "good enough", detect that and bail out.
-    if [ ${PYTHON_VERSION} = "os-provided" ] || [ ${PYTHON_VERSION} = "system" ]; then
+    if [ ${version} = "os-provided" ] || [ ${version} = "system" ]; then
         check_packages python3 python3-doc python3-pip python3-venv python3-dev python3-tk
         INSTALL_PATH="/usr"
 

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -344,13 +344,18 @@ install_python() {
         check_packages python3 python3-doc python3-pip python3-venv python3-dev python3-tk
         INSTALL_PATH="/usr"
 
-        ln -s "${INSTALL_PATH}/bin/python3" "${INSTALL_PATH}/bin/python"
-        ln -s "${INSTALL_PATH}/bin/pydoc3" "${INSTALL_PATH}/bin/pydoc"
-        ln -s "${INSTALL_PATH}/bin/python3-config" "${INSTALL_PATH}/bin/python-config"
+        local current_bin_path="${CURRENT_PATH}/bin"
+        if [ ! -d "${current_bin_path}" ]; then
+            mkdir -p "${current_bin_path}"
 
-        # Add the current symlink but point it to "/usr" since python is at /usr/bin/python
-        mkdir -p "${PYTHON_INSTALL_PATH}"
-        add_symlink
+            # Add an interpreter symlink but point it to "/usr" since python is at /usr/bin/python, add other alises
+            ln -s "${INSTALL_PATH}/bin/python3" "${current_bin_path}/python3"
+            ln -s "${INSTALL_PATH}/bin/python3" "${current_bin_path}/python"
+            ln -s "${INSTALL_PATH}/bin/pydoc3" "${current_bin_path}/pydoc3"
+            ln -s "${INSTALL_PATH}/bin/pydoc3" "${current_bin_path}/pydoc"
+            ln -s "${INSTALL_PATH}/bin/python3-config" "${current_bin_path}/python3-config"
+            ln -s "${INSTALL_PATH}/bin/python3-config" "${current_bin_path}/python-config"
+        fi
 
         should_install_from_source=false
     elif [ "$(dpkg --print-architecture)" = "amd64" ] && [ "${USE_ORYX_IF_AVAILABLE}" = "true" ] && type oryx > /dev/null 2>&1; then

--- a/test/python/install_additional_python.sh
+++ b/test/python/install_additional_python.sh
@@ -24,6 +24,7 @@ check "pylint" pylint --version
 
 # Check paths in settings
 check "current symlink is correct" bash -c "which python | grep /usr/local/python/current/bin/python"
+check "current symlink works" /usr/local/python/current/bin/python --version
 check "which autopep8" bash -c "which autopep8 | grep /usr/local/py-utils/bin/autopep8"
 check "which black" bash -c "which black | grep /usr/local/py-utils/bin/black"
 check "which yapf" bash -c "which yapf | grep /usr/local/py-utils/bin/yapf"

--- a/test/python/install_os_provided_python.sh
+++ b/test/python/install_os_provided_python.sh
@@ -23,6 +23,7 @@ check "pylint" pylint --version
 
 # Check paths in settings
 check "current symlink is correct" bash -c "which python | grep /usr/local/python/current/bin/python"
+check "current symlink works" /usr/local/python/current/bin/python --version
 check "which autopep8" bash -c "which autopep8 | grep /usr/local/py-utils/bin/autopep8"
 check "which black" bash -c "which black | grep /usr/local/py-utils/bin/black"
 check "which yapf" bash -c "which yapf | grep /usr/local/py-utils/bin/yapf"

--- a/test/python/install_via_oryx.sh
+++ b/test/python/install_via_oryx.sh
@@ -23,6 +23,7 @@ check "pylint" pylint --version
 
 # Check paths in settings
 check "current symlink is correct" bash -c "which python | grep /usr/local/python/current/bin/python"
+check "current symlink works" /usr/local/python/current/bin/python --version
 check "which autopep8" bash -c "which autopep8 | grep /usr/local/py-utils/bin/autopep8"
 check "which black" bash -c "which black | grep /usr/local/py-utils/bin/black"
 check "which yapf" bash -c "which yapf | grep /usr/local/py-utils/bin/yapf"

--- a/test/python/test.sh
+++ b/test/python/test.sh
@@ -23,6 +23,7 @@ check "pylint" pylint --version
 
 # Check paths in settings
 check "current symlink is correct" bash -c "which python | grep /usr/local/python/current/bin/python"
+check "current symlink works" /usr/local/python/current/bin/python --version
 check "which autopep8" bash -c "which autopep8 | grep /usr/local/py-utils/bin/autopep8"
 check "which black" bash -c "which black | grep /usr/local/py-utils/bin/black"
 check "which yapf" bash -c "which yapf | grep /usr/local/py-utils/bin/yapf"


### PR DESCRIPTION
Due to https://github.com/Azure/azure-cli/issues/23376, the Azure CLI fails to start if the `os-provided` version of python is installed. This points to a broader challenge with the strategy of mapping `/usr` to a symlink which also results in group priv changes.

This PR updates the model by only symlinking specific binaries that are referenced in PATH config rather than everything.

Resolves #270 