### PR TITLE
Temporaily pin TFLint to 0.46.1

### DIFF
--- a/src/terraform/devcontainer-feature.json
+++ b/src/terraform/devcontainer-feature.json
@@ -20,10 +20,12 @@
         "tflint": {
             "type": "string",
             "proposals": [
-                "latest"
+                "latest",
+                "0.47.0",
+                "0.46.1"
             ],
-            "default": "latest",
-            "description": "Tflint version"
+            "default": "0.46.1",
+            "description": "Tflint version (Default value temporarily pinned to version 0.46.1: https://github.com/devcontainers/features/issues/581)"
         },
         "terragrunt": {
             "type": "string",


### PR DESCRIPTION
There was an upstream change to TFLint that causes this Feature to fail to install.  While I re-write this portion of the Feature to support the upstream change, pin to a working version.

ref: https://github.com/terraform-linters/tflint/issues/1783
issue: https://github.com/devcontainers/features/issues/581