### PR TITLE
Removing forced gid 999 for docker

### DIFF
--- a/src/docker-outside-of-docker/install.sh
+++ b/src/docker-outside-of-docker/install.sh
@@ -261,11 +261,13 @@ if ! grep -qE '^docker:' /etc/group; then
     groupadd --system docker
 fi
 
+# Remarking this out to restore functionality in Azure VMs.  ID 999 is a reserved group ID
 # Ensure docker group gid is 999
-if [ "$(getent group docker | cut -d: -f3)" != "999" ]; then
-    echo "(*) Updating docker group gid to 999..."
-    groupmod -g 999 docker
-fi
+# if [ "$(getent group docker | cut -d: -f3)" != "999" ]; then
+#     echo "(*) Updating docker group gid to 999..."
+#     groupmod -g 999 docker
+# fi
+
 
 usermod -aG docker "${USERNAME}"
 


### PR DESCRIPTION
The group GID of 999 is a reserved ID on Azure VMs.  This PR removes the forced check for 999 and allows the rest of the feature to finish activating.


Log of file before this change:
```bash
[2023-04-05T18:53:18.249Z] 
#0 7.617 (*) Installing compose-switch as docker-compose...
#0 7.782 compose_switch_version=1.0.5
#0 7.949 (*) Updating docker group gid to 999...
#0 7.950 groupmod: GID '999' already exists
#0 7.951 ERROR: Feature "Docker (docker-outside-of-docker)" (ghcr.io/devcontainers/features/docker-outside-of-docker) failed to install! Look at the documentation at https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker for help troubleshooting this error.
------
[2023-04-05T18:53:18.249Z] failed to solve: process "/bin/sh -c chmod -R 0700 /tmp/build-features/docker-outside-of-docker_1 && cd /tmp/build-features/docker-outside-of-docker_1 && chmod +x ./devcontainer-features-install.sh && ./devcontainer-features-install.sh" did not complete successfully: exit code: 4

```