### PR TITLE
Remove duplicate env var sourcing for codespaces

### DIFF
--- a/src/sshd/devcontainer-feature.json
+++ b/src/sshd/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "sshd",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "name": "SSH server",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/sshd",
     "description": "Adds a SSH server into a container so that you can use an external terminal, sftp, or SSHFS to interact with it.",

--- a/src/sshd/install.sh
+++ b/src/sshd/install.sh
@@ -13,7 +13,6 @@ SSHD_PORT="${SSHD_PORT:-"2222"}"
 USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
 START_SSHD="${START_SSHD:-"false"}"
 NEW_PASSWORD="${NEW_PASSWORD:-"skip"}"
-FIX_ENVIRONMENT="${FIX_ENVIRONMENT:-"true"}"
 
 set -e
 


### PR DESCRIPTION
Codespaces already has the same mechanism built-in for sourcing secrets for login shells, from env-secrets file.
Removing the redundant and codespaces specific code from sshd feature.