### PR TITLE
[common-utils] Fix permission of scripts in containers

### DIFF
--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "common-utils",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "name": "Common Utilities",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/common-utils",
     "description": "Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.",

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -474,18 +474,18 @@ fi
 
 # code shim, it fallbacks to code-insiders if code is not available
 cp -f "${FEATURE_DIR}/bin/code" /usr/local/bin/
-chmod +x /usr/local/bin/code
+chmod +rx /usr/local/bin/code
 
 # systemctl shim for Debian/Ubuntu - tells people to use 'service' if systemd is not running
 if [ "${ADJUSTED_ID}" = "debian" ]; then
     cp -f "${FEATURE_DIR}/bin/systemctl" /usr/local/bin/systemctl
-    chmod +x /usr/local/bin/systemctl
+    chmod +rx /usr/local/bin/systemctl
 fi
 
 # Persist image metadata info, script if meta.env found in same directory
 if [ -f "/usr/local/etc/vscode-dev-containers/meta.env" ] || [ -f "/usr/local/etc/dev-containers/meta.env" ]; then
     cp -f "${FEATURE_DIR}/bin/devcontainer-info" /usr/local/bin/devcontainer-info
-    chmod +x /usr/local/bin/devcontainer-info
+    chmod +rx /usr/local/bin/devcontainer-info
 fi
 
 # Write marker file

--- a/test/common-utils/devcontainer-info.sh
+++ b/test/common-utils/devcontainer-info.sh
@@ -5,15 +5,20 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
+check_info() {
+    local info=$1
+    check "devcontainer-info ${info}" sh -c "devcontainer-info | grep test-${info}"
+}
+
 # Definition specific tests
-check "devcontainer-info version" sh -c "devcontainer-info | grep test-version"
-check "devcontainer-info id" sh -c "devcontainer-info | grep test-build"
-check "devcontainer-info variant" sh -c "devcontainer-info | grep test-variant"
-check "devcontainer-info repository" sh -c "devcontainer-info | grep test-repository"
-check "devcontainer-info release" sh -c "devcontainer-info | grep test-release"
-check "devcontainer-info revigion" sh -c "devcontainer-info | grep test-revision"
-check "devcontainer-info timestamp" sh -c "devcontainer-info | grep test-time"
-check "devcontainer-info url" sh -c "devcontainer-info | grep test-url"
+check_info "version"
+check_info "id"
+check_info "variant"
+check_info "repository"
+check_info "release"
+check_info "revision"
+check_info "time"
+check_info "url"
 
 # Report result
 reportResults

--- a/test/common-utils/devcontainer-info.sh
+++ b/test/common-utils/devcontainer-info.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "devcontainer-info" sh -c "devcontainer-info | grep test-build"
+
+# Report result
+reportResults

--- a/test/common-utils/devcontainer-info.sh
+++ b/test/common-utils/devcontainer-info.sh
@@ -11,6 +11,7 @@ check_info() {
 }
 
 # Definition specific tests
+check "user" bash -c "whoami | grep vscode"
 check_info "version"
 check_info "id"
 check_info "variant"

--- a/test/common-utils/devcontainer-info.sh
+++ b/test/common-utils/devcontainer-info.sh
@@ -6,7 +6,14 @@ set -e
 source dev-container-features-test-lib
 
 # Definition specific tests
-check "devcontainer-info" sh -c "devcontainer-info | grep test-build"
+check "devcontainer-info version" sh -c "devcontainer-info | grep test-version"
+check "devcontainer-info id" sh -c "devcontainer-info | grep test-build"
+check "devcontainer-info variant" sh -c "devcontainer-info | grep test-variant"
+check "devcontainer-info repository" sh -c "devcontainer-info | grep test-repository"
+check "devcontainer-info release" sh -c "devcontainer-info | grep test-release"
+check "devcontainer-info revigion" sh -c "devcontainer-info | grep test-revision"
+check "devcontainer-info timestamp" sh -c "devcontainer-info | grep test-time"
+check "devcontainer-info url" sh -c "devcontainer-info | grep test-url"
 
 # Report result
 reportResults

--- a/test/common-utils/devcontainer-info/Dockerfile
+++ b/test/common-utils/devcontainer-info/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/base:debian
+
+COPY meta.env /usr/local/etc/dev-containers/meta.env

--- a/test/common-utils/devcontainer-info/Dockerfile
+++ b/test/common-utils/devcontainer-info/Dockerfile
@@ -1,3 +1,3 @@
-FROM mcr.microsoft.com/devcontainers/base:debian
+FROM ubuntu:focal
 
 COPY meta.env /usr/local/etc/dev-containers/meta.env

--- a/test/common-utils/devcontainer-info/meta.env
+++ b/test/common-utils/devcontainer-info/meta.env
@@ -1,0 +1,1 @@
+DEFINITION_ID='test-build'

--- a/test/common-utils/devcontainer-info/meta.env
+++ b/test/common-utils/devcontainer-info/meta.env
@@ -1,5 +1,5 @@
 VERSION='test-version'
-DEFINITION_ID='test-build'
+DEFINITION_ID='test-id'
 VARIANT='test-variant'
 GIT_REPOSITORY='test-repository'
 GIT_REPOSITORY_RELEASE='test-release'

--- a/test/common-utils/devcontainer-info/meta.env
+++ b/test/common-utils/devcontainer-info/meta.env
@@ -1,1 +1,8 @@
+VERSION='test-version'
 DEFINITION_ID='test-build'
+VARIANT='test-variant'
+GIT_REPOSITORY='test-repository'
+GIT_REPOSITORY_RELEASE='test-release'
+GIT_REPOSITORY_REVISION='test-revision'
+BUILD_TIMESTAMP='test-time'
+CONTENTS_URL='test-url'

--- a/test/common-utils/scenarios.json
+++ b/test/common-utils/scenarios.json
@@ -114,5 +114,13 @@
                 "configureZshAsDefaultShell": true
             }
         }
+    },
+    "devcontainer-info": {
+        "build": {
+            "dockerfile": "Dockerfile"
+        },
+        "features": {
+            "common-utils": {}
+        }
     }
 }

--- a/test/common-utils/scenarios.json
+++ b/test/common-utils/scenarios.json
@@ -120,6 +120,15 @@
             "dockerfile": "Dockerfile"
         },
         "features": {
+            "common-utils": {
+                "username": "vscode",
+                "userUid": "1000",
+                "userGid": "1000",
+                "upgradePackages": true,
+                "installZsh": true
+            }
+        },
+        "remoteUser": "vscode"
             "common-utils": {}
         }
     }

--- a/test/common-utils/scenarios.json
+++ b/test/common-utils/scenarios.json
@@ -129,7 +129,5 @@
             }
         },
         "remoteUser": "vscode"
-            "common-utils": {}
-        }
     }
 }


### PR DESCRIPTION
Fix #387

The Dev Container CLI changes permission when copying scripts into the container and read permissions are removed for the non-root users.
Read permission must be added after copying the scripts into the container.