### PR TITLE
Add git extension for JupyterLab to Python feature

### DIFF
--- a/src/python/devcontainer-feature.json
+++ b/src/python/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "python",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "name": "Python",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/python",
   "description": "Installs the provided version of Python, as well as PIPX, and other common Python utilities.  JupyterLab is conditionally installed with the python feature. Note: May require source code compilation.",

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -465,6 +465,7 @@ fi
 # Install JupyterLab if needed
 if [ "${INSTALL_JUPYTERLAB}" = "true" ]; then
     install_user_package jupyterlab
+    install_user_package jupyterlab-git
 
     # Configure JupyterLab if needed
     if [ -n "${CONFIGURE_JUPYTERLAB_ALLOW_ORIGIN}" ]; then

--- a/test/python/install_additional_jupyterlab.sh
+++ b/test/python/install_additional_jupyterlab.sh
@@ -16,6 +16,9 @@ check "version" jupyter lab --version
 packages="$(python3 -m pip list)"
 check "location" grep jupyter <<< "$packages"
 
+# Check for git extension
+check "jupyterlab-git" grep jupyterlab-git <<< "$packages"
+
 # Check for correct JupyterLab configuration
 check "config" grep ".*.allow_origin = '*'" /home/vscode/.jupyter/jupyter_server_config.py
 

--- a/test/python/install_jupyterlab.sh
+++ b/test/python/install_jupyterlab.sh
@@ -16,6 +16,9 @@ check "version" jupyter lab --version
 packages="$(python3 -m pip list)"
 check "location" grep jupyter <<< "$packages"
 
+# Check for git extension
+check "jupyterlab-git" grep jupyterlab-git <<< "$packages"
+
 # Check for correct JupyterLab configuration
 check "config" grep ".*.allow_origin = '*'" /home/vscode/.jupyter/jupyter_server_config.py
 


### PR DESCRIPTION
Installs `jupyterlab-git` after `jupyterlab` in the Python feature. This extension makes it much easier to interact with git from JupyterLab. This extension adds ~6 MB (measured by `du -hx /usr/local/python`).

<img width="1282" alt="Demo of jupyterlab-git" src="https://user-images.githubusercontent.com/19893438/201726162-df96d1ff-2f42-4f90-a26d-71eb969f8379.png">