### PR TITLE
[common-utils] Fix nonempty .bashrc being restored

### DIFF
--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "common-utils",
-    "version": "2.0.7",
+    "version": "2.0.8",
     "name": "Common Utilities",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/common-utils",
     "description": "Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.",

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -393,7 +393,7 @@ fi
 possible_rc_files=( ".bashrc" ".profile" ".zshrc" )
 for rc_file in "${possible_rc_files[@]}"; do
     if [ -f "/etc/skel/${rc_file}" ]; then
-        if [ ! -e "${user_rc_path}/${rc_file}" ] || [ -s "${user_rc_path}/${rc_file}" ]; then
+        if [ ! -e "${user_rc_path}/${rc_file}" ] || [ ! -s "${user_rc_path}/${rc_file}" ]; then
             cp "/etc/skel/${rc_file}" "${user_rc_path}/${rc_file}"
             chown ${USERNAME}:${group_name} "${user_rc_path}/${rc_file}"
         fi


### PR DESCRIPTION
The user's dotfiles shall only be restored to their defaults if they do not exist or are empty. A missing negation caused the files to be overwritten even when they were nonempty.