### PR TITLE
Add sentinel to terraform feature

### DIFF
--- a/src/terraform/README.md
+++ b/src/terraform/README.md
@@ -18,7 +18,6 @@ Installs the Terraform CLI and optionally TFLint and Terragrunt. Auto-detects la
 | version | Terraform version | string | latest |
 | tflint | Tflint version | string | latest |
 | terragrunt | Terragrunt version | string | latest |
-| installSentinel | Install sentinel, a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions. | boolean | false |
 | installTFsec | Install tfsec, a tool to spot potential misconfigurations for your terraform code | boolean | false |
 | installTerraformDocs | Install terraform-docs, a utility to generate documentation from Terraform modules | boolean | false |
 

--- a/src/terraform/README.md
+++ b/src/terraform/README.md
@@ -18,6 +18,7 @@ Installs the Terraform CLI and optionally TFLint and Terragrunt. Auto-detects la
 | version | Terraform version | string | latest |
 | tflint | Tflint version | string | latest |
 | terragrunt | Terragrunt version | string | latest |
+| installSentinel | Install sentinel, a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions. | boolean | false |
 | installTFsec | Install tfsec, a tool to spot potential misconfigurations for your terraform code | boolean | false |
 | installTerraformDocs | Install terraform-docs, a utility to generate documentation from Terraform modules | boolean | false |
 

--- a/src/terraform/devcontainer-feature.json
+++ b/src/terraform/devcontainer-feature.json
@@ -33,6 +33,11 @@
             "default": "latest",
             "description": "Terragrunt version"
         },
+        "installSentinel": {
+            "type": "boolean",
+            "default": false,
+            "description": "Install sentinel, a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions"
+        },
         "installTFsec": {
             "type": "boolean",
             "default": false,

--- a/src/terraform/devcontainer-feature.json
+++ b/src/terraform/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "terraform",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "name": "Terraform, tflint, and TFGrunt",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/terraform",
     "description": "Installs the Terraform CLI and optionally TFLint and Terragrunt. Auto-detects latest version and installs needed dependencies.",

--- a/src/terraform/devcontainer-feature.json
+++ b/src/terraform/devcontainer-feature.json
@@ -33,11 +33,6 @@
             "default": "latest",
             "description": "Terragrunt version"
         },
-        "installSentinel": {
-            "type": "boolean",
-            "default": false,
-            "description": "Install sentinel, a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions"
-        },
         "installTFsec": {
             "type": "boolean",
             "default": false,

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -235,7 +235,7 @@ if [ "${INSTALL_SENTINEL}" = "true" ]; then
         if [ "${SENTINEL_SHA256}" = "automatic" ]; then
             receive_gpg_keys TERRAFORM_GPG_KEY
             curl -sSL -o sentinel_checksums.txt ${sentinel_releases_url}/${SENTINEL_VERSION}/sentinel_${SENTINEL_VERSION}_SHA256SUMS
-            curl -sSL -o sentinel_checksums.txt.sig ${sentinel_releases_url}/${SENTINEL_VERSION}/sentinel_${SENTINEL_VERSION}_SHA256SUMS.sig
+            curl -sSL -o sentinel_checksums.txt.sig ${sentinel_releases_url}/${SENTINEL_VERSION}/sentinel_${SENTINEL_VERSION}_SHA256SUMS.${TERRAFORM_GPG_KEY}.sig
             gpg --verify sentinel_checksums.txt.sig sentinel_checksums.txt
             # Verify the SHASUM matches the archive
             shasum -a 256 --ignore-missing -c sentinel_checksums.txt

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -226,9 +226,9 @@ fi
 
 if [ "${INSTALL_SENTINEL}" = "true" ]; then
     SENTINEL_VERSION="latest"
-    find_sentinel_version_from_url SENTINEL_VERSION 'https://releases.hashicorp.com/sentinel'
-    sentinel_filename="sentinel_${SENTINEL_VERSION}_linux_${architecture}.zip"
     sentinel_releases_url='https://releases.hashicorp.com/sentinel'
+    find_sentinel_version_from_url SENTINEL_VERSION ${sentinel_releases_url}
+    sentinel_filename="sentinel_${SENTINEL_VERSION}_linux_${architecture}.zip"
     echo "(*) Downloading Sentinel... ${sentinel_filename}"
     curl -sSL -o /tmp/tf-downloads/${sentinel_filename} ${sentinel_releases_url}/${SENTINEL_VERSION}/${sentinel_filename}
     if [ "${SENTINEL_SHA256}" != "dev-mode" ]; then

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -15,12 +15,14 @@ rm -rf /var/lib/apt/lists/*
 TERRAFORM_VERSION="${VERSION:-"latest"}"
 TFLINT_VERSION="${TFLINT:-"latest"}"
 TERRAGRUNT_VERSION="${TERRAGRUNT:-"latest"}"
+INSTALL_SENTINEL=${INSTALLSENTINEL:-false}
 INSTALL_TFSEC=${INSTALLTFSEC:-false}
 INSTALL_TERRAFORM_DOCS=${INSTALLTERRAFORMDOCS:-false}
 
 TERRAFORM_SHA256="${TERRAFORM_SHA256:-"automatic"}"
 TFLINT_SHA256="${TFLINT_SHA256:-"automatic"}"
 TERRAGRUNT_SHA256="${TERRAGRUNT_SHA256:-"automatic"}"
+SENTINEL_SHA256="${SENTINEL_SHA256:-"automatic"}"
 TFSEC_SHA256="${TFSEC_SHA256:-"automatic"}"
 TERRAFORM_DOCS_SHA256="${TERRAFORM_DOCS_SHA256:-"automatic"}"
 
@@ -112,6 +114,30 @@ find_version_from_git_tags() {
     echo "${variable_name}=${!variable_name}"
 }
 
+find_sentinel_version_from_url() {
+    local variable_name=$1
+    local requested_version=${!variable_name}
+    if [ "${requested_version}" = "none" ]; then return; fi
+    local repository=$2
+    if [ "$(echo "${requested_version}" | grep -o "." | wc -l)" != "2" ]; then
+        local prefix='sentinel_'
+        local regex="${prefix}\d.\d{2}.\d(?:-\w*)?"
+        local version_list="$(wget -q $2 -O - | grep -oP ${regex} | tr -d ${prefix} | sort -rV)"
+        if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "current" ] || [ "${requested_version}" = "lts" ]; then
+            declare -g ${variable_name}="$(echo "${version_list}" | head -n 1)"
+        else
+            set +e
+            declare -g ${variable_name}="$(echo "${version_list}" | grep -E -m 1 "^${requested_version//./\\.}([\\.\\s]|$)")"
+            set -e
+        fi
+    fi
+    if [ -z "${!variable_name}" ] || ! echo "${version_list}" | grep "^${!variable_name//./\\.}$" >/dev/null 2>&1; then
+        echo -e "Invalid ${variable_name} value: ${requested_version}\nValid values:\n${version_list}" >&2
+        exit 1
+    fi
+    echo "${variable_name}=${!variable_name}"
+}
+
 apt_get_update()
 {
     if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
@@ -196,6 +222,31 @@ if [ "${TERRAGRUNT_VERSION}" != "none" ]; then
     fi
     chmod a+x /tmp/tf-downloads/${terragrunt_filename}
     mv -f /tmp/tf-downloads/${terragrunt_filename} /usr/local/bin/terragrunt
+fi
+
+if [ "${INSTALL_SENTINEL}" = "true" ]; then
+    SENTINEL_VERSION="latest"
+    find_sentinel_version_from_url SENTINEL_VERSION 'https://releases.hashicorp.com/sentinel'
+    sentinel_filename="sentinel_${SENTINEL_VERSION}_linux_${architecture}.zip"
+    sentinel_releases_url='https://releases.hashicorp.com/sentinel'
+    echo "(*) Downloading Sentinel... ${sentinel_filename}"
+    curl -sSL -o /tmp/tf-downloads/${sentinel_filename} ${sentinel_releases_url}/${SENTINEL_VERSION}/${sentinel_filename}
+    if [ "${SENTINEL_SHA256}" != "dev-mode" ]; then
+        if [ "${SENTINEL_SHA256}" = "automatic" ]; then
+            receive_gpg_keys TERRAFORM_GPG_KEY
+            curl -sSL -o sentinel_checksums.txt ${sentinel_releases_url}/${SENTINEL_VERSION}/sentinel_${SENTINEL_VERSION}_SHA256SUMS
+            curl -sSL -o sentinel_checksums.txt.sig ${sentinel_releases_url}/${SENTINEL_VERSION}/sentinel_${SENTINEL_VERSION}_SHA256SUMS.sig
+            gpg --verify sentinel_checksums.txt.sig sentinel_checksums.txt
+            # Verify the SHASUM matches the archive
+            shasum -a 256 --ignore-missing -c sentinel_checksums.txt
+        else
+            echo "${SENTINEL_SHA256} *${SENTINEL_FILENAME}" >sentinel_checksums.txt
+        fi
+        sha256sum --ignore-missing -c sentinel_checksums.txt
+    fi
+    unzip /tmp/tf-downloads/${sentinel_filename}
+    chmod a+x /tmp/tf-downloads/sentinel
+    mv -f /tmp/tf-downloads/sentinel /usr/local/bin/sentinel
 fi
 
 if [ "${INSTALL_TFSEC}" = "true" ]; then

--- a/test/terraform/install_sentinel.sh
+++ b/test/terraform/install_sentinel.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Import test library for `check` command
+source dev-container-features-test-lib
+
+# Check to make sure the user is vscode
+check "user is vscode" whoami | grep vscode
+
+# Sentinel specific tests
+check "sentinel" sentinel --version
+
+# Report result
+reportResults

--- a/test/terraform/scenarios.json
+++ b/test/terraform/scenarios.json
@@ -1,4 +1,12 @@
 {
+    "install_sentinel": {
+        "image": "mcr.microsoft.com/devcontainers/base:jammy",
+        "features": {
+            "terraform": {
+                "installSentinel": true
+            }
+        }
+    },
     "install_tfsec": {
         "image": "mcr.microsoft.com/devcontainers/base:jammy",
         "features": {


### PR DESCRIPTION
Hi.

Based on my feature request #437 I'd like to contribute with this PR to the potential installation of sentinel with the terraform feature.
The description was copied from the corresponding [documentation](https://docs.hashicorp.com/sentinel).
Unfortunately, Hashicorp doesn't release sentinel via GH hence the introduction of a separate function in the `install.sh` to resolve the version from the release URL.