### PR TITLE
[Apple ARM - NVIDIA CUDA] Skip install

### DIFF
--- a/src/nvidia-cuda/devcontainer-feature.json
+++ b/src/nvidia-cuda/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "nvidia-cuda",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "name": "NVIDIA CUDA",
   "description": "Installs shared libraries for NVIDIA CUDA.",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/nvidia-cuda",

--- a/src/nvidia-cuda/install.sh
+++ b/src/nvidia-cuda/install.sh
@@ -17,6 +17,11 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 1
 fi
 
+if [[ $(uname -m) = "arm64" ]]; then
+    echo -e "NVIDIA® CUDA Toolkit no longer supports development or running applications on machines with the 'arm64' architecture. Please consider an alternative or check for updates or support for your architecture."
+    exit 1
+fi
+
 apt_get_update()
 {
     if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then


### PR DESCRIPTION
Skip installation for ARM chip because Nvdia Cuda Toolkit is no longer supported.

Reference: [https://developer.nvidia.com/nvidia-cuda-toolkit-11_7_0-developer-tools-mac-hosts](https://developer.nvidia.com/nvidia-cuda-toolkit-11_7_0-developer-tools-mac-hosts)
PR related to this discussion : [https://github.com/orgs/devcontainers/discussions/78#discussioncomment-7343974](https://github.com/orgs/devcontainers/discussions/78#discussioncomment-7343974)