### PR TITLE
[docker-outside-of-docker] Change owner of source socket if non-root access is enabled

### DIFF
--- a/src/docker-outside-of-docker/install.sh
+++ b/src/docker-outside-of-docker/install.sh
@@ -86,7 +86,7 @@ find_version_from_git_tags() {
     local repository=$2
     local prefix=${3:-"tags/v"}
     local separator=${4:-"."}
-    local last_part_optional=${5:-"false"}    
+    local last_part_optional=${5:-"false"}
     if [ "$(echo "${requested_version}" | grep -o "." | wc -l)" != "2" ]; then
         local escaped_separator=${separator//./\\.}
         local last_part
@@ -171,7 +171,7 @@ apt-get update
 if [ "${DOCKER_VERSION}" = "latest" ] || [ "${DOCKER_VERSION}" = "lts" ] || [ "${DOCKER_VERSION}" = "stable" ]; then
     # Empty, meaning grab whatever "latest" is in apt repo
     cli_version_suffix=""
-else    
+else
     # Fetch a valid version from the apt-cache (eg: the Microsoft repo appends +azure, breakfix, etc...)
     docker_version_dot_escaped="${DOCKER_VERSION//./\\.}"
     docker_version_dot_plus_escaped="${docker_version_dot_escaped//+/\\+}"
@@ -223,7 +223,7 @@ else
         fi
         ${pipx_bin} install --pip-args '--no-cache-dir --force-reinstall' docker-compose
         rm -rf /tmp/pip-tmp
-    else 
+    else
         compose_v1_version="1"
         find_version_from_git_tags compose_v1_version "https://github.com/docker/compose" "tags/"
         echo "(*) Installing docker-compose ${compose_v1_version}..."
@@ -285,10 +285,10 @@ usermod -aG docker "${USERNAME}"
 DOCKER_GID="$(grep -oP '^docker:x:\K[^:]+' /etc/group)"
 
 # If enabling non-root access and specified user is found, setup socat and add script
-chown -h "${USERNAME}":root "${TARGET_SOCKET}"        
+chown -h "${USERNAME}":root "${TARGET_SOCKET}"
 check_packages socat
 tee /usr/local/share/docker-init.sh > /dev/null \
-<< EOF 
+<< EOF
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -320,8 +320,8 @@ log()
 echo -e "\n** \$(date) **" | sudoIf tee -a \${SOCAT_LOG} > /dev/null
 log "Ensuring ${USERNAME} has access to ${SOURCE_SOCKET} via ${TARGET_SOCKET}"
 
-# If enabled, try to update the docker group with the right GID. If the group is root, 
-# fall back on using socat to forward the docker socket to another unix socket so 
+# If enabled, try to update the docker group with the right GID. If the group is root,
+# fall back on using socat to forward the docker socket to another unix socket so
 # that we can set permissions on it without affecting the host.
 if [ "${ENABLE_NONROOT_DOCKER}" = "true" ] && [ "${SOURCE_SOCKET}" != "${TARGET_SOCKET}" ] && [ "${USERNAME}" != "root" ] && [ "${USERNAME}" != "0" ]; then
     SOCKET_GID=\$(stat -c '%g' ${SOURCE_SOCKET})
@@ -341,7 +341,7 @@ if [ "${ENABLE_NONROOT_DOCKER}" = "true" ] && [ "${SOURCE_SOCKET}" != "${TARGET_
     log "Success"
 fi
 
-# Execute whatever commands were passed in (if any). This allows us 
+# Execute whatever commands were passed in (if any). This allows us
 # to set this script to ENTRYPOINT while still executing the default CMD.
 set +e
 exec "\$@"

--- a/src/docker-outside-of-docker/install.sh
+++ b/src/docker-outside-of-docker/install.sh
@@ -285,6 +285,7 @@ usermod -aG docker "${USERNAME}"
 DOCKER_GID="$(grep -oP '^docker:x:\K[^:]+' /etc/group)"
 
 # If enabling non-root access and specified user is found, setup socat and add script
+chown -h "${USERNAME}":root "${SOURCE_SOCKET}"
 chown -h "${USERNAME}":root "${TARGET_SOCKET}"
 check_packages socat
 tee /usr/local/share/docker-init.sh > /dev/null \


### PR DESCRIPTION
This change will fix the permission problem of running the Docker command in the non-root mode. When the dood feature was executed as part of the devcontainer specifying the non-root mode and the non-root user, such as 'www' in the example below, only the target socket would get the 'www' owner, which is not sufficient since the docker.sock (target socket) is merely a symbolic link to docker-host.sock (source socket).

```
www@a73c2f1d2a7f:/var/www$ whoami
www

www@a73c2f1d2a7f:/var/www$ docker ps
Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.24/containers/json": dial unix /var/run/docker.sock: connect: permission denied

root@a73c2f1d2a7f:/var/run# ls -la
total 12
drwxr-xr-x 1 root root 4096 Jan 15 13:09 .
drwxr-xr-x 1 root root 4096 Jan 15 13:09 ..
srwxrwxr-x 1 root root    0 Jan 12 14:22 docker-host.sock
lrwxrwxrwx 1 www  root   25 Jan 15 13:09 docker.sock -> /var/run/docker-host.sock
drwxrwxrwt 2 root root 4096 Jan  9 01:00 lock
-rw-rw-r-- 1 root utmp    0 Jan  9 01:00 utmp
 ```