### PR TITLE
Dotnet: Fix Feature failures on ubuntu:jammy (when installing using apt)

### DIFF
--- a/src/dotnet/devcontainer-feature.json
+++ b/src/dotnet/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "dotnet",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "name": "Dotnet CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/dotnet",
     "description": "Installs the .NET CLI. Provides option of installing sdk or runtime, and option of versions to install. Uses latest version of .NET sdk as defaults to install.",

--- a/src/dotnet/install.sh
+++ b/src/dotnet/install.sh
@@ -194,11 +194,13 @@ install_using_apt() {
         curl -sSL ${MICROSOFT_GPG_KEYS_URI} | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg
         echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/microsoft-${ID}-${VERSION_CODENAME}-prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
 
-        cat << 'EOF' > /etc/apt/preferences
+        # See https://github.com/dotnet/core/issues/7699
+        cat << 'EOF' >> /etc/apt/preferences
 Package: *
 Pin: origin "packages.microsoft.com"
 Pin-Priority: 1001
 EOF
+
         apt-get update -y
     fi
 

--- a/src/dotnet/install.sh
+++ b/src/dotnet/install.sh
@@ -33,6 +33,16 @@ DOTNET_VERSION_CODENAMES_REQUIRE_OLDER_LIBSSL_1="buster bullseye bionic focal hi
 # alongside DOTNET_VERSION, but not set as default.
 ADDITIONAL_VERSIONS=${ADDITIONALVERSIONS:-""}
 
+APT_PREFERENCES_CONTENT="$(cat << 'EOF'
+Package: *
+Pin: origin "packages.microsoft.com"
+Pin-Priority: 1001
+EOF
+)"
+
+APT_PREFERENCES_FILE_ADDED="false"
+APT_PREFERENCES_UPDATED="false"
+
 set -e
 
 # Clean up
@@ -149,7 +159,7 @@ apt_cache_package_and_version_soft_match() {
 
     apt-get update -y
     major_minor_version="$(echo "${requested_version}" | cut -d "." --field=1,2)"
-    package_name="$(apt-cache search "${partial_package_name}-[0-9].[0-9]" | awk -F" - " '{print $1}' | grep -v "source-built-artifacts" | grep -m 1 "${partial_package_name}-${major_minor_version}")"
+    package_name="$(apt-cache search "${partial_package_name}-[0-9].[0-9]$" | awk -F" - " '{print $1}' | grep -m 1 "${partial_package_name}-${major_minor_version}")"
     dot_escaped="${requested_version//./\\.}"
     dot_plus_escaped="${dot_escaped//+/\\+}"
     # Regex needs to handle debian package version number format: https://www.systutorials.com/docs/linux/man/5-deb-version/
@@ -194,13 +204,11 @@ install_using_apt() {
         curl -sSL ${MICROSOFT_GPG_KEYS_URI} | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg
         echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/microsoft-${ID}-${VERSION_CODENAME}-prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
 
-        # See https://github.com/dotnet/core/issues/7699
-        cat << 'EOF' >> /etc/apt/preferences
-Package: *
-Pin: origin "packages.microsoft.com"
-Pin-Priority: 1001
-EOF
+        [ ! -f /etc/apt/preferences ] && APT_PREFERENCES_FILE_ADDED="true"
+        APT_PREFERENCES_UPDATED="true"
 
+        # See https://github.com/dotnet/core/issues/7699
+        echo "${APT_PREFERENCES_CONTENT}" >> /etc/apt/preferences
         apt-get update -y
     fi
 
@@ -471,6 +479,14 @@ if [ "${CHANGE_OWNERSHIP}" = "true" ]; then
 fi
 
 # Clean up
+if [ "${APT_PREFERENCES_UPDATED}" = "true" ]; then
+    if [ "${APT_PREFERENCES_FILE_ADDED}" = "true" ]; then
+        rm -f /etc/apt/preferences
+    else
+        head -n -3 /etc/apt/preferences > /tmp/preferences-temp && mv /tmp/preferences-temp /etc/apt/preferences
+    fi
+fi
+
 rm -rf /var/lib/apt/lists/*
 
 echo "Done!"

--- a/test/dotnet/install_dotnet_6_jammy.sh
+++ b/test/dotnet/install_dotnet_6_jammy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "dotnet sdks" dotnet --list-sdks
+check "some major version of dotnet 6 is installed" bash -c "dotnet --list-sdks |  grep '6\.[0-9]*\.[0-9]*'"
+check "dotnet version 6 installed"  bash -c "ls -l /usr/lib/dotnet/sdk | grep '6\.[0-9]*\.[0-9]*'"
+
+# Verify current symlink exists and works
+check "current link dotnet" /usr/local/dotnet/current/dotnet --info
+check "current link sdk" ls -l /usr/local/dotnet/current/sdk
+
+# Report result
+reportResults

--- a/test/dotnet/install_dotnet_7_jammy.sh
+++ b/test/dotnet/install_dotnet_7_jammy.sh
@@ -5,9 +5,6 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
-cat /etc/apt/preferences
-
-
 check "dotnet sdks" dotnet --list-sdks
 check "some major version of dotnet 7 is installed" bash -c "dotnet --list-sdks |  grep '7\.[0-9]*\.[0-9]*'"
 check "dotnet version 7 installed"  bash -c "ls -l /usr/lib/dotnet/sdk | grep '7\.[0-9]*\.[0-9]*'"

--- a/test/dotnet/install_dotnet_7_jammy.sh
+++ b/test/dotnet/install_dotnet_7_jammy.sh
@@ -5,6 +5,9 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
+cat /etc/apt/preferences
+
+
 check "dotnet sdks" dotnet --list-sdks
 check "some major version of dotnet 7 is installed" bash -c "dotnet --list-sdks |  grep '7\.[0-9]*\.[0-9]*'"
 check "dotnet version 7 installed"  bash -c "ls -l /usr/lib/dotnet/sdk | grep '7\.[0-9]*\.[0-9]*'"

--- a/test/dotnet/install_dotnet_7_jammy.sh
+++ b/test/dotnet/install_dotnet_7_jammy.sh
@@ -7,7 +7,7 @@ source dev-container-features-test-lib
 
 check "dotnet sdks" dotnet --list-sdks
 check "some major version of dotnet 7 is installed" bash -c "dotnet --list-sdks |  grep '7\.[0-9]*\.[0-9]*'"
-check "dotnet version 7 installed"  bash -c "ls -l /usr/share/dotnet/sdk | grep '7\.[0-9]*\.[0-9]*'"
+check "dotnet version 7 installed"  bash -c "ls -l /usr/lib/dotnet/sdk | grep '7\.[0-9]*\.[0-9]*'"
 
 # Verify current symlink exists and works
 check "current link dotnet" /usr/local/dotnet/current/dotnet --info

--- a/test/dotnet/install_dotnet_latest.sh
+++ b/test/dotnet/install_dotnet_latest.sh
@@ -7,7 +7,7 @@ source dev-container-features-test-lib
 
 check "dotnet sdks" dotnet --list-sdks
 check "some major version of dotnet 7 is installed" bash -c "dotnet --list-sdks |  grep '7\.[0-9]*\.[0-9]*'"
-check "dotnet version 7 installed"  bash -c "ls -l /usr/share/dotnet/sdk | grep '7\.[0-9]*\.[0-9]*'"
+check "dotnet version 7 installed"  bash -c "ls -l /usr/lib/dotnet/sdk | grep '7\.[0-9]*\.[0-9]*'"
 
 # Verify current symlink exists and works
 check "current link dotnet" /usr/local/dotnet/current/dotnet --info

--- a/test/dotnet/scenarios.json
+++ b/test/dotnet/scenarios.json
@@ -48,6 +48,14 @@
             }
         }
     },
+    "install_dotnet_6_jammy": {
+        "image": "ubuntu:jammy",
+        "features": {
+            "dotnet": {
+                "version": "6"
+            }
+        }
+    },
     "install_dotnet_latest": {
         "image": "ubuntu:jammy",
         "features": {

--- a/test/dotnet/scenarios.json
+++ b/test/dotnet/scenarios.json
@@ -49,7 +49,7 @@
         }
     },
     "install_dotnet_6_jammy": {
-        "image": "ubuntu:jammy",
+        "image": "mcr.microsoft.com/devcontainers/base:jammy",
         "features": {
             "dotnet": {
                 "version": "6"

--- a/test/dotnet/test.sh
+++ b/test/dotnet/test.sh
@@ -11,7 +11,7 @@ check "sdks" dotnet --list-sdks
 check "version" dotnet --version
 
 echo "Validating expected version present..."
-check "some major version of dotnet 7 is installed" bash -c "dotnet --version |  grep '7\.[0-9]*\.[0-9]*'"
+check "some major version of dotnet (7/8) is installed" bash -c "dotnet --version |  grep '[7-8]\.[0-9]*\.[0-9]*'"
 
 # Verify current symlink exists and works
 check "current link dotnet" /usr/local/dotnet/current/dotnet --info


### PR DESCRIPTION
Closes: https://github.com/devcontainers/features/issues/560

Fixes `dotnet` Feature failures for `ubuntu:jammy`:
- Installs incorrect apt package (eg. `dotnet-sdk-6.0-source-built-artifacts` instead of `dotnet-sdk-6.0`)
- Fails to install package from Microsoft feed
    - Ref: https://learn.microsoft.com/en-us/dotnet/core/install/linux-package-mixup?pivots=os-linux-ubuntu#i-need-a-version-of-net-that-isnt-provided-by-my-linux-distribution
    - https://github.com/dotnet/core/issues/7699
- Fails to install from Ubuntu feed
    - (eg: .NET 6 is available in jammy feeds, however, it fails to install & falls backs to MSFT feeds)
