### PR TITLE
Install git before github-cli

### DIFF
--- a/src/github-cli/devcontainer-feature.json
+++ b/src/github-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "github-cli",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "name": "GitHub CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/github-cli",
     "description": "Installs the GitHub CLI. Auto-detects latest version and installs needed dependencies.",

--- a/src/github-cli/devcontainer-feature.json
+++ b/src/github-cli/devcontainer-feature.json
@@ -20,7 +20,8 @@
         }
     },
     "installsAfter": [
-        "ghcr.io/devcontainers/features/common-utils"
+        "ghcr.io/devcontainers/features/common-utils",
+        "ghcr.io/devcontainers/features/git"
     ]
 }
 


### PR DESCRIPTION
If building a devcontainer on e.g. `debian:bullseye`, github-cli installation can fail due to git not being installed yet:

```
0 13.38 2022-11-18 13:37:19 (6.08 MB/s) - 'gh_2.20.2_linux_amd64.deb' saved [10
176698/10176698]
#0 13.38
#0 13.40 Selecting previously unselected package gh.
#0 13.41 (Reading database ... 13628 files and directories currently installed.)
#0 13.41 Preparing to unpack .../gh_2.20.2_linux_amd64.deb ...
#0 13.41 Unpacking gh (2.20.2) ...
#0 13.65 dpkg: dependency problems prevent configuration of gh:
#0 13.65  gh depends on git; however:
#0 13.65   Package git is not installed.
#0 13.65
#0 13.65 dpkg: error processing package gh (--install):
#0 13.65  dependency problems - leaving unconfigured
#0 13.66 Errors were encountered while processing:
#0 13.66  gh
#0 13.67 ERROR: Feature "GitHub CLI" (ghcr.io/devcontainers/features/github-cli)
 failed to install! Look at the documentation at https://github.com/devcontainer
s/features/tree/main/src/github-cli for help troubleshooting this error.
```