### PR TITLE
Change Ruby extension to ruby-lsp

### DIFF
--- a/src/ruby/devcontainer-feature.json
+++ b/src/ruby/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "1.0.10",
+    "version": "1.1.0",
     "name": "Ruby (via rvm)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/ruby",
     "description": "Installs Ruby, rvm, rbenv, common Ruby utilities, and needed dependencies.",
@@ -21,7 +21,8 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "rebornix.Ruby"
+                "rebornix.Ruby",
+                "shopify.ruby-lsp"
             ]
         }
     },


### PR DESCRIPTION
This is the extension that is recommended in the VSCode documentation now. 

https://code.visualstudio.com/docs/languages/ruby