### PR TITLE
update go tools

### DIFF
--- a/src/go/install.sh
+++ b/src/go/install.sh
@@ -191,7 +191,7 @@ else
 fi
 
 # Install Go tools that are isImportant && !replacedByGopls based on
-# https://github.com/golang/vscode-go/blob/v0.31.1/src/goToolsInformation.ts
+# https://github.com/golang/vscode-go/blob/v0.38.0/src/goToolsInformation.ts
 GO_TOOLS="\
     golang.org/x/tools/gopls@latest \
     honnef.co/go/tools/cmd/staticcheck@latest \

--- a/src/go/install.sh
+++ b/src/go/install.sh
@@ -197,9 +197,12 @@ GO_TOOLS="\
     honnef.co/go/tools/cmd/staticcheck@latest \
     golang.org/x/lint/golint@latest \
     github.com/mgechev/revive@latest \
-    github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest \
-    github.com/ramya-rao-a/go-outline@latest \
-    github.com/go-delve/delve/cmd/dlv@latest"
+    github.com/go-delve/delve/cmd/dlv@latest \
+    github.com/fatih/gomodifytags@latest \
+    github.com/haya14busa/goplay/cmd/goplay@latest \
+    github.com/cweill/gotests/... \ 
+    github.com/josharian/impl@latest"
+
 if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
     echo "Installing common Go tools..."
     export PATH=${TARGET_GOROOT}/bin:${PATH}


### PR DESCRIPTION
close #553 

updated the Go tools used in `features/go`

## After

```
GO_TOOLS="\
    golang.org/x/tools/gopls@latest \
    honnef.co/go/tools/cmd/staticcheck@latest \
    golang.org/x/lint/golint@latest \
    github.com/mgechev/revive@latest \
    github.com/go-delve/delve/cmd/dlv@latest \
    github.com/fatih/gomodifytags@latest \
    github.com/haya14busa/goplay/cmd/goplay@latest \
    github.com/cweill/gotests/... \ 
    github.com/josharian/impl@latest"
```

## Description

### Additions

- **gomodifytags**
- **goplay**
- **gotests**
- **impl**

added the following tools that were newly added to [go tools list](https://github.com/golang/vscode-go/blob/v0.38.0/src/goToolsInformation.ts)

### Removed

- **gopkgs**
removed it because removed from the list in [go tools list](https://github.com/golang/vscode-go/blob/v0.38.0/src/goToolsInformation.ts)

- **go-outlines**
removed it because it had `replacedByGopls` set to true.

### Other

In addition, regarding linting tools, the following ones are not used by default, but they are set as optional attributes by the [official documentation](https://github.com/golang/vscode-go/blob/master/docs/tools.md#staticcheck), allowing users to choose them. Therefore, in this pull request, we have kept them without removing:

- golint
- revive
- go-clilint
