### PR TITLE
Adds httpProxy option to Python Feature

### DIFF
--- a/src/python/devcontainer-feature.json
+++ b/src/python/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "python",
-  "version": "1.0.23",
+  "version": "1.1.0",
   "name": "Python",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/python",
   "description": "Installs the provided version of Python, as well as PIPX, and other common Python utilities.  JupyterLab is conditionally installed with the python feature. Note: May require source code compilation.",

--- a/src/python/devcontainer-feature.json
+++ b/src/python/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "python",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "name": "Python",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/python",
   "description": "Installs the provided version of Python, as well as PIPX, and other common Python utilities.  JupyterLab is conditionally installed with the python feature. Note: May require source code compilation.",
@@ -45,6 +45,11 @@
       "type": "string",
       "default": "",
       "description": "Configure JupyterLab to accept HTTP requests from the specified origin"
+    },
+    "httpProxy": {
+      "type": "string",
+      "default": "",
+      "description": "Connect to GPG keyservers using a proxy for fetching source code signatures by configuring this option"
     }
   },
   "containerEnv": {

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -87,7 +87,7 @@ receive_gpg_keys() {
         keyring_args="--no-default-keyring --keyring $2"
     fi
     if [ ! -z "${KEYSERVER_PROXY}" ]; then
-	    keyring_args="${keyring_args} --keyserver-options http-proxy=${KEYSERVER_PROXY}"
+        keyring_args="${keyring_args} --keyserver-options http-proxy=${KEYSERVER_PROXY}"
     fi
 
     # Use a temporary location for gpg keys to avoid polluting image

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -32,6 +32,8 @@ GPG_KEY_SERVERS="keyserver hkp://keyserver.ubuntu.com
 keyserver hkps://keys.openpgp.org
 keyserver hkp://keyserver.pgp.com"
 
+KEYSERVER_PROXY="${HTTPPROXY:-"${HTTP_PROXY:-""}"}"
+
 set -e
 
 # Clean up
@@ -83,6 +85,9 @@ receive_gpg_keys() {
     if [ ! -z "$2" ]; then
         mkdir -p "$(dirname \"$2\")"
         keyring_args="--no-default-keyring --keyring $2"
+    fi
+    if [ ! -z "${KEYSERVER_PROXY}" ]; then
+	    keyring_args="${keyring_args} --keyserver-options http-proxy=${KEYSERVER_PROXY}"
     fi
 
     # Use a temporary location for gpg keys to avoid polluting image


### PR DESCRIPTION
This option allows GPG to use a HTTP proxy to fetch keys from remote keyservers
fixes #530
As discussed in the issue this only sets the proxy variable for GPG rather than the full feature script