### PR TITLE
[features/conda] Address CVE-2023-0286, CVE-2023-23931, and CVE-2022-40897 vulnerabilities

### DIFF
--- a/src/conda/devcontainer-feature.json
+++ b/src/conda/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "conda",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "name": "Conda",
     "description": "A cross-platform, language-agnostic binary package manager",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/conda",

--- a/src/conda/install.sh
+++ b/src/conda/install.sh
@@ -114,8 +114,13 @@ if ! conda --version &> /dev/null ; then
     
     find "${CONDA_DIR}" -type d -print0 | xargs -n 1 -0 chmod g+s
 
-    # Temporary due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23491
+    # Temporary fixes
+    # Due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23491
     install_user_package certifi
+    # Due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0286 and https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-23931
+    install_user_package cryptography
+    # Due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
+    install_user_package setuptools
 fi
 
 # Display a notice on conda when not running in GitHub Codespaces

--- a/test/conda/test.sh
+++ b/test/conda/test.sh
@@ -32,5 +32,11 @@ check-version-ge() {
 certifiVersion=$(python -c "import certifi; print(certifi.__version__)")
 check-version-ge "certifi" "${certifiVersion}" "2022.12.07"
 
+cryptographyVersion=$(python -c "import cryptography; print(cryptography.__version__)")
+check-version-ge "cryptography" "${cryptographyVersion}" "39.0.1"
+
+setuptoolsVersion=$(python -c "import setuptools; print(setuptools.__version__)")
+check-version-ge "setuptools" "${setuptoolsVersion}" "65.5.1"
+
 # Report result
 reportResults


### PR DESCRIPTION
**Feature name**:

- ghcr.io/devcontainers/features/conda

**Description**:

This PR addresses the following vulnerabilities: 
- CVE-2023-0286, CVE-2023-23931 - related to `cryptography` package;
- CVE-2022-40897 - related to `setuptools` package;

These vulnerabilities come from the conda v4.12.0 distribution.

_Changelog_:

- Update `install.sh` to install updates for `cryptography` and `setuptools` packages;

- Add tests to verify `cryptography` and `setuptools` packages version:
  - `cryptography`: _minimum package version set to `39.0.1` which fixes CVE-2023-0286, CVE-2023-23931_;
  - `setuptools`: _minimum package version set to `65.5.1` which fixes CVE-2022-40897_

**Checklist**:

- [x] Checked that applied changes work as expected
