### PR TITLE
Terraform: Add cosign integrity check for TFLint

### DIFF
--- a/src/terraform/devcontainer-feature.json
+++ b/src/terraform/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "terraform",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "name": "Terraform, tflint, and TFGrunt",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/terraform",
     "description": "Installs the Terraform CLI and optionally TFLint and Terragrunt. Auto-detects latest version and installs needed dependencies.",
@@ -24,8 +24,8 @@
                 "0.47.0",
                 "0.46.1"
             ],
-            "default": "0.46.1",
-            "description": "Tflint version (Default value temporarily pinned to version 0.46.1: https://github.com/devcontainers/features/issues/581)"
+            "default": "latest",
+            "description": "Tflint version (https://github.com/terraform-linters/tflint/releases)"
         },
         "terragrunt": {
             "type": "string",

--- a/test/terraform/older_tflint.sh
+++ b/test/terraform/older_tflint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "terraform" terraform -version
+
+check "tflint" tflint --version
+
+# Report result
+reportResults

--- a/test/terraform/scenarios.json
+++ b/test/terraform/scenarios.json
@@ -22,5 +22,13 @@
                 "installTerraformDocs": true
             }
         }
+    },
+    "older_tflint": {
+        "image": "mcr.microsoft.com/devcontainers/base:jammy",
+        "features": {
+            "terraform": {
+                "tflint": "0.40.0"
+            }
+        }
     }
 }


### PR DESCRIPTION
ref: https://github.com/devcontainers/features/issues/581

Updates the `terraform` Feature to use [cosign](https://github.com/sigstore/cosign) to validate signatures.  This change also unpins the temporary mitigation added in https://github.com/devcontainers/features/pull/583

