### PR TITLE
Add support for mariner

### DIFF
--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -289,7 +289,7 @@ chmod +x /etc/profile.d/00-restore-env.sh
 # Get an adjusted ID independant of distro variants
 if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
     ADJUSTED_ID="debian"
-elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* ]]; then
+elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"mariner"* ]]; then
     ADJUSTED_ID="rhel"
 elif [ "${ID}" = "alpine" ]; then
     ADJUSTED_ID="alpine"

--- a/test/common-utils/mariner.sh
+++ b/test/common-utils/mariner.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+. /etc/os-release
+check "non-root user" test "$(whoami)" = "devcontainer"
+check "distro" test "${ID}" = "mariner"
+
+# Report result
+reportResults

--- a/test/common-utils/scenarios.json
+++ b/test/common-utils/scenarios.json
@@ -62,6 +62,13 @@
             "common-utils": {}
         }
     },
+    "mariner": {
+        "image": "mcr.microsoft.com/cbl-mariner/base/core:2.0",
+        "remoteUser": "devcontainer",
+        "features": {
+            "common-utils": {}
+        }
+    },
     "alpine": {
         "image": "alpine",
         "remoteUser": "devcontainer",


### PR DESCRIPTION
Verified this works by just adding "mariner" to the list of distro ID's you treat as "rhel"

Manually published the feature and built a Codespace that uses a Mariner image and this feature to configure it.

Also ran the tests in my fork before submitting the PR: https://github.com/markphip/features/actions

If you do not want to "fully support" mariner you could just drop the tests aspect of this PR