### PR TITLE
PHP fixes

### DIFF
--- a/src/php/NOTES.md
+++ b/src/php/NOTES.md
@@ -5,3 +5,10 @@
 This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
 
 `bash` is required to execute the `install.sh` script.
+
+
+## Version support
+
+See the [releases page](https://www.php.net/releases/).
+
+Note: An **exact** version must be specified, e.g. `8.0.16` not `8`.

--- a/src/php/devcontainer-feature.json
+++ b/src/php/devcontainer-feature.json
@@ -11,7 +11,7 @@
                 "8.0.16"
             ],
             "default": "latest",
-            "description": "Select or enter a PHP version"
+            "description": "Select or enter an exact PHP version"
         },
         "installComposer": {
             "type": "boolean",

--- a/src/php/install.sh
+++ b/src/php/install.sh
@@ -189,13 +189,15 @@ install_php() {
     cp "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
     # Install xdebug
-    "${PHP_INSTALL_DIR}/bin/pecl" install xdebug
-    XDEBUG_INI="${CONF_DIR}/xdebug.ini"
+    if (( $(($PHP_MAJOR_VERSION)) >= 8 )); then 
+        "${PHP_INSTALL_DIR}/bin/pecl" install xdebug
+        XDEBUG_INI="${CONF_DIR}/xdebug.ini"
 
-    echo "zend_extension=${PHP_EXT_DIR}/xdebug.so" > "${XDEBUG_INI}"
-    echo "xdebug.mode = debug" >> "${XDEBUG_INI}"
-    echo "xdebug.start_with_request = yes" >> "${XDEBUG_INI}"
-    echo "xdebug.client_port = 9003" >> "${XDEBUG_INI}"
+        echo "zend_extension=${PHP_EXT_DIR}/xdebug.so" > "${XDEBUG_INI}"
+        echo "xdebug.mode = debug" >> "${XDEBUG_INI}"
+        echo "xdebug.start_with_request = yes" >> "${XDEBUG_INI}"
+        echo "xdebug.client_port = 9003" >> "${XDEBUG_INI}"
+    fi
 
     # Install PHP Composer if needed
     if [[ "${INSTALL_COMPOSER}" = "true" ]] || [[ $(composer --version) = "" ]]; then


### PR DESCRIPTION
The specified version is appended straight in to URL:

https://github.com/devcontainers/features/blob/a9a7a25d60585ce2145374ec6825cbdc7f16cb90/src/php/install.sh#L151

Resulting in build failure if it's not an exact match, e.g.:
https://www.php.net/distributions/php-8.tar.gz

```
2023-01-06 19:54:49.869Z: #13 19.74 Connecting to www.php.net (www.php.net)|185.85.0.29|:443... 
2023-01-06 19:54:50.037Z: connected.
2023-01-06 19:54:50.317Z: #13 20.18 HTTP request sent, awaiting response... 
2023-01-06 19:54:50.430Z: 404 Not Found
2023-01-06 19:54:50.430Z: #13 20.44 2023-01-06 19:54:50 ERROR 404: Not Found.
2023-01-06 19:54:50.430Z: #13 20.44 
2023-01-06 19:54:50.597Z: #13 20.44 ERROR: Feature "PHP" (ghcr.io/devcontainers/features/php) failed to install! Look at the documentation at https://github.com/devcontainers/features/tree/main/src/php for help troubleshooting this error.
2023-01-06 19:54:50.737Z: #13 ERROR: executor failed running [/bin/sh -c cd /tmp/build-features/php_3 && chmod +x ./devcontainer-features-install.sh && ./devcontainer-features-install.sh]: exit code: 8
2023-01-06 19:54:50.737Z: ------
2023-01-06 19:54:50.737Z:  > [dev_containers_target_stage 4/5] RUN cd /tmp/build-features/php_3 && chmod +x ./devcontainer-features-install.sh && ./devcontainer-features-install.sh:
2023-01-06 19:54:50.737Z: ------
2023-01-06 19:54:50.737Z: executor failed running [/bin/sh -c cd /tmp/build-features/php_3 && chmod +x ./devcontainer-features-install.sh && ./devcontainer-features-install.sh]: exit code: 8
2023-01-06 19:54:50.765Z: ERROR: Service 'app' failed to build : Build failed
```

---

Also don't fail on:
```
2023-01-06 20:10:38.800Z: #12 295.5 pecl/xdebug requires PHP (version >= 8.0.0, version <= 8.2.99), installed version is 7.2.34
2023-01-06 20:10:38.940Z: #12 295.5 No valid packages found
2023-01-06 20:10:38.941Z: #12 295.5 install failed
2023-01-06 20:10:38.941Z: #12 295.5 ERROR: Feature "PHP" (ghcr.io/devcontainers/features/php) failed to install! Look at the documentation at https://github.com/devcontainers/features/tree/main/src/php for help troubleshooting this error.
2023-01-06 20:10:39.529Z: #12 ERROR: executor failed running [/bin/sh -c cd /tmp/build-features/php_3 && chmod +x ./devcontainer-features-install.sh && ./devcontainer-features-install.sh]: exit code: 1
2023-01-06 20:10:39.529Z: 
2023-01-06 20:10:39.529Z: ------
2023-01-06 20:10:39.529Z:  > [dev_containers_target_stage 4/5] RUN cd /tmp/build-features/php_3 && chmod +x ./devcontainer-features-install.sh && ./devcontainer-features-install.sh:
2023-01-06 20:10:39.529Z: ------
2023-01-06 20:10:39.529Z: executor failed running [/bin/sh -c cd /tmp/build-features/php_3 && chmod +x ./devcontainer-features-install.sh && ./devcontainer-features-install.sh]: exit code: 1
2023-01-06 20:10:39.529Z: ERROR: Service 'app' failed to build : Build failed
```