### PR TITLE
Configure npm proxy when proxy environmentals exist

### DIFF
--- a/src/node/devcontainer-feature.json
+++ b/src/node/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "node",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "name": "Node.js (via nvm), yarn and pnpm",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/node",
     "description": "Installs Node.js, nvm, yarn, pnpm, and needed dependencies.",

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -228,6 +228,9 @@ if type pnpm > /dev/null 2>&1; then
     echo "pnpm already installed."
 else
     if type npm > /dev/null 2>&1; then
+        [ ! -z "$http_proxy" ] && npm set proxy="$http_proxy"
+        [ ! -z "$https_proxy" ] && npm set https-proxy="$https_proxy"
+        [ ! -z "$no_proxy" ] && npm set noproxy="$no_proxy"
         npm install -g pnpm
     else
         echo "Skip installing pnpm because npm is missing"


### PR DESCRIPTION
PR for issue #702 (Node feature does not pick up proxy settings).
Docker automatically sets up proxy environmentals in the container when configured (see https://docs.docker.com/network/proxy/) so usually everything works without additional configuration. An exception is npm, which does not pick up these environmentals and needs to be configured manually. This PR adds the necessary configuration steps.