### PR TITLE
Git: Build from source with USE_LIBPCRE

### DIFF
--- a/src/git/devcontainer-feature.json
+++ b/src/git/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "git",
-    "version": "1.0.5",
+    "version": "1.1.0",
     "name": "Git (from source)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/git",
     "description": "Install an up-to-date version of Git, built from source as needed. Useful for when you want the latest and greatest features. Auto-detects latest stable version and installs needed dependencies.",

--- a/src/git/install.sh
+++ b/src/git/install.sh
@@ -147,11 +147,13 @@ if [ "$(echo "${GIT_VERSION}" | grep -o '\.' | wc -l)" != "2" ]; then
     fi
 fi
 
+check_packages libpcre2-posix2 libpcre2-dev
+
 echo "Downloading source for ${GIT_VERSION}..."
 curl -sL https://github.com/git/git/archive/v${GIT_VERSION}.tar.gz | tar -xzC /tmp 2>&1
 echo "Building..."
 cd /tmp/git-${GIT_VERSION}
-make -s prefix=/usr/local all && make -s prefix=/usr/local install 2>&1
+make -s USE_LIBPCRE=YesPlease prefix=/usr/local all && make -s USE_LIBPCRE=YesPlease prefix=/usr/local install 2>&1
 rm -rf /tmp/git-${GIT_VERSION}
 rm -rf /var/lib/apt/lists/*
 echo "Done!"

--- a/test/git/install_git_from_src.sh
+++ b/test/git/install_git_from_src.sh
@@ -8,5 +8,9 @@ source dev-container-features-test-lib
 check "version" git  --version
 check "gettext" dpkg-query -l gettext
 
+cd /tmp && git clone https://github.com/devcontainers/feature-starter.git
+cd feature-starter
+check "perl" bash -c "git -c grep.patternType=perl grep -q 'a.+b'"
+
 # Report result
 reportResults


### PR DESCRIPTION
Enable support for `git grep --perl-regexp` when git is built from source.