### PR TITLE
docker-in-docker fix : Use ${devcontainerId} for volume name

### DIFF
--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "1.0.9",
+    "version": "2.0.0",
     "name": "Docker (Docker-in-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
     "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",
@@ -55,7 +55,7 @@
     },
     "mounts": [
         {
-            "source": "dind-var-lib-docker",
+            "source": "dind-var-lib-docker-${devcontainerId}",
             "target": "/var/lib/docker",
             "type": "volume"
         }


### PR DESCRIPTION
Closes - https://github.com/devcontainers/features/issues/248 

❗  Bug fix - Currently, user is not able to open two instances of VS code with docker-in-docker running.