### PR TITLE
Fix: common-utils configureZshAsDefaultShell option not working on alpine linux image

### DIFF
--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "common-utils",
-    "version": "2.0.10",
+    "version": "2.0.11",
     "name": "Common Utilities",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/common-utils",
     "description": "Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.",

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -439,7 +439,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     if [ "${CONFIGURE_ZSH_AS_DEFAULT_SHELL}" == "true" ]; then
         # Fixing chsh always asking for a password on alpine linux
         # ref: https://askubuntu.com/questions/812420/chsh-always-asking-a-password-and-get-pam-authentication-failure.
-        if [ -f "/etc/pam.d/chsh" ] && grep -Eq "^auth(.*)pam_rootok\.so$" /etc/pam.d/chsh; then
+        if [ -f "/etc/pam.d/chsh" ] && grep -vEq "^auth[[:blank:]]+sufficient[[:blank:]]+pam_rootok\.so$"; then
             awk '/^auth(.*)pam_rootok\.so$/ { $2 = "sufficient" } { print }' /etc/pam.d/chsh > /tmp/chsh.tmp && mv /tmp/chsh.tmp /etc/pam.d/chsh
         else
             echo "auth sufficient pam_rootok.so" > /etc/pam.d/chsh

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -439,7 +439,11 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     if [ "${CONFIGURE_ZSH_AS_DEFAULT_SHELL}" == "true" ]; then
         # Fixing chsh always asking for a password on alpine linux
         # ref: https://askubuntu.com/questions/812420/chsh-always-asking-a-password-and-get-pam-authentication-failure.
-        echo "auth sufficient pam_shells.so" > /etc/pam.d/chsh
+        if [ -f "/etc/pam.d/chsh" ] && grep -Eq "^auth(.*)pam_rootok\.so$" /etc/pam.d/chsh; then
+            awk '/^auth(.*)pam_rootok\.so$/ { $2 = "sufficient" } { print }' /etc/pam.d/chsh > /tmp/chsh.tmp && mv /tmp/chsh.tmp /etc/pam.d/chsh
+        else
+            echo "auth sufficient pam_rootok.so" > /etc/pam.d/chsh
+        fi
 
         chsh --shell /bin/zsh ${USERNAME}
     fi

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -439,7 +439,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     if [ "${CONFIGURE_ZSH_AS_DEFAULT_SHELL}" == "true" ]; then
         # Fixing chsh always asking for a password on alpine linux
         # ref: https://askubuntu.com/questions/812420/chsh-always-asking-a-password-and-get-pam-authentication-failure.
-        if [ -f "/etc/pam.d/chsh" ] && grep -vEq "^auth[[:blank:]]+sufficient[[:blank:]]+pam_rootok\.so$"; then
+        if [ -f "/etc/pam.d/chsh" ] && grep -vEq "^auth[[:blank:]]+sufficient[[:blank:]]+pam_rootok\.so$" /etc/pam.d/chsh; then
             awk '/^auth(.*)pam_rootok\.so$/ { $2 = "sufficient" } { print }' /etc/pam.d/chsh > /tmp/chsh.tmp && mv /tmp/chsh.tmp /etc/pam.d/chsh
         else
             echo "auth sufficient pam_rootok.so" >> /etc/pam.d/chsh

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -439,10 +439,10 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     if [ "${CONFIGURE_ZSH_AS_DEFAULT_SHELL}" == "true" ]; then
         # Fixing chsh always asking for a password on alpine linux
         # ref: https://askubuntu.com/questions/812420/chsh-always-asking-a-password-and-get-pam-authentication-failure.
-        if [ -f "/etc/pam.d/chsh" ] && grep -vEq "^auth[[:blank:]]+sufficient[[:blank:]]+pam_rootok\.so$" /etc/pam.d/chsh; then
-            awk '/^auth(.*)pam_rootok\.so$/ { $2 = "sufficient" } { print }' /etc/pam.d/chsh > /tmp/chsh.tmp && mv /tmp/chsh.tmp /etc/pam.d/chsh
-        else
+        if [ ! -f "/etc/pam.d/chsh" ] || ! grep -Eq '^auth(.*)pam_rootok\.so$' /etc/pam.d/chsh; then
             echo "auth sufficient pam_rootok.so" >> /etc/pam.d/chsh
+        elif [[ -n "$(awk '/^auth(.*)pam_rootok\.so$/ && !/^auth[[:blank:]]+sufficient[[:blank:]]+pam_rootok\.so$/' /etc/pam.d/chsh)" ]]; then
+            awk '/^auth(.*)pam_rootok\.so$/ { $2 = "sufficient" } { print }' /etc/pam.d/chsh > /tmp/chsh.tmp && mv /tmp/chsh.tmp /etc/pam.d/chsh
         fi
 
         chsh --shell /bin/zsh ${USERNAME}

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -442,7 +442,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
         if [ -f "/etc/pam.d/chsh" ] && grep -vEq "^auth[[:blank:]]+sufficient[[:blank:]]+pam_rootok\.so$"; then
             awk '/^auth(.*)pam_rootok\.so$/ { $2 = "sufficient" } { print }' /etc/pam.d/chsh > /tmp/chsh.tmp && mv /tmp/chsh.tmp /etc/pam.d/chsh
         else
-            echo "auth sufficient pam_rootok.so" > /etc/pam.d/chsh
+            echo "auth sufficient pam_rootok.so" >> /etc/pam.d/chsh
         fi
 
         chsh --shell /bin/zsh ${USERNAME}

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -437,6 +437,10 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     if [ "${CONFIGURE_ZSH_AS_DEFAULT_SHELL}" == "true" ]; then
+        # Fixing chsh always asking for a password on alpine linux
+        # ref: https://askubuntu.com/questions/812420/chsh-always-asking-a-password-and-get-pam-authentication-failure.
+        echo "auth sufficient pam_shells.so" > /etc/pam.d/chsh
+
         chsh --shell /bin/zsh ${USERNAME}
     fi
 

--- a/test/common-utils/alpine-base-zsh-default.sh
+++ b/test/common-utils/alpine-base-zsh-default.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "alpine default shell zsh" \
+  bash -c "getent passwd $(whoami) | awk -F : '{ print $7 }' | grep '/bin/zsh'"
+
+# Report result
+reportResults

--- a/test/common-utils/scenarios.json
+++ b/test/common-utils/scenarios.json
@@ -143,6 +143,7 @@
         "build": {
             "dockerfile": "Dockerfile"
         },
+        "remoteUser": "vscode",
         "features": {
             "common-utils": {
                 "username": "vscode",
@@ -151,7 +152,15 @@
                 "upgradePackages": true,
                 "installZsh": true
             }
-        },
-        "remoteUser": "vscode"
+        }
+    },
+    "alpine-base-zsh-default": {
+        "image": "mcr.microsoft.com/devcontainers/base:alpine",
+        "remoteUser": "vscode",
+        "features": {
+            "common-utils": {
+                "configureZshAsDefaultShell": true
+            }
+        }
     }
 }


### PR DESCRIPTION
Hi, I was trying to set up a [devcontainer for my side-project](https://github.com/krikchaip/docker-kubernetes-course/blob/main/.devcontainer/devcontainer.json) using the base alpine image with `common-utils` feature. I knew that the image already included the feature, but I also wanted to set the default shell to `zsh`. According to [the documentation](https://github.com/devcontainers/features/tree/main/src/common-utils), I had to pass `"configureZshAsDefaultShell": "true"`, but it didn't seem to be working for me.

While reading error logs, I found that the problem came from `chsh` command, which was always asking for a password.

https://github.com/devcontainers/features/blob/main/src/common-utils/main.sh#LL439C9-L441C7
```bash
if [ "${CONFIGURE_ZSH_AS_DEFAULT_SHELL}" == "true" ]; then
    chsh --shell /bin/zsh ${USERNAME}

    # PASSWORD:
    # error -> chsh: PAM: Authentication failure
fi
```

After doing some research, I found [the solution](https://askubuntu.com/questions/812420/chsh-always-asking-a-password-and-get-pam-authentication-failure). Basically, You need to modify the content in some file as shown on my PR.

`/etc/pam.d/chsh`
```bash
auth sufficient pam_shells.so
```