### PR TITLE
Install gawk RPM

### DIFF
--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "common-utils",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "name": "Common Utilities",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/common-utils",
     "description": "Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.",

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -146,6 +146,7 @@ install_debian_packages() {
 # RedHat / RockyLinux / CentOS / Fedora packages
 install_redhat_packages() {
     local package_list="\
+        gawk \
         openssh-clients \
         gnupg2 \
         iproute \


### PR DESCRIPTION
This script requires awk and it may not be available on a minimal distro like Mariner. I tested with Mariner, Fedora and Rocky Linux. Theoretically could also add this for Debian and Alpine based distros but I leave that for you to decide.