### PR TITLE
Add pytest to Python Feature

### DIFF
--- a/src/python/devcontainer-feature.json
+++ b/src/python/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "python",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "name": "Python",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/python",
   "description": "Installs the provided version of Python, as well as PIPX, and other common Python utilities.  JupyterLab is conditionally installed with the python feature. Note: May require source code compilation.",

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -26,7 +26,7 @@ CONFIGURE_JUPYTERLAB_ALLOW_ORIGIN="${CONFIGUREJUPYTERLABALLOWORIGIN:-""}"
 # alongside PYTHON_VERSION, but not set as default.
 ADDITIONAL_VERSIONS="${ADDITIONALVERSIONS:-""}"
 
-DEFAULT_UTILS=("pylint" "flake8" "autopep8" "black" "yapf" "mypy" "pydocstyle" "pycodestyle" "bandit" "pipenv" "virtualenv")
+DEFAULT_UTILS=("pylint" "flake8" "autopep8" "black" "yapf" "mypy" "pydocstyle" "pycodestyle" "bandit" "pipenv" "virtualenv" "pytest")
 PYTHON_SOURCE_GPG_KEYS="64E628F8D684696D B26995E310250568 2D347EA6AA65421D FB9921286F5E1540 3A5CA953F73C700D 04C367C218ADD4FF 0EDDC5F26A45C816 6AF053F07D9DC8D2 C9BE28DEE6DF025C 126EB563A74B06BF D9866941EA5BBD71 ED9D77D5"
 GPG_KEY_SERVERS="keyserver hkp://keyserver.ubuntu.com
 keyserver hkps://keys.openpgp.org

--- a/test/python/install_additional_python.sh
+++ b/test/python/install_additional_python.sh
@@ -21,6 +21,7 @@ check "mypy" mypy --version
 check "pycodestyle" pycodestyle --version
 check "pydocstyle" pydocstyle --version
 check "pylint" pylint --version
+check "pytest" pytest --version
 
 # Check paths in settings
 check "current symlink is correct" bash -c "which python | grep /usr/local/python/current/bin/python"
@@ -34,6 +35,7 @@ check "which mypy" bash -c "which mypy | grep /usr/local/py-utils/bin/mypy"
 check "which pycodestyle" bash -c "which pycodestyle | grep /usr/local/py-utils/bin/pycodestyle"
 check "which pydocstyle" bash -c "which pydocstyle | grep /usr/local/py-utils/bin/pydocstyle"
 check "which pylint" bash -c "which pylint | grep /usr/local/py-utils/bin/pylint"
+check "which pytest" bash -c "which pytest | grep /usr/local/py-utils/bin/pytest"
 
 # Report result
 reportResults

--- a/test/python/install_os_provided_python.sh
+++ b/test/python/install_os_provided_python.sh
@@ -20,6 +20,7 @@ check "mypy" mypy --version
 check "pycodestyle" pycodestyle --version
 check "pydocstyle" pydocstyle --version
 check "pylint" pylint --version
+check "pytest" pytest --version
 
 # Check paths in settings
 check "current symlink is correct" bash -c "which python | grep /usr/local/python/current/bin/python"
@@ -33,6 +34,7 @@ check "which mypy" bash -c "which mypy | grep /usr/local/py-utils/bin/mypy"
 check "which pycodestyle" bash -c "which pycodestyle | grep /usr/local/py-utils/bin/pycodestyle"
 check "which pydocstyle" bash -c "which pydocstyle | grep /usr/local/py-utils/bin/pydocstyle"
 check "which pylint" bash -c "which pylint | grep /usr/local/py-utils/bin/pylint"
+check "which pytest" bash -c "which pytest | grep /usr/local/py-utils/bin/pytest"
 
 # Report result
 reportResults

--- a/test/python/install_via_oryx.sh
+++ b/test/python/install_via_oryx.sh
@@ -20,6 +20,7 @@ check "mypy" mypy --version
 check "pycodestyle" pycodestyle --version
 check "pydocstyle" pydocstyle --version
 check "pylint" pylint --version
+check "pytest" pytest --version
 
 # Check paths in settings
 check "current symlink is correct" bash -c "which python | grep /usr/local/python/current/bin/python"
@@ -33,6 +34,7 @@ check "which mypy" bash -c "which mypy | grep /usr/local/py-utils/bin/mypy"
 check "which pycodestyle" bash -c "which pycodestyle | grep /usr/local/py-utils/bin/pycodestyle"
 check "which pydocstyle" bash -c "which pydocstyle | grep /usr/local/py-utils/bin/pydocstyle"
 check "which pylint" bash -c "which pylint | grep /usr/local/py-utils/bin/pylint"
+check "which pytest" bash -c "which pytest | grep /usr/local/py-utils/bin/pytest"
 
 # Report result
 reportResults

--- a/test/python/test.sh
+++ b/test/python/test.sh
@@ -20,6 +20,7 @@ check "mypy" mypy --version
 check "pycodestyle" pycodestyle --version
 check "pydocstyle" pydocstyle --version
 check "pylint" pylint --version
+check "pytest" pytest --version
 
 # Check paths in settings
 check "current symlink is correct" bash -c "which python | grep /usr/local/python/current/bin/python"
@@ -33,6 +34,7 @@ check "which mypy" bash -c "which mypy | grep /usr/local/py-utils/bin/mypy"
 check "which pycodestyle" bash -c "which pycodestyle | grep /usr/local/py-utils/bin/pycodestyle"
 check "which pydocstyle" bash -c "which pydocstyle | grep /usr/local/py-utils/bin/pydocstyle"
 check "which pylint" bash -c "which pylint | grep /usr/local/py-utils/bin/pylint"
+check "which pytest" bash -c "which pytest | grep /usr/local/py-utils/bin/pytest"
 
 # Report result
 reportResults


### PR DESCRIPTION
The Python feature installs the Python Extension for VS Code, which enables testing functionality through `pytest`, but this package is not installed for the user.