### PR TITLE
Fix: Docker-in-docker for python - Arm64

### DIFF
--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "name": "Docker (Docker-in-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
     "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -265,7 +265,21 @@ if [ "${DOCKER_DASH_COMPOSE_VERSION}" != "none" ]; then
                 pip3 install --disable-pip-version-check --no-cache-dir --user pipx
                 pipx_bin=/tmp/pip-tmp/bin/pipx
             fi
-            ${pipx_bin} install --pip-args '--no-cache-dir --force-reinstall' docker-compose
+
+            set +e
+                ${pipx_bin} install --pip-args '--no-cache-dir --force-reinstall' docker-compose
+                exit_code=$?
+            set -e
+
+            if [ ${exit_code} -ne 0 ]; then
+                # Temporary: https://github.com/devcontainers/features/issues/616
+                # See https://github.com/yaml/pyyaml/issues/601
+                echo "(*) Failed to install docker-compose via pipx. Trying via pip3..."
+
+                export PYTHONUSERBASE=/usr/local
+                pip3 install --disable-pip-version-check --no-cache-dir --user "Cython<3.0" pyyaml wheel docker-compose --no-build-isolation
+            fi
+
             rm -rf /tmp/pip-tmp
         else
             compose_v1_version="1"


### PR DESCRIPTION
Ref: https://github.com/devcontainers/features/issues/616 & https://github.com/yaml/pyyaml/issues/601#issuecomment-1638509577

Helps unblock docker-in-docker Feature installation for Python >= 3.10 on ARM64 machines.

Note: `pyyaml` cannot be installed with `pipx`, hence need to install `docker-compose` via `pip3`