### PR TITLE
kubectl-helm-minikube: Allow none

### DIFF
--- a/src/kubectl-helm-minikube/devcontainer-feature.json
+++ b/src/kubectl-helm-minikube/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "kubectl-helm-minikube",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "name": "Kubectl, Helm, and Minikube",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/kubectl-helm-minikube",
     "description": "Installs latest version of kubectl, Helm, and optionally minikube. Auto-detects latest versions and installs needed dependencies.",
@@ -12,7 +12,8 @@
                 "none",
                 "1.23",
                 "1.22",
-                "1.21"
+                "1.21",
+                "none"
             ],
             "default": "latest",
             "description": "Select or enter a Kubernetes version to install"
@@ -20,7 +21,8 @@
         "helm": {
             "type": "string",
             "proposals": [
-                "latest"
+                "latest",
+                "none"
             ],
             "default": "latest",
             "description": "Select or enter a Helm version to install"
@@ -28,7 +30,8 @@
         "minikube": {
             "type": "string",
             "proposals": [
-                "latest"
+                "latest",
+                "none"
             ],
             "default": "latest",
             "description": "Select or enter a Minikube version to install"

--- a/src/kubectl-helm-minikube/install.sh
+++ b/src/kubectl-helm-minikube/install.sh
@@ -14,7 +14,7 @@ rm -rf /var/lib/apt/lists/*
 
 KUBECTL_VERSION="${VERSION:-"latest"}"
 HELM_VERSION="${HELM:-"latest"}"
-MINIKUBE_VERSION="${MINIKUBE:-"none"}" # latest is also valid
+MINIKUBE_VERSION="${MINIKUBE:-"latest"}" # latest is also valid
 
 KUBECTL_SHA256="${KUBECTL_SHA256:-"automatic"}"
 HELM_SHA256="${HELM_SHA256:-"automatic"}"
@@ -121,77 +121,83 @@ case $architecture in
     *) echo "(!) Architecture $architecture unsupported"; exit 1 ;;
 esac
 
-# Install the kubectl, verify checksum
-echo "Downloading kubectl..."
-if [ "${KUBECTL_VERSION}" = "latest" ] || [ "${KUBECTL_VERSION}" = "lts" ] || [ "${KUBECTL_VERSION}" = "current" ] || [ "${KUBECTL_VERSION}" = "stable" ]; then
-    KUBECTL_VERSION="$(curl -sSL https://dl.k8s.io/release/stable.txt)"
-else
-    find_version_from_git_tags KUBECTL_VERSION https://github.com/kubernetes/kubernetes
-fi
-if [ "${KUBECTL_VERSION::1}" != 'v' ]; then
-    KUBECTL_VERSION="v${KUBECTL_VERSION}"
-fi
-curl -sSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${architecture}/kubectl"
-chmod 0755 /usr/local/bin/kubectl
-if [ "$KUBECTL_SHA256" = "automatic" ]; then
-    KUBECTL_SHA256="$(curl -sSL "https://dl.k8s.io/${KUBECTL_VERSION}/bin/linux/${architecture}/kubectl.sha256")"
-fi
-([ "${KUBECTL_SHA256}" = "dev-mode" ] || (echo "${KUBECTL_SHA256} */usr/local/bin/kubectl" | sha256sum -c -))
-if ! type kubectl > /dev/null 2>&1; then
-    echo '(!) kubectl installation failed!'
-    exit 1
+if [ ${KUBECTL_VERSION} != "none" ]; then
+    # Install the kubectl, verify checksum
+    echo "Downloading kubectl..."
+    if [ "${KUBECTL_VERSION}" = "latest" ] || [ "${KUBECTL_VERSION}" = "lts" ] || [ "${KUBECTL_VERSION}" = "current" ] || [ "${KUBECTL_VERSION}" = "stable" ]; then
+        KUBECTL_VERSION="$(curl -sSL https://dl.k8s.io/release/stable.txt)"
+    else
+        find_version_from_git_tags KUBECTL_VERSION https://github.com/kubernetes/kubernetes
+    fi
+    if [ "${KUBECTL_VERSION::1}" != 'v' ]; then
+        KUBECTL_VERSION="v${KUBECTL_VERSION}"
+    fi
+    curl -sSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${architecture}/kubectl"
+    chmod 0755 /usr/local/bin/kubectl
+    if [ "$KUBECTL_SHA256" = "automatic" ]; then
+        KUBECTL_SHA256="$(curl -sSL "https://dl.k8s.io/${KUBECTL_VERSION}/bin/linux/${architecture}/kubectl.sha256")"
+    fi
+    ([ "${KUBECTL_SHA256}" = "dev-mode" ] || (echo "${KUBECTL_SHA256} */usr/local/bin/kubectl" | sha256sum -c -))
+    if ! type kubectl > /dev/null 2>&1; then
+        echo '(!) kubectl installation failed!'
+        exit 1
+    fi
+
+    # kubectl bash completion
+    kubectl completion bash > /etc/bash_completion.d/kubectl
+
+    # kubectl zsh completion
+    if [ -e "${USERHOME}}/.oh-my-zsh" ]; then
+        mkdir -p "${USERHOME}/.oh-my-zsh/completions"
+        kubectl completion zsh > "${USERHOME}/.oh-my-zsh/completions/_kubectl"
+        chown -R "${USERNAME}" "${USERHOME}/.oh-my-zsh"
+    fi
 fi
 
-# kubectl bash completion
-kubectl completion bash > /etc/bash_completion.d/kubectl
-
-# kubectl zsh completion
-if [ -e "${USERHOME}}/.oh-my-zsh" ]; then
-    mkdir -p "${USERHOME}/.oh-my-zsh/completions"
-    kubectl completion zsh > "${USERHOME}/.oh-my-zsh/completions/_kubectl"
-    chown -R "${USERNAME}" "${USERHOME}/.oh-my-zsh"
-fi
-
-# Install Helm, verify signature and checksum
-echo "Downloading Helm..."
-find_version_from_git_tags HELM_VERSION "https://github.com/helm/helm"
-if [ "${HELM_VERSION::1}" != 'v' ]; then
-    HELM_VERSION="v${HELM_VERSION}"
-fi
-mkdir -p /tmp/helm
-helm_filename="helm-${HELM_VERSION}-linux-${architecture}.tar.gz"
-tmp_helm_filename="/tmp/helm/${helm_filename}"
-curl -sSL "https://get.helm.sh/${helm_filename}" -o "${tmp_helm_filename}"
-curl -sSL "https://github.com/helm/helm/releases/download/${HELM_VERSION}/${helm_filename}.asc" -o "${tmp_helm_filename}.asc"
-export GNUPGHOME="/tmp/helm/gnupg"
-mkdir -p "${GNUPGHOME}"
-chmod 700 ${GNUPGHOME}
-curl -sSL "${HELM_GPG_KEYS_URI}" -o /tmp/helm/KEYS
-echo -e "disable-ipv6\n${GPG_KEY_SERVERS}" > ${GNUPGHOME}/dirmngr.conf
-gpg -q --import "/tmp/helm/KEYS"
-if ! gpg --verify "${tmp_helm_filename}.asc" > ${GNUPGHOME}/verify.log 2>&1; then
-    echo "Verification failed!"
-    cat /tmp/helm/gnupg/verify.log
-    exit 1
-fi
-if [ "${HELM_SHA256}" = "automatic" ]; then
-    curl -sSL "https://get.helm.sh/${helm_filename}.sha256" -o "${tmp_helm_filename}.sha256"
-    curl -sSL "https://github.com/helm/helm/releases/download/${HELM_VERSION}/${helm_filename}.sha256.asc" -o "${tmp_helm_filename}.sha256.asc"
-    if ! gpg --verify "${tmp_helm_filename}.sha256.asc" > /tmp/helm/gnupg/verify.log 2>&1; then
+if [ ${HELM_VERSION} != "none" ]; then
+    # Install Helm, verify signature and checksum
+    echo "Downloading Helm..."
+    find_version_from_git_tags HELM_VERSION "https://github.com/helm/helm"
+    if [ "${HELM_VERSION::1}" != 'v' ]; then
+        HELM_VERSION="v${HELM_VERSION}"
+    fi
+    mkdir -p /tmp/helm
+    helm_filename="helm-${HELM_VERSION}-linux-${architecture}.tar.gz"
+    tmp_helm_filename="/tmp/helm/${helm_filename}"
+    curl -sSL "https://get.helm.sh/${helm_filename}" -o "${tmp_helm_filename}"
+    curl -sSL "https://github.com/helm/helm/releases/download/${HELM_VERSION}/${helm_filename}.asc" -o "${tmp_helm_filename}.asc"
+    export GNUPGHOME="/tmp/helm/gnupg"
+    mkdir -p "${GNUPGHOME}"
+    chmod 700 ${GNUPGHOME}
+    curl -sSL "${HELM_GPG_KEYS_URI}" -o /tmp/helm/KEYS
+    echo -e "disable-ipv6\n${GPG_KEY_SERVERS}" > ${GNUPGHOME}/dirmngr.conf
+    gpg -q --import "/tmp/helm/KEYS"
+    if ! gpg --verify "${tmp_helm_filename}.asc" > ${GNUPGHOME}/verify.log 2>&1; then
         echo "Verification failed!"
         cat /tmp/helm/gnupg/verify.log
         exit 1
     fi
-    HELM_SHA256="$(cat "${tmp_helm_filename}.sha256")"
-fi
-([ "${HELM_SHA256}" = "dev-mode" ] || (echo "${HELM_SHA256} *${tmp_helm_filename}" | sha256sum -c -))
-tar xf "${tmp_helm_filename}" -C /tmp/helm
-mv -f "/tmp/helm/linux-${architecture}/helm" /usr/local/bin/
-chmod 0755 /usr/local/bin/helm
-rm -rf /tmp/helm
-if ! type helm > /dev/null 2>&1; then
-    echo '(!) Helm installation failed!'
-    exit 1
+
+    if [ "${HELM_SHA256}" = "automatic" ]; then
+        curl -sSL "https://get.helm.sh/${helm_filename}.sha256" -o "${tmp_helm_filename}.sha256"
+        curl -sSL "https://github.com/helm/helm/releases/download/${HELM_VERSION}/${helm_filename}.sha256.asc" -o "${tmp_helm_filename}.sha256.asc"
+        if ! gpg --verify "${tmp_helm_filename}.sha256.asc" > /tmp/helm/gnupg/verify.log 2>&1; then
+            echo "Verification failed!"
+            cat /tmp/helm/gnupg/verify.log
+            exit 1
+        fi
+        HELM_SHA256="$(cat "${tmp_helm_filename}.sha256")"
+    fi
+
+    ([ "${HELM_SHA256}" = "dev-mode" ] || (echo "${HELM_SHA256} *${tmp_helm_filename}" | sha256sum -c -))
+    tar xf "${tmp_helm_filename}" -C /tmp/helm
+    mv -f "/tmp/helm/linux-${architecture}/helm" /usr/local/bin/
+    chmod 0755 /usr/local/bin/helm
+    rm -rf /tmp/helm
+    if ! type helm > /dev/null 2>&1; then
+        echo '(!) Helm installation failed!'
+        exit 1
+    fi
 fi
 
 # Install Minikube, verify checksum

--- a/test/kubectl-helm-minikube/install_only_kubectl.sh
+++ b/test/kubectl-helm-minikube/install_only_kubectl.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+set +e
+    kubectl
+    exit_code=$?
+    check "kubectl-is-not-installed" bash -c "echo ${exit_code} | grep 127"
+
+    helm version
+    exit_code=$?
+    check "helm-is-not-installed" bash -c "echo ${exit_code} | grep 127"
+
+    minikube version
+    exit_code=$?
+    check "minikube is-not-installed" bash -c "echo ${exit_code} | grep 127"
+set -e
+
+# Report result
+reportResults

--- a/test/kubectl-helm-minikube/scenarios.json
+++ b/test/kubectl-helm-minikube/scenarios.json
@@ -1,0 +1,12 @@
+{
+    "install_only_kubectl": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "kubectl-helm-minikube": {
+                "version": "none",
+                "helm": "none",
+                "minikube": "none"
+            }
+        }
+    }
+}

--- a/test/kubectl-helm-minikube/test.sh
+++ b/test/kubectl-helm-minikube/test.sh
@@ -8,6 +8,7 @@ source dev-container-features-test-lib
 # Definition specific tests
 check "kube" kubectl
 check "helm" helm version
+check "minikune" minikube version
 
 # Report result
 reportResults


### PR DESCRIPTION
I was looking forward to use the kubectl-helm-minikube Feature to (only) add kubectl to my dev container. However, it currently fails. Fixing that!

```jsonc
"kubectl-helm-minikube": {
                "version": "none",
                "helm": "none",
                "minikube": "none"
            }
```