### PR TITLE
Speeds up Node Feature: Remove unnecessary "chmod" command

### DIFF
--- a/src/node/devcontainer-feature.json
+++ b/src/node/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "node",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "name": "Node.js (via nvm), yarn and pnpm",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/node",
     "description": "Installs Node.js, nvm, yarn, pnpm, and needed dependencies.",

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -221,10 +221,4 @@ fi
 su ${USERNAME} -c "umask 0002 && . $NVM_DIR/nvm.sh && nvm clear-cache"
 rm -rf /var/lib/apt/lists/*
 
-# Ensure privs are correct for installed node versions. Unfortunately the
-# way nvm installs node versions pulls privs from the tar which does not
-# have group write set. We need this when the gid/uid is updated.
-mkdir -p "${NVM_DIR}/versions"
-chmod -R g+rw "${NVM_DIR}/versions"
-
 echo "Done!"


### PR DESCRIPTION
`chmod`ing the `$NVM_DIR/versions` folder takes a lot of time depending upon the size of this folder.
We already change the permissions of `NVM_DIR` in [here](https://github.com/devcontainers/features/blob/main/src/node/install.sh#L154). Hence, removing duplicates! 

Tested with the following scenario 👇 

```jsonc
"image": "mcr.microsoft.com/devcontainers/universal",
        "remoteUser": "codespace",
        "features": {
            "node": {
                "version": "16"
            }
        }
```

Left : Before the PR changes - Node Feature took 138.4s
Right: Post the PR changes - Node Feature took 5.6s 

Removing the duplicate `chmod` did not make a difference to the permissions of the `version` folder.

![image](https://user-images.githubusercontent.com/24955913/230678229-73ac664e-045b-4ccc-a7a8-939c4d9a40de.png)
