### PR TITLE
Azure CLI: Compatibility with Debian `bookworm`

### DIFF
--- a/src/azure-cli/devcontainer-feature.json
+++ b/src/azure-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-cli",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "name": "Azure CLI",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/azure-cli",
   "description": "Installs the Azure CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",

--- a/src/azure-cli/install.sh
+++ b/src/azure-cli/install.sh
@@ -140,7 +140,8 @@ install_using_pip() {
     export PIP_CACHE_DIR=/tmp/pip-tmp/cache
     pipx_bin=pipx
     if ! type pipx > /dev/null 2>&1; then
-        pip3 install --disable-pip-version-check --no-cache-dir --user pipx
+        # TODO: Revisit if --break-system-packages is the best choice here.  Added to support debian bookworm.
+        pip3 install --disable-pip-version-check --no-cache-dir --user pipx --break-system-packages
         pipx_bin=/tmp/pip-tmp/bin/pipx
     fi
 

--- a/src/azure-cli/install.sh
+++ b/src/azure-cli/install.sh
@@ -143,20 +143,18 @@ install_using_pip_strategy() {
 }
 
 install_with_pipx() {
+    echo "(*) Attempting to install globally with pipx..."
     local ver="$1"
-
-    local REMOTE_USER_LOCAL_FOLDER="${_REMOTE_USER_HOME}/.local"
-    local PIPX_HOME="${REMOTE_USER_LOCAL_FOLDER}/pipx"
-    local PIPX_BIN_DIR="${REMOTE_USER_LOCAL_FOLDER}/bin"
+    local PIPX_HOME="/usr/local/pipx"
+    local PIPX_BIN_DIR=/usr/local/bin
 
     if ! type pipx > /dev/null 2>&1; then
         echo "(*) Installing pipx..."
         check_packages pipx
-        pipx ensurepath # Adds PIPX_BIN_DIR to the PATH
+        pipx ensurepath # Ensures PIPX_BIN_DIR is on the PATH
     fi
 
     pipx install azure-cli${ver}
-    chown -hR ${_REMOTE_USER}:${_REMOTE_USER} "${REMOTE_USER_LOCAL_FOLDER}"   
 }
 
 install_with_complete_python_installation() {

--- a/src/azure-cli/install.sh
+++ b/src/azure-cli/install.sh
@@ -30,6 +30,8 @@ if [ -z "${_REMOTE_USER}" ]; then
     exit 1
 fi
 
+echo "Effective REMOTE_USER: ${_REMOTE_USER}"
+
 # Get central common setting
 get_common_setting() {
     if [ "${common_settings_file_loaded}" != "true" ]; then
@@ -145,8 +147,8 @@ install_using_pip_strategy() {
 install_with_pipx() {
     echo "(*) Attempting to install globally with pipx..."
     local ver="$1"
-    local PIPX_HOME="/usr/local/pipx"
-    local PIPX_BIN_DIR=/usr/local/bin
+    export 
+    local 
 
     if ! type pipx > /dev/null 2>&1; then
         echo "(*) Installing pipx..."
@@ -154,7 +156,11 @@ install_with_pipx() {
         pipx ensurepath # Ensures PIPX_BIN_DIR is on the PATH
     fi
 
+    PIPX_HOME="/usr/local/pipx" \
+    PIPX_BIN_DIR=/usr/local/bin \
     pipx install azure-cli${ver}
+
+    echo "(*) Finished installing globally with pipx."
 }
 
 install_with_complete_python_installation() {
@@ -180,7 +186,7 @@ install_with_complete_python_installation() {
 
         # Fail gracefully
         if [ "$?" != 0 ]; then
-            echo "Could not install azure-cli${ver} via pip"
+            echo "Could not install azure-cli${ver} via pip3"
             rm -rf /tmp/pip-tmp
             return 1
         fi

--- a/test/azure-cli/install_bicep.sh
+++ b/test/azure-cli/install_bicep.sh
@@ -8,6 +8,8 @@ source dev-container-features-test-lib
 # Check to make sure the user is vscode
 check "user is vscode" whoami | grep vscode
 
+check "version" az  --version
+
 # Bicep-specific tests
 check "bicep" bicep --version
 check "az bicep" az bicep version

--- a/test/azure-cli/install_extensions.sh
+++ b/test/azure-cli/install_extensions.sh
@@ -8,6 +8,8 @@ source dev-container-features-test-lib
 # Check to make sure the user is vscode
 check "user is vscode" whoami | grep vscode
 
+check "version" az  --version
+
 # Extension-specific tests
 check "aks-preview" az extension show --name aks-preview
 check "amg" az extension show --name amg

--- a/test/azure-cli/install_extensions_bookworm.sh
+++ b/test/azure-cli/install_extensions_bookworm.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+# Import test library for `check` command
+source dev-container-features-test-lib
+
+./install_extensions.sh

--- a/test/azure-cli/scenarios.json
+++ b/test/azure-cli/scenarios.json
@@ -9,6 +9,16 @@
       }
     }
   },
+  "install_extensions_bookworm": {
+    "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+    "user": "vscode",
+    "features": {
+      "azure-cli": {
+        "version": "latest",
+        "extensions": "aks-preview,amg,containerapp"
+      }
+    }
+  },
   "install_bicep": {
     "image": "mcr.microsoft.com/devcontainers/base:jammy",
     "user": "vscode",


### PR DESCRIPTION
closes https://github.com/devcontainers/features/issues/589
related https://github.com/devcontainers/features/issues/577

Changes needed to the Azure CLI Feature post Debian bookworm / [PEP 668](https://peps.python.org/pep-0668/#abstract)

When azure-cli binaries aren't available from `apt`, checks if  `pipx` if available in apt and if so, attempts to use that to install the Azure CLI.  From the base images I tested, `pipx` is only available in the `bookworm` apt repos (and that's the goal for this PR!). 