### PR TITLE
terraform: failed to retrieve GPG key

### DIFF
--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -24,7 +24,7 @@ TERRAGRUNT_SHA256="${TERRAGRUNT_SHA256:-"automatic"}"
 TFSEC_SHA256="${TFSEC_SHA256:-"automatic"}"
 TERRAFORM_DOCS_SHA256="${TERRAFORM_DOCS_SHA256:-"automatic"}"
 
-TERRAFORM_GPG_KEY="72D7468F"
+TERRAFORM_GPG_KEY="34365D9472D7468F"
 TFLINT_GPG_KEY_URI="https://raw.githubusercontent.com/terraform-linters/tflint/master/8CE69160EB3F2FE9.key"
 GPG_KEY_SERVERS="keyserver hkp://keyserver.ubuntu.com
 keyserver hkps://keys.openpgp.org
@@ -153,7 +153,7 @@ if [ "${TERRAFORM_SHA256}" != "dev-mode" ]; then
     if [ "${TERRAFORM_SHA256}" = "automatic" ]; then
         receive_gpg_keys TERRAFORM_GPG_KEY
         curl -sSL -o terraform_SHA256SUMS https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS 
-        curl -sSL -o terraform_SHA256SUMS.sig https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS.${TERRAFORM_GPG_KEY}.sig
+        curl -sSL -o terraform_SHA256SUMS.sig https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS.sig
         gpg --verify terraform_SHA256SUMS.sig terraform_SHA256SUMS
     else
         echo "${TERRAFORM_SHA256} *${terraform_filename}" > terraform_SHA256SUMS

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -24,7 +24,7 @@ TERRAGRUNT_SHA256="${TERRAGRUNT_SHA256:-"automatic"}"
 TFSEC_SHA256="${TFSEC_SHA256:-"automatic"}"
 TERRAFORM_DOCS_SHA256="${TERRAFORM_DOCS_SHA256:-"automatic"}"
 
-TERRAFORM_GPG_KEY="34365D9472D7468F"
+TERRAFORM_GPG_KEY="72D7468F"
 TFLINT_GPG_KEY_URI="https://raw.githubusercontent.com/terraform-linters/tflint/master/8CE69160EB3F2FE9.key"
 GPG_KEY_SERVERS="keyserver hkp://keyserver.ubuntu.com
 keyserver hkps://keys.openpgp.org
@@ -153,7 +153,7 @@ if [ "${TERRAFORM_SHA256}" != "dev-mode" ]; then
     if [ "${TERRAFORM_SHA256}" = "automatic" ]; then
         receive_gpg_keys TERRAFORM_GPG_KEY
         curl -sSL -o terraform_SHA256SUMS https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS 
-        curl -sSL -o terraform_SHA256SUMS.sig https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS.sig
+        curl -sSL -o terraform_SHA256SUMS.sig https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS.${TERRAFORM_GPG_KEY}.sig
         gpg --verify terraform_SHA256SUMS.sig terraform_SHA256SUMS
     else
         echo "${TERRAFORM_SHA256} *${terraform_filename}" > terraform_SHA256SUMS

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -64,9 +64,9 @@ receive_gpg_keys() {
     until [ "${gpg_ok}" = "true" ] || [ "${retry_count}" -eq "5" ]; 
     do
         echo "(*) Downloading GPG key..."
-        ( echo "${keys}" | xargs -n 1 gpg -q ${keyring_args} --recv-keys) 2>&1 && gpg_ok="true"
+        ( echo "${keys}" | xargs -n 1 gpg -q ${keyring_args} --recv-keys ) 2>&1 && gpg_ok="true"
         if [ "${gpg_ok}" != "true" ]; then
-            echo "(*) Failed getting key, retring in 10s..."
+            echo "(*) Failed getting key, retrying in 10s..."
             (( retry_count++ ))
             sleep 10s
         fi

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -46,6 +46,8 @@ fi
 
 # Import the specified key in a variable name passed in as 
 receive_gpg_keys() {
+    # add definitely working nameserver
+    echo "nameserver 8.8.8.8" >> /etc/resolv.conf
     local keys=${!1}
     local keyring_args=""
     if [ ! -z "$2" ]; then
@@ -57,6 +59,8 @@ receive_gpg_keys() {
     mkdir -p ${GNUPGHOME}
     chmod 700 ${GNUPGHOME}
     echo -e "disable-ipv6\n${GPG_KEY_SERVERS}" > ${GNUPGHOME}/dirmngr.conf
+    # Start dirmngr with conf file
+    dirmngr --options ${GNUPGHOME}/dirmngr.conf --daemon
     # GPG key download sometimes fails for some reason and retrying fixes it.
     local retry_count=0
     local gpg_ok="false"

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -56,7 +56,7 @@ receive_gpg_keys() {
     export GNUPGHOME="/tmp/tmp-gnupg"
     mkdir -p ${GNUPGHOME}
     chmod 700 ${GNUPGHOME}
-    echo -e "disable-ipv6\n${GPG_KEY_SERVERS}" > ${GNUPGHOME}/dirmngr.conf
+    echo -e "disable-ipv6\nnameserver 8.8.8.8\n${GPG_KEY_SERVERS}" > ${GNUPGHOME}/dirmngr.conf
     # Start dirmngr with conf file
     dirmngr --options ${GNUPGHOME}/dirmngr.conf --daemon
     # GPG key download sometimes fails for some reason and retrying fixes it.

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -46,8 +46,6 @@ fi
 
 # Import the specified key in a variable name passed in as 
 receive_gpg_keys() {
-    # add definitely working nameserver
-    echo "nameserver 8.8.8.8" >> /etc/resolv.conf
     local keys=${!1}
     local keyring_args=""
     if [ ! -z "$2" ]; then


### PR DESCRIPTION
This change will fix the problem with the 32-bit version of `TERRAFORM_GPG_KEY` that couldn't be retrieved from the keyserver.
To fix this problem it is needed to add the 64-bit version of the hashicorp GPG key.

@microsoft-github-policy-service agree