### PR TITLE
CommonUtils - ensure home directory exists.

### DIFF
--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "common-utils",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "name": "Common Utilities",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/common-utils",
     "description": "Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.",

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -383,11 +383,10 @@ if [ "${USERNAME}" = "root" ]; then
     user_rc_path="/root"
 else
     user_rc_path="/home/${USERNAME}"
-fi
-
-if [ ! -d "${user_rc_path}" ]; then
-    mkdir -p "${user_rc_path}"
-    chown ${USERNAME}:${group_name} "${user_rc_path}"
+    if [ ! -d "${user_rc_path}" ]; then
+        mkdir -p "${user_rc_path}"
+        chown ${USERNAME}:${group_name} "${user_rc_path}"
+    fi
 fi
 
 # Restore user .bashrc / .profile / .zshrc defaults from skeleton file if it doesn't exist or is empty

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -385,6 +385,11 @@ else
     user_rc_path="/home/${USERNAME}"
 fi
 
+if [ ! -d "${user_rc_path}" ]; then
+    mkdir -p "${user_rc_path}"
+    chown ${USERNAME}:${group_name} "${user_rc_path}"
+fi
+
 # Restore user .bashrc / .profile / .zshrc defaults from skeleton file if it doesn't exist or is empty
 possible_rc_files=( ".bashrc" ".profile" ".zshrc" )
 for rc_file in "${possible_rc_files[@]}"; do


### PR DESCRIPTION
The common utils attempts to copy certain config files into the user's home directory... without first ensuring the directory exists!
Create the user's home directory if it doesn't exist.