### PR TITLE
[Docker-in-docker] Updates docker-init scripts

### DIFF
--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "name": "Docker (Docker-in-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
     "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -362,8 +362,6 @@ EOF
 tee -a /usr/local/share/docker-init.sh > /dev/null \
 << 'EOF'
 dockerd_start="AZURE_DNS_AUTO_DETECTION=${AZURE_DNS_AUTO_DETECTION} DOCKER_DEFAULT_ADDRESS_POOL=${DOCKER_DEFAULT_ADDRESS_POOL} $(cat << 'INNEREOF'
-    # Stop dockerd and containerd in case they are already running
-    docker info > /dev/null 2>&1 && pkill dockerd && pkill containerd
     # explicitly remove dockerd and containerd PID file to ensure that it can start properly if it was stopped uncleanly
     find /run /var/run -iname 'docker*.pid' -delete || :
     find /run /var/run -iname 'container*.pid' -delete || :
@@ -478,10 +476,12 @@ do
         retry_count=`expr $retry_count + 1`
     done
     
-    if [ "${docker_ok}" != "true" ]; then
+    if [ "${docker_ok}" != "true" ] && [ "${retry_docker_start_count}" != "4" ]; then
         echo "(*) Failed to start docker, retrying..."
-        sudo_if pkill dockerd
-        sudo_if pkill containerd
+        set +e
+            sudo_if pkill dockerd
+            sudo_if pkill containerd
+        set -e
     fi
     
     retry_docker_start_count=`expr $retry_docker_start_count + 1`


### PR DESCRIPTION
- If we run `pkill` on a process which is already terminated, then it returns exit code 1. This could result failing of the docker-init script. Hence, wrap it within `set` 
- Let's not kill docker daemon at the start of docker-init script if docker is running, if that is needed then the retry logic would take care of it.