### PR TITLE
Ruby: Fix failures - omit "ruby-debug-ide"

### DIFF
--- a/src/ruby/devcontainer-feature.json
+++ b/src/ruby/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "name": "Ruby (via rvm)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/ruby",
     "description": "Installs Ruby, rvm, rbenv, common Ruby utilities, and needed dependencies.",

--- a/src/ruby/install.sh
+++ b/src/ruby/install.sh
@@ -17,9 +17,16 @@ INSTALL_RUBY_TOOLS="${INSTALL_RUBY_TOOLS:-"true"}"
 # alongside RUBY_VERSION, but not set as default.
 ADDITIONAL_VERSIONS="${ADDITIONALVERSIONS:-""}"
 
+. /etc/os-release
+
 # Note: ruby-debug-ide will install the right version of debase if missing and
 # installing debase directly fails on Ruby 3.1.0 as of 1/7/2022, so omitting.
-DEFAULT_GEMS="rake ruby-debug-ide"
+# installing ruby-debug-ide on debian fails, so omitting.
+if [ "${ID}" = "debian" ]; then
+    DEFAULT_GEMS="rake"
+else
+    DEFAULT_GEMS="rake ruby-debug-ide"
+fi
 
 RVM_GPG_KEYS="409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"
 GPG_KEY_SERVERS="keyserver hkp://keyserver.ubuntu.com

--- a/src/ruby/install.sh
+++ b/src/ruby/install.sh
@@ -17,16 +17,10 @@ INSTALL_RUBY_TOOLS="${INSTALL_RUBY_TOOLS:-"true"}"
 # alongside RUBY_VERSION, but not set as default.
 ADDITIONAL_VERSIONS="${ADDITIONALVERSIONS:-""}"
 
-. /etc/os-release
-
 # Note: ruby-debug-ide will install the right version of debase if missing and
 # installing debase directly fails on Ruby 3.1.0 as of 1/7/2022, so omitting.
 # installing ruby-debug-ide on debian fails, so omitting.
-if [ "${ID}" = "debian" ]; then
-    DEFAULT_GEMS="rake"
-else
-    DEFAULT_GEMS="rake ruby-debug-ide"
-fi
+DEFAULT_GEMS="rake"
 
 RVM_GPG_KEYS="409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"
 GPG_KEY_SERVERS="keyserver hkp://keyserver.ubuntu.com

--- a/test/ruby/install_additional_ruby.sh
+++ b/test/ruby/install_additional_ruby.sh
@@ -10,7 +10,6 @@ check "ruby version 2.5.9 installed"  rvm list | grep 2.5.9
 check "ruby version 3.0.4 installed"  rvm list | grep 3.0.4
 
 check "rbenv" bash -c 'eval "$(rbenv init -)" && rbenv --version'
-check "ruby-debug-ide" bash -c "gem list | grep ruby-debug-ide"
 check "rake" bash -c "gem list | grep rake"
 
 # Report result

--- a/test/ruby/install_additional_ruby.sh
+++ b/test/ruby/install_additional_ruby.sh
@@ -10,6 +10,8 @@ check "ruby version 2.5.9 installed"  rvm list | grep 2.5.9
 check "ruby version 3.0.4 installed"  rvm list | grep 3.0.4
 
 check "rbenv" bash -c 'eval "$(rbenv init -)" && rbenv --version'
+check "ruby-debug-ide" bash -c "gem list | grep ruby-debug-ide"
+check "rake" bash -c "gem list | grep rake"
 
 # Report result
 reportResults

--- a/test/ruby/ruby_debian.sh
+++ b/test/ruby/ruby_debian.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "ruby" ruby -v
+check "rake" bash -c "gem list | grep rake"
+
+# Report result
+reportResults

--- a/test/ruby/scenarios.json
+++ b/test/ruby/scenarios.json
@@ -7,5 +7,11 @@
                 "additionalVersions": "2.5,3.0.4"
             }
         }
+    },
+    "ruby_debian": {
+        "image": "mcr.microsoft.com/devcontainers/base:bullseye",
+        "features": {
+            "ruby": {}
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/devcontainers/features/issues/496

Currently, installing the `ruby-debug-ide` gem on a `debian` image fails which is failing the installation of the `ruby` Feature. To avoid this failure due to a IDE debugger, omitting it's installation from the Feature.