### PR TITLE
Add `prerelease` extension tag

### DIFF
--- a/src/dotnet/devcontainer-feature.json
+++ b/src/dotnet/devcontainer-feature.json
@@ -34,7 +34,7 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "ms-dotnettools.csharp"
+                "ms-dotnettools.csharp@prerelease"
             ]
         }
     },


### PR DESCRIPTION
Part of https://github.com/devcontainers/templates/issues/164

To use the C# Dev Kit today, users need the pre-release version of the C# extension.

The other main change to ensure the Feature works well in all setups is https://github.com/devcontainers/features/issues/560 (a fix is in-progress).

@timheuer would love to know if you had any other thoughts/feedback on this Feature. Thanks!