### PR TITLE
PHP: Allow 'version:none'

### DIFF
--- a/src/php/devcontainer-feature.json
+++ b/src/php/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "php",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "name": "PHP",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/php",
     "options": {
@@ -10,7 +10,8 @@
                 "latest",
                 "8",
                 "8.2",
-                "8.2.0"
+                "8.2.0",
+                "none"
             ],
             "default": "latest",
             "description": "Select or enter a PHP version"

--- a/src/php/install.sh
+++ b/src/php/install.sh
@@ -126,9 +126,10 @@ addcomposer() {
     "${PHP_SRC}" -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
     HASH="$(wget -q -O - https://composer.github.io/installer.sig)"
     "${PHP_SRC}" -r "if (hash_file('sha384', 'composer-setup.php') === '$HASH') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-    "${PHP_SRC}" composer-setup.php
+    "${PHP_SRC}" composer-setup.php --install-dir="/usr/local/bin" --filename=composer
     "${PHP_SRC}" -r "unlink('composer-setup.php');"
 }
+
 install_php() {
     PHP_VERSION="$1"
     PHP_INSTALL_DIR="${PHP_DIR}/${PHP_VERSION}"

--- a/test/php/install_additional_php.sh
+++ b/test/php/install_additional_php.sh
@@ -9,5 +9,7 @@ check "php version 8.1.4 installed as default" php --version | grep 8.1.4
 check "php version 8.0.17 installed"   ls -l /usr/local/php | grep 8.0.17
 check "php version 8.0.3 installed"  ls -l /usr/local/php | grep 8.0.3
 
+check "composer-version" composer --version
+
 # Report result
 reportResults

--- a/test/php/install_only_composer.sh
+++ b/test/php/install_only_composer.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "composer-version" composer --version
+
+# Report result
+reportResults

--- a/test/php/install_php_8.sh
+++ b/test/php/install_php_8.sh
@@ -6,6 +6,7 @@ set -e
 source dev-container-features-test-lib
 
 check "php-version-8-is-installed" bash -c "php --version | grep '8.'"
+check "composer-version" composer --version
 
 # Report result
 reportResults

--- a/test/php/install_php_8_2.sh
+++ b/test/php/install_php_8_2.sh
@@ -6,6 +6,7 @@ set -e
 source dev-container-features-test-lib
 
 check "php-version-8.2-is-installed" bash -c "php --version | grep '8.2'"
+check "composer-version" composer --version
 
 # Report result
 reportResults

--- a/test/php/scenarios.json
+++ b/test/php/scenarios.json
@@ -23,5 +23,14 @@
                 "version": "8.2"
             }
         }
+    },
+    "install_only_composer": {
+        "image": "mcr.microsoft.com/devcontainers/php:latest",
+        "features": {
+            "php": {
+                "version": "none",
+                "installComposer": true
+            }
+        }
     }
 }

--- a/test/php/test.sh
+++ b/test/php/test.sh
@@ -7,7 +7,7 @@ source dev-container-features-test-lib
 
 check "PHP version" php --version
 check "Mbstring loaded" php -r "extension_loaded('mbstring') || throw new Error('Extension Mbstring is not loaded');"
-check "Composer version" composer --version
+check "composer-version" composer --version
 
 # Report result
 reportResults


### PR DESCRIPTION
I was looking forward to use the PHP Feature to (only) add composer to my dev container. However, it currently fails. Fixing that! 

```jsonc
"ghcr.io/devcontainers/features/php:1": {
        "version": "none",
        "installComposer": true
}
```