### PR TITLE
feat(common-utils): Support the new path of `meta.env` file and the new field for saving source revisions

### DIFF
--- a/src/common-utils/bin/devcontainer-info
+++ b/src/common-utils/bin/devcontainer-info
@@ -1,5 +1,12 @@
 #!/bin/sh
-. /usr/local/etc/vscode-dev-containers/meta.env
+
+# Load meta.env
+if [ -f "/usr/local/etc/vscode-dev-containers/meta.env" ]; then
+    . /usr/local/etc/vscode-dev-containers/meta.env
+fi
+if [ -f "/usr/local/etc/dev-containers/meta.env" ]; then
+    . /usr/local/etc/dev-containers/meta.env
+fi
 
 # Minimal output
 if [ "$1" = "version" ] || [ "$1" = "image-version" ]; then

--- a/src/common-utils/bin/devcontainer-info
+++ b/src/common-utils/bin/devcontainer-info
@@ -29,6 +29,7 @@ if [ ! -z "${DEFINITION_ID}" ]; then echo "- Definition ID: ${DEFINITION_ID}"; f
 if [ ! -z "${VARIANT}" ]; then echo "- Variant: ${VARIANT}"; fi
 if [ ! -z "${GIT_REPOSITORY}" ]; then echo "- Source code repository: ${GIT_REPOSITORY}"; fi
 if [ ! -z "${GIT_REPOSITORY_RELEASE}" ]; then echo "- Source code release/branch: ${GIT_REPOSITORY_RELEASE}"; fi
+if [ ! -z "${GIT_REPOSITORY_REVISION}" ]; then echo "- Source code revision: ${GIT_REPOSITORY_REVISION}"; fi
 if [ ! -z "${BUILD_TIMESTAMP}" ]; then echo "- Timestamp: ${BUILD_TIMESTAMP}"; fi
 if [ ! -z "${CONTENTS_URL}" ]; then echo && echo "More info: ${CONTENTS_URL}"; fi
 echo

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -477,7 +477,7 @@ if [ "${ADJUSTED_ID}" = "debian" ]; then
 fi
 
 # Persist image metadata info, script if meta.env found in same directory
-if [ -f "/usr/local/etc/vscode-dev-containers/meta.env" ]; then
+if [ -f "/usr/local/etc/vscode-dev-containers/meta.env" ] || [ -f "/usr/local/etc/dev-containers/meta.env" ] ; then
     cp -f "${FEATURE_DIR}/bin/devcontainer-info" /usr/local/bin/devcontainer-info
     chmod +x /usr/local/bin/devcontainer-info
 fi

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -477,7 +477,7 @@ if [ "${ADJUSTED_ID}" = "debian" ]; then
 fi
 
 # Persist image metadata info, script if meta.env found in same directory
-if [ -f "/usr/local/etc/vscode-dev-containers/meta.env" ] || [ -f "/usr/local/etc/dev-containers/meta.env" ] ; then
+if [ -f "/usr/local/etc/vscode-dev-containers/meta.env" ] || [ -f "/usr/local/etc/dev-containers/meta.env" ]; then
     cp -f "${FEATURE_DIR}/bin/devcontainer-info" /usr/local/bin/devcontainer-info
     chmod +x /usr/local/bin/devcontainer-info
 fi


### PR DESCRIPTION
Close #345

Add the following two features to the `devcontainer-info` command:

- Allows `meta.env` file to be placed in `/usr/local/etc/dev-containers/meta.env`.
- Reads and displays variable `GIT_REPOSITORY_REVISION`, which is supposed to record the revision of the source code of the image.