### PR TITLE
Enhancing Terraform Feature Stability

### DIFF
--- a/src/terraform/devcontainer-feature.json
+++ b/src/terraform/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "terraform",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "name": "Terraform, tflint, and TFGrunt",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/terraform",
     "description": "Installs the Terraform CLI and optionally TFLint and Terragrunt. Auto-detects latest version and installs needed dependencies.",

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -160,36 +160,6 @@ check_packages() {
 
 # Install 'cosign' for validating signatures
 # https://docs.sigstore.dev/cosign/overview/
-get_cosign_latest_version() {
-    local github_api_url="https://api.github.com/repos/sigstore/cosign/releases/latest"
-    local response
-    response=$(curl -s -w "%{http_code}" "$github_api_url")
-    local status_code=${response: -3}
-    local content=${response::-3}
-
-    if [[ $status_code -eq 200 ]]; then
-        local latest_version
-        latest_version=$(echo "$content" | grep tag_name | cut -d : -f2 | tr -d "v\", ")
-        echo "$latest_version"
-    else
-        local github_url="https://github.com/sigstore/cosign/releases/latest"
-        redirect_url=$(curl -s -L -w "%{url_effective}" -o /dev/null "$github_url")
-
-        response=$(curl -L -s -o /dev/null -w "%{url_effective}\n%{response_code}" "$github_url")
-        local status_code=${response: -3}
-        local redirect_url=${response::-3}
-
-        if [[ $status_code -eq 200 ]]; then
-            local latest_version
-            latest_version=$(echo "$redirect_url" | cut -d '/' -f8 | tr -d "v")
-            echo "$latest_version"
-        else
-            echo "Failed to fetch latest cosign version"
-            exit 1
-        fi
-    fi
-}
-
 ensure_cosign() {
     check_packages curl ca-certificates gnupg2
 

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -195,7 +195,8 @@ ensure_cosign() {
 
     if ! type cosign > /dev/null 2>&1; then
         echo "Installing cosign..."
-        local LATEST_COSIGN_VERSION=$(get_cosign_latest_version)
+        LATEST_COSIGN_VERSION="latest"
+        find_version_from_git_tags LATEST_COSIGN_VERSION 'https://github.com/sigstore/cosign'
         curl -L "https://github.com/sigstore/cosign/releases/latest/download/cosign_${LATEST_COSIGN_VERSION}_${architecture}.deb" -o /tmp/cosign_${LATEST_COSIGN_VERSION}_${architecture}.deb
         
         dpkg -i /tmp/cosign_${LATEST_COSIGN_VERSION}_${architecture}.deb


### PR DESCRIPTION
**Description:**
This pull request aims to enhance the stability of the Terraform feature by addressing a limitation in the `ensure_cosign` function. The function currently relies on the GitHub API for retrieving information, but this API has usage limitations, allowing only 60 calls per hour for non-authorized users (as documented [here](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limiting)).

**Problem:**
The existing implementation poses challenges, especially within corporate networks where multiple users often share the same external IP address. This setup can quickly exhaust the rate limit, disrupting the reliability of the feature.

**Solution:**
~~This pull request introduces a solution to address the rate-limiting issue. A fallback method has been implemented to retrieve the latest cosign version number.~~
This pull request presents a solution to mitigate the rate-limiting issue. Instead of implementing a separate fallback mechanism, we've leveraged the existing function, `find_version_from_git_tags`, to retrieve the latest cosign version. This approach, as suggested by @samruddhikhandale, streamlines the codebase and effectively overcomes the rate-limiting constraint.

**Changes Made:**
~~- Implemented a fallback mechanism to retrieve the latest cosign version number.~~
- Replaced the direct GitHub API call by the existing `find_version_from_git_tags` function.