### PR TITLE
docker-in-docker: Add an `onCreateCommand` to wait for Docker to be ready

### DIFF
--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "name": "Docker (Docker-in-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
     "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",
@@ -48,6 +48,7 @@
         }
     },
     "entrypoint": "/usr/local/share/docker-init.sh",
+    "onCreateCommand": "/usr/local/share/docker-oncreatecommand.sh",
     "privileged": true,
     "containerEnv": {
         "DOCKER_BUILDKIT": "1"

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -447,8 +447,8 @@ INNEREOF
 retry_docker_start_count=0
 docker_ok="false"
 
-until [ "${docker_ok}" = "true"  ] || [ "${retry_docker_start_count}" -eq "5" ];
-do 
+until [ -f /tmp/docker-ready ] || [ "${retry_docker_start_count}" -eq "5" ];
+do
     # Start using sudo if not invoked as root
     if [ "$(id -u)" -ne 0 ]; then
         sudo /bin/sh -c "${dockerd_start}"
@@ -457,20 +457,20 @@ do
     fi
 
     retry_count=0
-    until [ "${docker_ok}" = "true"  ] || [ "${retry_count}" -eq "5" ];
+    until [ "${retry_count}" -eq "5" ];
     do
-        sleep 1s
-        set +e
-            docker info > /dev/null 2>&1 && docker_ok="true"
-        set -e
+        if [ -f "/tmp/docker-ready" ]; then
+            echo "Docker is ready"
+            exit 0
+        fi
 
-        retry_count=`expr $retry_count + 1`
+        sleep 1
+        retry_count=$((retry_count + 1))
     done
-    
-    if [ "${docker_ok}" != "true" ]; then
-        echo "(*) Failed to start docker, retrying..."
-    fi
-    
+
+    echo "(*) Failed to start docker, retrying..."
+    cat /tmp/dockerd.log
+
     retry_docker_start_count=`expr $retry_docker_start_count + 1`
 done
 
@@ -479,7 +479,37 @@ done
 exec "$@"
 EOF
 
+# This will run as the feature's onCreateCommand. It will run as the user, and
+# it will block execution of the user's commands until it exits (until Docker is
+# ready).
+tee /usr/local/share/docker-oncreatecommand.sh > /dev/null \
+<< 'EOF'
+#!/usr/bin/env bash
+
+set -e
+
+docker_ok="false"
+retry_count=0
+
+until [ "${docker_ok}" = "true"  ] || [ "${retry_count}" -eq "60" ];
+do
+    sleep 1s
+    if docker info >/dev/null 2>&1; then
+        docker_ok="true"
+    fi
+
+    retry_count=$((retry_count + 1))
+done
+
+if [ "${docker_ok}" == "true" ]; then
+    echo "Docker is ready"
+    touch /tmp/docker-ready
+fi
+EOF
+
+
 chmod +x /usr/local/share/docker-init.sh
+chmod +x /usr/local/share/docker-oncreatecommand.sh
 chown ${USERNAME}:root /usr/local/share/docker-init.sh
 
 # Clean up


### PR DESCRIPTION
In my devcontainer, which runs as an unprivileged user, Docker was not running properly after the script started up. Editing the script to output more debug info (to make `docker info` not be quiet) showed it was outputting:

> ERROR: permission denied while trying to connect to the Docker daemon
> socket at unix:///var/run/docker.sock: Get
> "http://%2Fvar%2Frun%2Fdocker.sock/v1.24/info": dial unix
> /var/run/docker.sock: connect: permission denied

Further adding a `groups` call showed that the user was not in the `docker` group when we tried to call `docker info`. This made it always fail when run from the install script. The retry loop ran the maximum number of times, and we were left with several `defunct` (zombie) docker and containerd processes.

Moving the checking to an `onCreateCommand` fixes this, as this runs fully as the user. Furthermore, this makes the user's commands, and the container's startup, block on Docker being available. This is beneficial, as it means that there won't be a time when you can use the dev container but Docker isn't there.

We do still keep the retrying logic, and we signal between the `onCreateCommand` and the install script by creating a flag file.