### PR TITLE
Fix 2 instances of a typo in the desktop-lite NOTES and README

### DIFF
--- a/src/desktop-lite/NOTES.md
+++ b/src/desktop-lite/NOTES.md
@@ -25,7 +25,7 @@ You can also connect to the desktop using a [VNC viewer](https://www.realvnc.com
 
 ## Customizing Fluxbox
 
-The window manager is installed is [Fluxbox](http://fluxbox.org/). **Right-click** to see the application menu. In addition, any UI-based commands you execute inside the dev container will automatically appear on the desktop.
+The window manager installed is [Fluxbox](http://fluxbox.org/). **Right-click** to see the application menu. In addition, any UI-based commands you execute inside the dev container will automatically appear on the desktop.
 
 You can customize the desktop using Fluxbox configuration files. The configuration files are located in the `.fluxbox` folder of the home directory of the user you using to connect to the dev container (`$HOME/.fluxbox`).
 


### PR DESCRIPTION
This simply amends 'is installed is', which occurs in 2 places in the desktop-lite docs, to 'installed is'.

Alternatively, the amendment could be to 'that is installed is'.