### PR TITLE
[common-utils] fix bug when user home is custom by base docker

### DIFF
--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "common-utils",
-    "version": "2.1.3",
+    "version": "2.2.0",
     "name": "Common Utilities",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/common-utils",
     "description": "Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.",

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -407,16 +407,14 @@ fi
 
 if [ "${USERNAME}" = "root" ]; then
     user_home="/root"
+# Check if user already has a home directory other than /home/${USERNAME}
+elif [ "/home/${USERNAME}" != $( getent passwd $USERNAME | cut -d: -f6 ) ]; then
+    user_home=$( getent passwd $USERNAME | cut -d: -f6 )
 else
-    # Check if user already has a home directory other than /home/${USERNAME}
-    if [ "/home/${USERNAME}" != $( getent passwd $USERNAME | cut -d: -f6 ) ]; then
-        user_home=$( getent passwd $USERNAME | cut -d: -f6 )
-    else
-        user_home="/home/${USERNAME}"
-        if [ ! -d "${user_home}" ]; then
-            mkdir -p "${user_home}"
-            chown ${USERNAME}:${group_name} "${user_home}"
-        fi
+    user_home="/home/${USERNAME}"
+    if [ ! -d "${user_home}" ]; then
+        mkdir -p "${user_home}"
+        chown ${USERNAME}:${group_name} "${user_home}"
     fi
 fi
 

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -408,10 +408,15 @@ fi
 if [ "${USERNAME}" = "root" ]; then
     user_home="/root"
 else
-    user_home="/home/${USERNAME}"
-    if [ ! -d "${user_home}" ]; then
-        mkdir -p "${user_home}"
-        chown ${USERNAME}:${group_name} "${user_home}"
+    # Check if user already has a home directory other than /home/${USERNAME}
+    if [ "/home/${USERNAME}" != $( getent passwd $USERNAME | cut -d: -f6 ) ]; then
+        user_home=$( getent passwd $USERNAME | cut -d: -f6 )
+    else
+        user_home="/home/${USERNAME}"
+        if [ ! -d "${user_home}" ]; then
+            mkdir -p "${user_home}"
+            chown ${USERNAME}:${group_name} "${user_home}"
+        fi
     fi
 fi
 

--- a/test/common-utils/devcontainer-custom-home.sh
+++ b/test/common-utils/devcontainer-custom-home.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "user is customUser" grep customUser <(whoami)
+check "home is /customHome" grep "/customHome" <(getent passwd customUser | cut -d: -f6) 
+
+# Report result
+reportResults

--- a/test/common-utils/devcontainer-custom-home/Dockerfile
+++ b/test/common-utils/devcontainer-custom-home/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:focal
+
+RUN groupadd customUser -g 30000 && \
+    useradd customUser -u 30000 -g 30000 --create-home --home-dir /customHome

--- a/test/common-utils/devcontainer-custom-user-default-home.sh
+++ b/test/common-utils/devcontainer-custom-user-default-home.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "user is customUser" grep customUser <(whoami)
+check "home is /home/customUser" grep "/home/customUser" <(getent passwd customUser | cut -d: -f6) 
+
+# Report result
+reportResults

--- a/test/common-utils/scenarios.json
+++ b/test/common-utils/scenarios.json
@@ -183,5 +183,21 @@
                 "configureZshAsDefaultShell": true
             }
         }
+    },
+    "devcontainer-custom-home": {
+        "build": {
+            "dockerfile": "Dockerfile"
+        },
+        "remoteUser": "customUser",
+        "features": {
+            "common-utils": {}
+        }
+    },
+    "devcontainer-custom-user-default-home": {
+        "image": "mcr.microsoft.com/devcontainers/base:alpine",
+        "remoteUser": "customUser",
+        "features": {
+            "common-utils": {}
+        }
     }
 }


### PR DESCRIPTION
Resolves #639 

main.sh first checks if user has home directory already set and different than /home/${USERNAME}. if it does, then uses the custom home directory, otherwise behaves as usual