### PR TITLE
[terraform] Update retry logic to handle DNS-related errors more gracefully

### DIFF
--- a/src/terraform/devcontainer-feature.json
+++ b/src/terraform/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "terraform",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "name": "Terraform, tflint, and TFGrunt",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/terraform",
     "description": "Installs the Terraform CLI and optionally TFLint and Terragrunt. Auto-detects latest version and installs needed dependencies.",

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -82,7 +82,7 @@ receive_gpg_keys() {
     if [ "${gpg_ok}" = "false" ]; then
         retry_count=0;
         echo "(*) Resolving GPG keyserver IP address..."
-        local keyserver_ip_address=$( resolve_ip_by_domain keyserver.ubuntu.com )
+        local keyserver_ip_address=$( dig +short keyserver.ubuntu.com | head -n1 )
         echo "(*) GPG keyserver IP address $keyserver_ip_address"
         
         until [ "${gpg_ok}" = "true" ] || [ "${retry_count}" -eq "3" ]; 


### PR DESCRIPTION
**Feature name**:

- ghcr.io/devcontainers/features/terraform

**Description**:

This PR aims to update the retry logic to handle the `gpg: keyserver receive failed: Server indicated a failure` error more gracefully. 

The `gpg` returns the `keyserver receive failed: Server indicated a failure` error if something goes wrong with DNS-related stuff. It looks like `gpg` could use several libraries for working with DNS servers based on macros values. Related code:

- https://github.com/gpg/libgpg-error/blob/master/src/err-codes.h.in#L253
- https://github.com/gpg/gnupg/blob/master/dirmngr/dns-stuff.c#L1610

This means that `gpg` could work with DNS servers differently than other tools. 

The fix is to try to get the IP address of the GPG keyserver and explicitly pass it to the gpg tool to avoid DNS-related issues.

_Changelog_:

- Retry logic updated: Additional tries with explicitly passing the keyserver IP address were added;
- The`dnsutils` package added to dependencies;

**Attached related issue**:

- #686

**Checklist**:

- [x] Checked that applied changes work as expected
