### PR TITLE
Azure-cli: Revert temporary fix which installed az with python

### DIFF
--- a/src/azure-cli/devcontainer-feature.json
+++ b/src/azure-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "name": "Azure CLI",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/azure-cli",
   "description": "Installs the Azure CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",
@@ -26,7 +26,7 @@
     "installUsingPython": {
       "type": "boolean",
       "description": "Install Azure CLI using Python instead of pipx",
-      "default": true
+      "default": false
     }
   },
   "customizations": {

--- a/src/azure-cli/install.sh
+++ b/src/azure-cli/install.sh
@@ -141,7 +141,6 @@ install_using_pip_strategy() {
         ver="==${AZ_VERSION}"
     fi
 
-    # Temprary quick fix for https://github.com/devcontainers/features/issues/624
     if [ "${INSTALL_USING_PYTHON}" = "true" ]; then
         install_with_complete_python_installation "${ver}" || install_with_pipx "${ver}" || return 1
     else

--- a/test/azure-cli/install_with_python.sh
+++ b/test/azure-cli/install_with_python.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Import test library for `check` command
+source dev-container-features-test-lib
+
+# Check to make sure the user is vscode
+check "user is vscode" whoami | grep vscode
+check "version" az  --version
+
+
+# Report result
+reportResults

--- a/test/azure-cli/scenarios.json
+++ b/test/azure-cli/scenarios.json
@@ -28,5 +28,15 @@
         "installBicep": true
       }
     }
+  },
+  "install_with_python": {
+    "image": "mcr.microsoft.com/devcontainers/base:jammy",
+    "user": "vscode",
+    "features": {
+      "azure-cli": {
+        "version": "latest",
+        "installUsingPython": true
+      }
+    }
   }
 }


### PR DESCRIPTION
Ref: https://github.com/devcontainers/features/pull/626 and https://github.com/devcontainers/features/issues/624

The upstream issue with pipx is fixed, hence, switching back to using pipx as first choice for installing az-cli.

Note: Tested this change locally, works with ARM. 

![image](https://github.com/devcontainers/features/assets/24955913/ec7ea8a3-5f19-4d36-bdbf-90b7cce5b909)
