### PR TITLE
[Rust] Remove `mutantdino.resourcemonitor` extension

### DIFF
--- a/src/rust/devcontainer-feature.json
+++ b/src/rust/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "rust",
-    "version": "1.0.12",
+    "version": "1.0.13",
     "name": "Rust",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/rust",
     "description": "Installs Rust, common Rust utilities, and their required dependencies",

--- a/src/rust/devcontainer-feature.json
+++ b/src/rust/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "rust",
-    "version": "1.0.12",
+    "version": "1.1.0",
     "name": "Rust",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/rust",
     "description": "Installs Rust, common Rust utilities, and their required dependencies",

--- a/src/rust/devcontainer-feature.json
+++ b/src/rust/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "rust",
-    "version": "1.0.13",
+    "version": "1.0.12",
     "name": "Rust",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/rust",
     "description": "Installs Rust, common Rust utilities, and their required dependencies",

--- a/src/rust/devcontainer-feature.json
+++ b/src/rust/devcontainer-feature.json
@@ -39,7 +39,6 @@
         "vscode": {
             "extensions": [
                 "vadimcn.vscode-lldb",
-                "mutantdino.resourcemonitor",
                 "rust-lang.rust-analyzer",
                 "tamasfe.even-better-toml",
                 "serayuzgur.crates"


### PR DESCRIPTION
I don't see this extension as essential to Rust development.

As far as I know, there is no way to opt-out of the extension defined here(Ref: https://github.com/devcontainers/features/issues/386), and I would like to see it removed.

Users who need this extension can set it to `dev.containers.defaultExtensions` in their own configuration files.