### PR TITLE
Nix feature: allow extra configuration of /etc/nix/nix.conf

### DIFF
--- a/src/nix/devcontainer-feature.json
+++ b/src/nix/devcontainer-feature.json
@@ -25,6 +25,11 @@
             "type": "string",
             "default": "",
             "description": "Optional URI to a Nix Flake to install in profile."
+        },
+        "extraNixConfig": {
+            "type": "string",
+            "default": "",
+            "description": "Optional comma separated list of extra lines to add to /etc/nix/nix.conf."
         }
     },
     "installsAfter": [

--- a/src/nix/install.sh
+++ b/src/nix/install.sh
@@ -9,6 +9,7 @@ VERSION="${VERSION:-"latest"}"
 MULTIUSER="${MULTIUSER:-"true"}"
 PACKAGES="${PACKAGES//,/ }"
 FLAKEURI="${FLAKEURI:-""}"
+EXTRANIXCONFIG="${EXTRANIXCONFIG:-""}"
 USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
 
 # Nix keys for securly verifying installer download signature per https://nixos.org/download.html#nix-verify-installation
@@ -98,6 +99,16 @@ mkdir -p /etc/nix
 create_or_update_file /etc/nix/nix.conf 'sandbox = false' 
 if  [ ! -z "${FLAKEURI}" ] && [ "${FLAKEURI}" != "none" ]; then
     create_or_update_file /etc/nix/nix.conf 'experimental-features = nix-command flakes'
+fi
+# Extra nix config
+if [ ! -z "${EXTRANIXCONFIG}" ]; then
+    OLDIFS=$IFS
+    IFS=","
+        read -a extra_nix_config <<< "$EXTRANIXCONFIG"
+        for line in "${extra_nix_config[@]}"; do
+            create_or_update_file /etc/nix/nix.conf "$line"
+        done
+    IFS=$OLDIFS
 fi
 
 # Create entrypoint if needed


### PR DESCRIPTION
This would allow one to specify e.g.

```
  "features": {
    "ghcr.io/devcontainers/features/nix:1": {
      "extraNixConfig": "extra-substituters = https://foo.cachix.org,extra-trusted-public-keys = foo.cachix.org-1:bar="
    }
  }
```

so that the nix daemon can run against additional binary caches.