### PR TITLE
add a postCreateCommand to `git-lfs` Feature

### DIFF
--- a/src/git-lfs/devcontainer-feature.json
+++ b/src/git-lfs/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "git-lfs",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "name": "Git Large File Support (LFS)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/git-lfs",
     "description": "Installs Git Large File Support (Git LFS) along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like git and curl.",
@@ -13,8 +13,14 @@
             ],
             "default": "latest",
             "description": "Select version of Git LFS to install"
+        },
+        "autoPull": {
+            "type": "boolean",
+            "default": true,
+            "description": "Automatically pull LFS files when creating the container. If false, manually running 'git lfs pull' will pull lfs files."
         }
     },
+    "postCreateCommand": "/tmp/pull-git-lfs-artifacts.sh",
     "installsAfter": [
         "ghcr.io/devcontainers/features/common-utils"
     ]

--- a/src/git-lfs/devcontainer-feature.json
+++ b/src/git-lfs/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "git-lfs",
-    "version": "1.0.8",
+    "version": "1.1.0",
     "name": "Git Large File Support (LFS)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/git-lfs",
     "description": "Installs Git Large File Support (Git LFS) along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like git and curl.",
@@ -17,7 +17,7 @@
         "autoPull": {
             "type": "boolean",
             "default": true,
-            "description": "Automatically pull LFS files when creating the container. If false, manually running 'git lfs pull' will pull lfs files."
+            "description": "Automatically pull LFS files when creating the container.  When false, running 'git lfs pull' in the container will have the same effect."
         }
     },
     "postCreateCommand": "/tmp/pull-git-lfs-artifacts.sh",

--- a/src/git-lfs/devcontainer-feature.json
+++ b/src/git-lfs/devcontainer-feature.json
@@ -20,7 +20,7 @@
             "description": "Automatically pull LFS files when creating the container.  When false, running 'git lfs pull' in the container will have the same effect."
         }
     },
-    "postCreateCommand": "/tmp/pull-git-lfs-artifacts.sh",
+    "postCreateCommand": "/usr/local/share/pull-git-lfs-artifacts.sh",
     "installsAfter": [
         "ghcr.io/devcontainers/features/common-utils"
     ]

--- a/src/git-lfs/install.sh
+++ b/src/git-lfs/install.sh
@@ -187,15 +187,16 @@ if [ "${use_github}" = "true" ]; then
 fi
 
 # --- Generate a 'pull-git-lfs-artifacts.sh' script to be executed by the 'postCreateCommand' lifecycle hook
+PULL_GIT_LFS_SCRIPT_PATH="/usr/local/share/pull-git-lfs-artifacts.sh"
 
-tee /tmp/pull-git-lfs-artifacts.sh > /dev/null \
+tee "$PULL_GIT_LFS_SCRIPT_PATH" > /dev/null \
 << EOF
 #!/bin/sh
 set -e
 AUTO_PULL=${AUTO_PULL}
 EOF
 
-tee -a /tmp/pull-git-lfs-artifacts.sh > /dev/null \
+tee -a "$PULL_GIT_LFS_SCRIPT_PATH" > /dev/null \
 << 'EOF'
 
 echo "Fetching git lfs artifacts..."
@@ -214,7 +215,7 @@ fi
 git lfs pull
 EOF
 
-chmod 755 /tmp/pull-git-lfs-artifacts.sh
+chmod 755 "$PULL_GIT_LFS_SCRIPT_PATH"
 
 # Clean up
 rm -rf /var/lib/apt/lists/*

--- a/src/git-lfs/install.sh
+++ b/src/git-lfs/install.sh
@@ -8,6 +8,7 @@
 # Maintainer: The VS Code and Codespaces Teams
 
 GIT_LFS_VERSION=${VERSION:-"latest"}
+AUTO_PULL=${AUTOPULL:="true"}
 
 GIT_LFS_ARCHIVE_GPG_KEY_URI="https://packagecloud.io/github/git-lfs/gpgkey"
 GIT_LFS_ARCHIVE_ARCHITECTURES="amd64 arm64"
@@ -184,6 +185,36 @@ fi
 if [ "${use_github}" = "true" ]; then
     install_using_github
 fi
+
+# --- Generate a 'pull-git-lfs-artifacts.sh' script to be executed by the 'postCreateCommand' lifecycle hook
+
+tee /tmp/pull-git-lfs-artifacts.sh > /dev/null \
+<< EOF
+#!/bin/sh
+set -e
+AUTO_PULL=${AUTO_PULL}
+EOF
+
+tee -a /tmp/pull-git-lfs-artifacts.sh > /dev/null \
+<< 'EOF'
+
+echo "Fetching git lfs artifacts..."
+
+if [ "${AUTO_PULL}" != "true" ]; then
+    echo "(!) Skipping 'git lfs pull' because 'autoPull' is not set to 'true'"
+    exit 0
+fi
+
+# Check if repo is a git lfs repo.
+if ! git lfs ls-files > /dev/null 2>&1; then
+    echo "(!) Skipping automatic 'git lfs pull' because no git lfs files were detected"
+    exit 0
+fi
+
+git lfs pull
+EOF
+
+chmod 755 /tmp/pull-git-lfs-artifacts.sh
 
 # Clean up
 rm -rf /var/lib/apt/lists/*

--- a/test/git-lfs/autoPullDisabled.sh
+++ b/test/git-lfs/autoPullDisabled.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "lfs file has not been expanded" cat "big-file-1.txt" | grep "git-lfs\.github\.com"
+
+reportResults

--- a/test/git-lfs/autoPullDisabled.sh
+++ b/test/git-lfs/autoPullDisabled.sh
@@ -6,6 +6,6 @@ set -e
 source dev-container-features-test-lib
 
 check "target file exists" cat big-file-1.txt
-check "lfs file has not been expanded" cat "big-file-1.txt" | grep -v "this is test file 1"  # Inverted grep
+check "lfs file has not been expanded" cat "big-file-1.txt" | grep "git-lfs\.github\.com"
 
 reportResults

--- a/test/git-lfs/autoPullDisabled.sh
+++ b/test/git-lfs/autoPullDisabled.sh
@@ -5,6 +5,7 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
-check "lfs file has not been expanded" cat "big-file-1.txt" | grep "git-lfs\.github\.com"
+check "target file exists" cat big-file-1.txt
+check "lfs file has not been expanded" cat "big-file-1.txt" | grep -v "this is test file 1"  # Inverted grep
 
 reportResults

--- a/test/git-lfs/autoPullEnabled.sh
+++ b/test/git-lfs/autoPullEnabled.sh
@@ -5,6 +5,7 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
+check "target file exists" cat big-file-1.txt
 check "lfs file has been expanded" cat "big-file-1.txt" | grep "this is test file 1"
 
 reportResults

--- a/test/git-lfs/autoPullEnabled.sh
+++ b/test/git-lfs/autoPullEnabled.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "lfs file has been expanded" cat "big-file-1.txt" | grep "this is test file 1"
+
+reportResults

--- a/test/git-lfs/scenarios.json
+++ b/test/git-lfs/scenarios.json
@@ -5,7 +5,7 @@
         "remoteUser": "vscode",
         "features": {
             "git-lfs": {
-                "autoPull": "true"
+                "autoPull": true
             }
         }
     },
@@ -15,7 +15,7 @@
         "remoteUser": "vscode",
         "features": {
             "git-lfs": {
-                "autoPull": "false"
+                "autoPull": false
             }
         }
     }

--- a/test/git-lfs/scenarios.json
+++ b/test/git-lfs/scenarios.json
@@ -1,7 +1,7 @@
 {
     "autoPullEnabled": {
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-        "initializeCommand": "(git clone https://github.com/codspace/git-lfs-example /tmp/testRepo || true) && (cp -r /tmp/testRepo/.git* . && cp -r /tmp/testRepo/* .)",
+        "initializeCommand": "(git clone https://github.com/codspace/git-lfs-example /tmp/testRepo-1 || true) && (cp -r /tmp/testRepo-1/.git* . && cp -r /tmp/testRepo-1/* .)",
         "features": {
             "git-lfs": {
                 "autoPull": "true"
@@ -10,7 +10,7 @@
     },
     "autoPullDisabled": {
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-        "initializeCommand": "(git clone https://github.com/codspace/git-lfs-example /tmp/testRepo || true) && (cp -r /tmp/testRepo/.git* . && cp -r /tmp/testRepo/* .)",
+        "initializeCommand": "(git clone https://github.com/codspace/git-lfs-example /tmp/testRepo-2 || true) && (cp -r /tmp/testRepo-2/.git* . && cp -r /tmp/testRepo-2/* .)",
         "features": {
             "git-lfs": {
                 "autoPull": "false"

--- a/test/git-lfs/scenarios.json
+++ b/test/git-lfs/scenarios.json
@@ -1,0 +1,20 @@
+{
+    "autoPullEnabled": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "initializeCommand": "(git clone https://github.com/codspace/git-lfs-example /tmp/testRepo || true) && (cp -r /tmp/testRepo/.git* . && cp -r /tmp/testRepo/* .)",
+        "features": {
+            "git-lfs": {
+                "autoPull": "true"
+            }
+        }
+    },
+    "autoPullDisabled": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "initializeCommand": "(git clone https://github.com/codspace/git-lfs-example /tmp/testRepo || true) && (cp -r /tmp/testRepo/.git* . && cp -r /tmp/testRepo/* .)",
+        "features": {
+            "git-lfs": {
+                "autoPull": "false"
+            }
+        }
+    }
+}

--- a/test/git-lfs/scenarios.json
+++ b/test/git-lfs/scenarios.json
@@ -1,7 +1,8 @@
 {
     "autoPullEnabled": {
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-        "initializeCommand": "(git clone https://github.com/codspace/git-lfs-example /tmp/testRepo-1 || true) && (cp -r /tmp/testRepo-1/.git* . && cp -r /tmp/testRepo-1/* .)",
+        "initializeCommand": "(GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/codspace/git-lfs-example /tmp/testRepo-1 || true) && (cp -r /tmp/testRepo-1/.git* . && cp -r /tmp/testRepo-1/* .)",
+        "remoteUser": "vscode",
         "features": {
             "git-lfs": {
                 "autoPull": "true"
@@ -10,7 +11,8 @@
     },
     "autoPullDisabled": {
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-        "initializeCommand": "(git clone https://github.com/codspace/git-lfs-example /tmp/testRepo-2 || true) && (cp -r /tmp/testRepo-2/.git* . && cp -r /tmp/testRepo-2/* .)",
+        "initializeCommand": "(GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/codspace/git-lfs-example /tmp/testRepo-2 || true) && (cp -r /tmp/testRepo-2/.git* . && cp -r /tmp/testRepo-2/* .)",
+        "remoteUser": "vscode",
         "features": {
             "git-lfs": {
                 "autoPull": "false"

--- a/test/git-lfs/scenarios.json
+++ b/test/git-lfs/scenarios.json
@@ -1,7 +1,7 @@
 {
     "autoPullEnabled": {
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-        "initializeCommand": "(GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/codspace/git-lfs-example /tmp/testRepo-1 || true) && (cp -r /tmp/testRepo-1/.git* . && cp -r /tmp/testRepo-1/* .)",
+        "initializeCommand": "(GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/devcontainers/git-lfs-example /tmp/testRepo-1 || true) && (cp -r /tmp/testRepo-1/.git* . && cp -r /tmp/testRepo-1/* .)",
         "remoteUser": "vscode",
         "features": {
             "git-lfs": {
@@ -11,7 +11,7 @@
     },
     "autoPullDisabled": {
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-        "initializeCommand": "(GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/codspace/git-lfs-example /tmp/testRepo-2 || true) && (cp -r /tmp/testRepo-2/.git* . && cp -r /tmp/testRepo-2/* .)",
+        "initializeCommand": "(GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/devcontainers/git-lfs-example /tmp/testRepo-2 || true) && (cp -r /tmp/testRepo-2/.git* . && cp -r /tmp/testRepo-2/* .)",
         "remoteUser": "vscode",
         "features": {
             "git-lfs": {


### PR DESCRIPTION
The postCreateCommand will trigger `git lfs pull` if lfs artifacts are detected in the repository.  

This is particularly useful for GitHub Codespaces, where the repo clone is performed before installing git-lfs.