### PR TITLE
Azure-cli - Temporary quick fix for jammy (ARM)

### DIFF
--- a/src/azure-cli/devcontainer-feature.json
+++ b/src/azure-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-cli",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "name": "Azure CLI",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/azure-cli",
   "description": "Installs the Azure CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",
@@ -22,6 +22,11 @@
       "type": "boolean",
       "description": "Optionally install Azure Bicep",
       "default": false
+    },
+    "installUsingPython": {
+      "type": "boolean",
+      "description": "Install Azure CLI using Python instead of pipx",
+      "default": true
     }
   },
   "customizations": {

--- a/src/azure-cli/install.sh
+++ b/src/azure-cli/install.sh
@@ -15,7 +15,7 @@ rm -rf /var/lib/apt/lists/*
 AZ_VERSION=${VERSION:-"latest"}
 AZ_EXTENSIONS=${EXTENSIONS}
 AZ_INSTALLBICEP=${INSTALLBICEP:-false}
-
+INSTALL_USING_PYTHON=${INSTALL_USING_PYTHON:-true}
 MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
 AZCLI_ARCHIVE_ARCHITECTURES="amd64"
 AZCLI_ARCHIVE_VERSION_CODENAMES="stretch buster bullseye bionic focal jammy"
@@ -141,7 +141,12 @@ install_using_pip_strategy() {
         ver="==${AZ_VERSION}"
     fi
 
-    install_with_pipx "${ver}" || install_with_complete_python_installation "${ver}" || return 1
+    # Temprary quick fix for https://github.com/devcontainers/features/issues/624
+    if [ "${INSTALL_USING_PYTHON}" = "true" ]; then
+        install_with_complete_python_installation "${ver}" || install_with_pipx "${ver}" || return 1
+    else
+        install_with_pipx "${ver}" || install_with_complete_python_installation "${ver}" || return 1
+    fi
 }
 
 install_with_pipx() {


### PR DESCRIPTION
Ref: https://github.com/devcontainers/features/issues/624

On macOS M2, azure-cli feature fails to install for jammy / ubuntu-22.04. See https://github.com/devcontainers/features/issues/624#issuecomment-1646348740

![image](https://github.com/devcontainers/features/assets/24955913/2d22f428-a678-4ec2-b257-d79b84b7db00)

This is a temporary quick fix to resolve this issue, I'd look into fixing the root cause soon.