### PR TITLE
[PHP] Enable Mbstring

### DIFF
--- a/src/php/devcontainer-feature.json
+++ b/src/php/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "php",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "name": "PHP",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/php",
     "options": {

--- a/src/php/install.sh
+++ b/src/php/install.sh
@@ -169,7 +169,7 @@ install_php() {
         VERSION_CONFIG="--with-pear"
     fi
 
-    ./configure --prefix="${PHP_INSTALL_DIR}" --with-config-file-path="$PHP_INI_DIR" --with-config-file-scan-dir="$CONF_DIR" --enable-option-checking=fatal --with-curl --with-libedit --with-openssl --with-zlib --with-password-argon2 --with-sodium=shared "$VERSION_CONFIG" EXTENSION_DIR="$PHP_EXT_DIR";
+    ./configure --prefix="${PHP_INSTALL_DIR}" --with-config-file-path="$PHP_INI_DIR" --with-config-file-scan-dir="$CONF_DIR" --enable-option-checking=fatal --with-curl --with-libedit --enable-mbstring --with-openssl --with-zlib --with-password-argon2 --with-sodium=shared "$VERSION_CONFIG" EXTENSION_DIR="$PHP_EXT_DIR";
 
     make -j "$(nproc)"
     find -type f -name '*.a' -delete

--- a/test/php/test.sh
+++ b/test/php/test.sh
@@ -6,6 +6,7 @@ set -e
 source dev-container-features-test-lib
 
 check "PHP version" php --version
+check "Mbstring loaded" php -r "extension_loaded('mbstring') || throw new Error('Extension Mbstring is not loaded');"
 check "Composer version" composer --version
 
 # Report result


### PR DESCRIPTION
Mbstring is such a popular PHP extension that it is used everywhere and most libraries don't work without it. It can be compiled directly with PHP. The official Docker images of PHP include it.