### PR TITLE
Update actions runner for test-scenarios workflows

### DIFF
--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -60,7 +60,7 @@ jobs:
         run: devcontainer features test  --skip-scenarios -f ${{ matrix.features }} -i ${{ matrix.baseImage }} .
 
   test-scenarios:
-    runs-on: ubuntu-latest
+    runs-on: devcontainer-image-builder-ubuntu
     continue-on-error: true
     strategy:
       matrix:

--- a/.github/workflows/test-manual.yaml
+++ b/.github/workflows/test-manual.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: devcontainer-image-builder-ubuntu
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -68,7 +68,7 @@ jobs:
 
   test-scenarios:
     needs: [detect-changes]
-    runs-on: ubuntu-latest
+    runs-on: devcontainer-image-builder-ubuntu
     continue-on-error: true
     strategy:
       matrix:


### PR DESCRIPTION
Fixes "You are running out of disk space. The runner will stop working when the machine runs out of disk space" errors on action runs for test-scenarios. 

See https://github.com/devcontainers/features/actions/runs/5627383080