### PR TITLE
Dind optional login

### DIFF
--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -45,6 +45,11 @@
             "type": "boolean",
             "default": true,
             "description": "Install Docker Buildx"
+        },
+        "login": {
+            "type": "boolean",
+            "default": false,
+            "description": "Run `docker login` after installation."
         }
     },
     "entrypoint": "/usr/local/share/docker-init.sh",

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -15,6 +15,7 @@ AZURE_DNS_AUTO_DETECTION="${AZUREDNSAUTODETECTION:-"true"}"
 DOCKER_DEFAULT_ADDRESS_POOL="${DOCKERDEFAULTADDRESSPOOL}"
 USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
 INSTALL_DOCKER_BUILDX="${INSTALLDOCKERBUILDX:-"true"}"
+DOCKER_LOGIN="${LOGIN:-"false"}"
 MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
 DOCKER_MOBY_ARCHIVE_VERSION_CODENAMES="buster bullseye bionic focal jammy"
 DOCKER_LICENSED_ARCHIVE_VERSION_CODENAMES="buster bullseye bionic focal hirsute impish jammy"
@@ -445,6 +446,10 @@ do
         fi
     set -e
 done
+
+if [ "${DOCKER_LOGIN}" = "true" ]; then
+    docker login
+fi
 
 set +e
 

--- a/test/docker-in-docker/docker_login.sh
+++ b/test/docker-in-docker/docker_login.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Feature specific tests
+check "docker-ps" bash -c "docker ps"
+check "docker-login" bash -c "docker login"
+
+# Report result
+reportResults

--- a/test/docker-in-docker/scenarios.json
+++ b/test/docker-in-docker/scenarios.json
@@ -68,6 +68,14 @@
         },
         "remoteUser": "node"
     },
+    "docker_login": {
+        "image": "ubuntu:focal",
+        "features": {
+            "docker-in-docker": {
+                "login": "true"
+            }
+        }
+    },
     "docker_retry": {
         "image": "ubuntu:focal",
         "features": {


### PR DESCRIPTION
I am running `devpod` on an AKS cluster and am running into authentication issues even though the cluster has `AcrPush` and `AcrPull` permissions. Since the build is happening inside of a container instead of on the node, the system identity can be used, but a `docker login` command needs to be executed, and it will leverage the [Managed identity for Azure resources](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#authentication-options).

When looking into solutions that did not involve janky practices, I decided it made sense to put `login` into the docker installation process. 

This PR adds login as an optional parameter and a supporting test case. 

