### PR TITLE
Optionally install Azure Bicep as part of azure-cli feature

### DIFF
--- a/src/azure-cli/devcontainer-feature.json
+++ b/src/azure-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-cli",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "name": "Azure CLI",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/azure-cli",
   "description": "Installs the Azure CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",
@@ -17,6 +17,11 @@
       "type": "string",
       "default": "",
       "description": "Optional comma separated list of Azure CLI extensions to install in profile."
+    },
+    "installBicep": {
+      "type": "boolean",
+      "description": "Optionally install Azure Bicep",
+      "default": false
     }
   },
   "customizations": {

--- a/src/azure-cli/install.sh
+++ b/src/azure-cli/install.sh
@@ -14,6 +14,7 @@ rm -rf /var/lib/apt/lists/*
 
 AZ_VERSION=${VERSION:-"latest"}
 AZ_EXTENSIONS=${EXTENSIONS}
+AZ_INSTALLBICEP=${INSTALLBICEP:-false}
 
 MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
 AZCLI_ARCHIVE_ARCHITECTURES="amd64"
@@ -195,6 +196,28 @@ if [ ${#AZ_EXTENSIONS[@]} -gt 0 ]; then
         echo "Installing ${i}"
         su ${_REMOTE_USER} -c "az extension add --name ${i} -y" || continue
     done
+fi
+
+if [ "${AZ_INSTALLBICEP}" = "true" ]; then
+    # Properly install Azure Bicep based on current architecture
+    # The `az bicep install` command installs the linux-x64 binary even on arm64 devcontainers
+    # The `az bicep install --target-platform` could be a solution; however, linux-arm64 is not an allowed value for this argument yet
+    # Manually installing Bicep and moving to the appropriate directory where az expects it to be
+    apt-get install curl -y
+    
+    if [ "${architecture}" = "arm64" ]; then
+        curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-arm64
+    else 
+        curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64
+    fi
+    
+    chmod +x ./bicep
+    mv ./bicep /usr/local/bin/bicep
+
+    # Add a synlink so bicep can be accessed as a standalone executable or as part of az
+    mkdir -p ${_REMOTE_USER_HOME}/.azure/bin
+    chown -hR ${_REMOTE_USER}:${_REMOTE_USER} ${_REMOTE_USER_HOME}/.azure
+    ln -s /usr/local/bin/bicep ${_REMOTE_USER_HOME}/.azure/bin/bicep
 fi
 
 # Clean up

--- a/src/azure-cli/install.sh
+++ b/src/azure-cli/install.sh
@@ -199,11 +199,13 @@ if [ ${#AZ_EXTENSIONS[@]} -gt 0 ]; then
 fi
 
 if [ "${AZ_INSTALLBICEP}" = "true" ]; then
+    # Install dependencies
+    check_packages apt-transport-https curl 
+    
     # Properly install Azure Bicep based on current architecture
     # The `az bicep install` command installs the linux-x64 binary even on arm64 devcontainers
     # The `az bicep install --target-platform` could be a solution; however, linux-arm64 is not an allowed value for this argument yet
     # Manually installing Bicep and moving to the appropriate directory where az expects it to be
-    apt-get install curl -y
     
     if [ "${architecture}" = "arm64" ]; then
         curl -Lo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-arm64
@@ -214,7 +216,7 @@ if [ "${AZ_INSTALLBICEP}" = "true" ]; then
     chmod +x ./bicep
     mv ./bicep /usr/local/bin/bicep
 
-    # Add a synlink so bicep can be accessed as a standalone executable or as part of az
+    # Add a symlink so bicep can be accessed as a standalone executable or as part of az
     mkdir -p ${_REMOTE_USER_HOME}/.azure/bin
     chown -hR ${_REMOTE_USER}:${_REMOTE_USER} ${_REMOTE_USER_HOME}/.azure
     ln -s /usr/local/bin/bicep ${_REMOTE_USER_HOME}/.azure/bin/bicep

--- a/test/azure-cli/install_bicep.sh
+++ b/test/azure-cli/install_bicep.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Import test library for `check` command
+source dev-container-features-test-lib
+
+# Check to make sure the user is vscode
+check "user is vscode" whoami | grep vscode
+
+# Bicep-specific tests
+check "bicep" bicep --version
+check "az bicep" az bicep version
+
+# Report result
+reportResults

--- a/test/azure-cli/scenarios.json
+++ b/test/azure-cli/scenarios.json
@@ -1,11 +1,21 @@
 {
   "install_extensions": {
-    "image": "ubuntu:focal",
+    "image": "mcr.microsoft.com/devcontainers/base:jammy",
     "user": "vscode",
     "features": {
       "azure-cli": {
         "version": "latest",
         "extensions": "aks-preview,amg,containerapp"
+      }
+    }
+  },
+  "install_bicep": {
+    "image": "mcr.microsoft.com/devcontainers/base:jammy",
+    "user": "vscode",
+    "features": {
+      "azure-cli": {
+        "version": "latest",
+        "installBicep": true
       }
     }
   }


### PR DESCRIPTION
When users run the `az bicep` command for the first time, Azure CLI looks for the Bicep binary in `$HOME/.azure/bin` and if is not found, it will auto-install Bicep. This is a convenience feature of Azure CLI; however, it incorrectly installs Bicep on `arm64` OS architectures. 

Here is an example of an error a user will encounter when running `az bicep` commands in a devcontainer hosted on M1 Macs:

```
$ az bicep version

qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
```

The error is due to OS architecture mismatch between the container `arm64` and the Bicep binary `amd64` that was auto-installed by Azure CLI.

The long term fix for the Azure CLI to properly download the correct Bicep binary based on OS architecture. However, this may have a longer turnaround time.

The short term fix is in this PR which gives the user an option to install the Azure Bicep as part of the `azure-cli` feature. The install script will manually install Bicep based on OS architecture and create a symlink so that `bicep` is accessible as both a stand-alone executable and as part of `az`.

This will immediately unblock users who wish to use Bicep on arm64 based devcontainers and will submit an issue in the azure-cli repo to address the underlying root cause.