### PR TITLE
Docker fix - BuildKit is enabled but the buildx component is missing or broken

### DIFF
--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "name": "Docker (Docker-in-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
     "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",
@@ -39,6 +39,11 @@
             "default": "",
             "proposals": [],
             "description": "Define default address pools for Docker networks. e.g. base=192.168.0.0/16,size=24"
+        },
+        "installDockerBuildx": {
+            "type": "boolean",
+            "default": true,
+            "description": "Install Docker Buildx"
         }
     },
     "entrypoint": "/usr/local/share/docker-init.sh",

--- a/src/docker-outside-of-docker/devcontainer-feature.json
+++ b/src/docker-outside-of-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-outside-of-docker",
-    "version": "1.0.10",
+    "version": "1.1.0",
     "name": "Docker (docker-outside-of-docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker",
     "description": "Re-use the host docker socket, adding the Docker CLI to a container. Feature invokes a script to enable using a forwarded Docker socket within a container to run Docker commands.",
@@ -28,6 +28,11 @@
             ],
             "default": "v1",
             "description": "Compose version to use for docker-compose (v1 or v2)"
+        },
+        "installDockerBuildx": {
+            "type": "boolean",
+            "default": true,
+            "description": "Install Docker Buildx"
         }
     },
     "entrypoint": "/usr/local/share/docker-init.sh",

--- a/src/docker-outside-of-docker/install.sh
+++ b/src/docker-outside-of-docker/install.sh
@@ -117,7 +117,7 @@ find_version_from_git_tags() {
 export DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
-check_packages apt-transport-https curl ca-certificates gnupg2 dirmngr
+check_packages apt-transport-https curl ca-certificates gnupg2 dirmngr wget
 if ! type git > /dev/null 2>&1; then
     check_packages git
 fi

--- a/test/docker-in-docker/Dockerfile
+++ b/test/docker-in-docker/Dockerfile
@@ -1,0 +1,1 @@
+FROM ubuntu:focal

--- a/test/docker-in-docker/docker_build.sh
+++ b/test/docker-in-docker/docker_build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "docker-buildx" docker buildx version
+check "docker-build" docker build ./
+
+# Report result
+reportResults

--- a/test/docker-in-docker/docker_build_2.sh
+++ b/test/docker-in-docker/docker_build_2.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "docker-buildx" docker buildx version
+check "docker-build" docker build ./
+
+# Report result
+reportResults

--- a/test/docker-in-docker/docker_build_older.sh
+++ b/test/docker-in-docker/docker_build_older.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "docker-buildx" docker buildx version
+check "docker-build" docker build ./
+
+# Report result
+reportResults

--- a/test/docker-in-docker/scenarios.json
+++ b/test/docker-in-docker/scenarios.json
@@ -25,5 +25,38 @@
                 "azureDnsAutoDetection": false
             }
         }
+    },
+    "docker_build": {
+        "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+        "features": {
+            "docker-in-docker": {
+                "version": "latest",
+                "moby": "false",
+                "dockerDashComposeVersion": "v2"
+            }
+        },
+        "remoteUser": "node"
+    },
+    "docker_build_2": {
+        "image": "ubuntu:focal",
+        "features": {
+            "docker-in-docker": {
+                "version": "latest",
+                "installDockerBuildx": true,
+                "moby": "false",
+                "dockerDashComposeVersion": "v2"
+            }
+        }
+    },
+    "docker_build_older": {
+        "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+        "features": {
+            "docker-in-docker": {
+                "version": "20",
+                "moby": "false",
+                "dockerDashComposeVersion": "v2"
+            }
+        },
+        "remoteUser": "node"
     }
 }

--- a/test/docker-outside-of-docker/Dockerfile
+++ b/test/docker-outside-of-docker/Dockerfile
@@ -1,0 +1,1 @@
+FROM ubuntu:jammy

--- a/test/docker-outside-of-docker/docker_build.sh
+++ b/test/docker-outside-of-docker/docker_build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "docker-buildx" docker buildx version
+check "docker-build" docker build ./
+
+# Report result
+reportResults

--- a/test/docker-outside-of-docker/docker_build_2.sh
+++ b/test/docker-outside-of-docker/docker_build_2.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "docker-buildx" docker buildx version
+check "docker-build" docker build ./
+
+# Report result
+reportResults

--- a/test/docker-outside-of-docker/docker_build_older.sh
+++ b/test/docker-outside-of-docker/docker_build_older.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "docker-buildx" docker buildx version
+check "docker-build" docker build ./
+
+# Report result
+reportResults

--- a/test/docker-outside-of-docker/scenarios.json
+++ b/test/docker-outside-of-docker/scenarios.json
@@ -30,7 +30,7 @@
             }
         }
     },
-    "docker-outside-of-docker": {
+    "docker_build_older": {
         "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
         "features": {
             "docker-outside-of-docker": {

--- a/test/docker-outside-of-docker/scenarios.json
+++ b/test/docker-outside-of-docker/scenarios.json
@@ -7,5 +7,38 @@
                 "version": "latest"
             }
         }
+    },
+    "docker_build": {
+        "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+        "features": {
+            "docker-outside-of-docker": {
+                "version": "latest",
+                "installDockerBuildx": true,
+                "moby": "false",
+                "dockerDashComposeVersion": "v2"
+            }
+        },
+        "remoteUser": "node"
+    },
+    "docker_build_2": {
+        "image": "ubuntu:focal",
+        "features": {
+            "docker-outside-of-docker": {
+                "version": "latest",
+                "moby": "false",
+                "dockerDashComposeVersion": "v2"
+            }
+        }
+    },
+    "docker-outside-of-docker": {
+        "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
+        "features": {
+            "docker-outside-of-docker": {
+                "version": "20",
+                "moby": "false",
+                "dockerDashComposeVersion": "v2"
+            }
+        },
+        "remoteUser": "node"
     }
 }


### PR DESCRIPTION
Fixes - https://github.com/devcontainers/features/issues/477

> DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/
            
More details - https://docs.docker.com/engine/deprecated/#legacy-builder-fallback