### PR TITLE
Node: Fix bug - version set by Feature is not default

### DIFF
--- a/src/node/devcontainer-feature.json
+++ b/src/node/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "node",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "name": "Node.js (via nvm) and yarn",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/node",
     "description": "Installs Node.js, nvm, yarn, and needed dependencies.",

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -152,7 +152,7 @@ if [ ! -d "${NVM_DIR}" ]; then
 else
     echo "NVM already installed."
     if [ "${NODE_VERSION}" != "" ]; then
-        su ${USERNAME} -c "umask 0002 && . $NVM_DIR/nvm.sh && nvm install ${NODE_VERSION}"
+        su ${USERNAME} -c "umask 0002 && . $NVM_DIR/nvm.sh && nvm install ${NODE_VERSION} && nvm alias default ${NODE_VERSION}"
     fi
 fi
 

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -81,6 +81,12 @@ check_packages() {
 # Ensure apt is in non-interactive to avoid prompts
 export DEBIAN_FRONTEND=noninteractive
 
+. /etc/os-release
+if [[ "bionic" = *"${VERSION_CODENAME}"* ]]; then
+    echo "(!) Unsupported distribution version '${VERSION_CODENAME}'. Details: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442"
+    exit 1
+fi
+
 # Install dependencies
 check_packages apt-transport-https curl ca-certificates tar gnupg2 dirmngr
 

--- a/test/node/install_node_on_universal_image.sh
+++ b/test/node/install_node_on_universal_image.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "version_on_path" bash -c "node -v | grep 'v19.1.0'"
+
+# Report result
+reportResults

--- a/test/node/scenarios.json
+++ b/test/node/scenarios.json
@@ -25,5 +25,14 @@
                 "version": "none"
             }
         }
+    },
+    "install_node_on_universal_image": {
+        "image": "mcr.microsoft.com/devcontainers/universal",
+        "remoteUser": "codespace",
+        "features": {
+            "node": {
+                "version": "19.1.0"
+            }
+        }
     }
 }


### PR DESCRIPTION
Version specified by the `node` Feature should be set as default. It was failing when `node` Feature was added on top of the `universal` image.