### PR TITLE
Docker-in-docker: Updates docker-init with "pkill"

### DIFF
--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "name": "Docker (Docker-in-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
     "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -362,6 +362,8 @@ EOF
 tee -a /usr/local/share/docker-init.sh > /dev/null \
 << 'EOF'
 dockerd_start="AZURE_DNS_AUTO_DETECTION=${AZURE_DNS_AUTO_DETECTION} DOCKER_DEFAULT_ADDRESS_POOL=${DOCKER_DEFAULT_ADDRESS_POOL} $(cat << 'INNEREOF'
+    # Stop dockerd and containerd in case they are already running
+    docker info > /dev/null 2>&1 && pkill dockerd && pkill containerd
     # explicitly remove dockerd and containerd PID file to ensure that it can start properly if it was stopped uncleanly
     find /run /var/run -iname 'docker*.pid' -delete || :
     find /run /var/run -iname 'container*.pid' -delete || :
@@ -468,15 +470,6 @@ do
     
     if [ "${docker_ok}" != "true" ]; then
         echo "(*) Failed to start docker, retrying..."
-
-        # Stop dockerd and containerd in case they are already running
-        if [ "$(id -u)" -ne 0 ]; then
-            sudo pkill dockerd
-            sudo pkill containerd
-        else
-            pkill dockerd
-            pkill containerd
-        fi
     fi
     
     retry_docker_start_count=`expr $retry_docker_start_count + 1`

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -362,8 +362,11 @@ EOF
 tee -a /usr/local/share/docker-init.sh > /dev/null \
 << 'EOF'
 dockerd_start="AZURE_DNS_AUTO_DETECTION=${AZURE_DNS_AUTO_DETECTION} DOCKER_DEFAULT_ADDRESS_POOL=${DOCKER_DEFAULT_ADDRESS_POOL} $(cat << 'INNEREOF'
+    # Stop dockerd and containerd in case they are already running
+    pkill dockerd
+    pkill containerd
+    
     # explicitly remove dockerd and containerd PID file to ensure that it can start properly if it was stopped uncleanly
-    # ie: docker kill <ID>
     find /run /var/run -iname 'docker*.pid' -delete || :
     find /run /var/run -iname 'container*.pid' -delete || :
 

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -445,6 +445,16 @@ dockerd_start="AZURE_DNS_AUTO_DETECTION=${AZURE_DNS_AUTO_DETECTION} DOCKER_DEFAU
 INNEREOF
 )"
 
+sudo_if() {
+    COMMAND="$*"
+
+    if [ "$(id -u)" -ne 0 ]; then
+        sudo $COMMAND
+    else
+        $COMMAND
+    fi
+}
+
 retry_docker_start_count=0
 docker_ok="false"
 
@@ -470,6 +480,8 @@ do
     
     if [ "${docker_ok}" != "true" ]; then
         echo "(*) Failed to start docker, retrying..."
+        sudo_if pkill dockerd
+        sudo_if pkill containerd
     fi
     
     retry_docker_start_count=`expr $retry_docker_start_count + 1`

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -362,10 +362,6 @@ EOF
 tee -a /usr/local/share/docker-init.sh > /dev/null \
 << 'EOF'
 dockerd_start="AZURE_DNS_AUTO_DETECTION=${AZURE_DNS_AUTO_DETECTION} DOCKER_DEFAULT_ADDRESS_POOL=${DOCKER_DEFAULT_ADDRESS_POOL} $(cat << 'INNEREOF'
-    # Stop dockerd and containerd in case they are already running
-    pkill dockerd
-    pkill containerd
-    
     # explicitly remove dockerd and containerd PID file to ensure that it can start properly if it was stopped uncleanly
     find /run /var/run -iname 'docker*.pid' -delete || :
     find /run /var/run -iname 'container*.pid' -delete || :
@@ -472,6 +468,15 @@ do
     
     if [ "${docker_ok}" != "true" ]; then
         echo "(*) Failed to start docker, retrying..."
+
+        # Stop dockerd and containerd in case they are already running
+        if [ "$(id -u)" -ne 0 ]; then
+            sudo pkill dockerd
+            sudo pkill containerd
+        else
+            pkill dockerd
+            pkill containerd
+        fi
     fi
     
     retry_docker_start_count=`expr $retry_docker_start_count + 1`


### PR DESCRIPTION
Fixes : https://github.com/devcontainers/images/issues/729

When the universal image is built with latest `docker-in-docker` Feature, it fails to start docker daemon as `containerd` does not start (Reported in https://github.com/devcontainers/features/issues/671#issuecomment-1702809633) .The image is trying to retry the docker daemon startup, but as `containerd` (or/and `dockerd)` is not in a good state before, it fails to restart causing `docker ps` to fail.

>  find /run /var/run -iname 'docker*.pid' -delete || :
    find /run /var/run -iname 'container*.pid' -delete || :

We do have these commands ^ but it simply removes the PID files, does not stop/clean the dockerd and containerd daemons 

🧪  Tested these PR changes with `universal:dev@sha256:b7a147f15c61f02b8220d1719431f205f65e48267ffed93e0b9c642c14cf956a` image, `docker ps` is successful. 

![image](https://github.com/devcontainers/features/assets/24955913/7386475d-5c81-41c7-a86a-ea978a387e9a)
