### PR TITLE
[common-utils] Bug fix: zsh missing rc snippet

### DIFF
--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "common-utils",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "name": "Common Utilities",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/common-utils",
     "description": "Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.",

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -467,7 +467,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
         else
             global_rc_path="/etc/zsh/zshrc"
         fi
-        cat "${FEATURE_DIR}/scripts/rc_snippet.sh" >> /etc/zshrc
+        cat "${FEATURE_DIR}/scripts/rc_snippet.sh" >> ${global_rc_path}
         ZSH_ALREADY_INSTALLED="true"
     fi
 
@@ -483,18 +483,12 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
         chsh --shell /bin/zsh ${USERNAME}
     fi
 
-    # Adapted, simplified inline Oh My Zsh! install steps that adds RC snippet and defaults to a codespaces theme.
+    # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
     # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     if [ "${INSTALL_OH_MY_ZSH}" = "true" ]; then
         user_rc_file="${user_home}/.zshrc"
         oh_my_install_dir="${user_home}/.oh-my-zsh"
         template_path="${oh_my_install_dir}/templates/zshrc.zsh-template"
-
-        if [ "${ZSH_RC_SNIPPET_ALREADY_ADDED}" != "true" ]; then
-            cat "${FEATURE_DIR}/scripts/rc_snippet.sh" >> ${user_rc_file}
-            ZSH_RC_SNIPPET_ALREADY_ADDED="true"
-        fi
-
         if [ ! -d "${oh_my_install_dir}" ]; then
             umask g-w,o-w
             mkdir -p ${oh_my_install_dir}
@@ -518,7 +512,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
 
         # Add devcontainer .zshrc template
         if [ "$INSTALL_OH_MY_ZSH_CONFIG" = "true" ]; then
-            echo -e "$(cat "${template_path}")\nDISABLE_AUTO_UPDATE=true\nDISABLE_UPDATE_PROMPT=true" >> ${user_rc_file}
+            echo -e "$(cat "${template_path}")\nDISABLE_AUTO_UPDATE=true\nDISABLE_UPDATE_PROMPT=true" > ${user_rc_file}
             sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="devcontainers"/g' ${user_rc_file}
         fi
 
@@ -570,7 +564,6 @@ echo -e "\
     LOCALE_ALREADY_SET=${LOCALE_ALREADY_SET}\n\
     EXISTING_NON_ROOT_USER=${EXISTING_NON_ROOT_USER}\n\
     RC_SNIPPET_ALREADY_ADDED=${RC_SNIPPET_ALREADY_ADDED}\n\
-    ZSH_RC_SNIPPET_ALREADY_ADDED=${ZSH_RC_SNIPPET_ALREADY_ADDED}\n\
     ZSH_ALREADY_INSTALLED=${ZSH_ALREADY_INSTALLED}" > "${MARKER_FILE}"
 
 echo "Done!"

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -490,7 +490,10 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
         oh_my_install_dir="${user_home}/.oh-my-zsh"
         template_path="${oh_my_install_dir}/templates/zshrc.zsh-template"
 
-        cat "${FEATURE_DIR}/scripts/rc_snippet.sh" >> ${user_rc_file}
+        if [ "${ZSH_RC_SNIPPET_ALREADY_ADDED}" != "true" ]; then
+            cat "${FEATURE_DIR}/scripts/rc_snippet.sh" >> ${user_rc_file}
+            ZSH_RC_SNIPPET_ALREADY_ADDED="true"
+        fi
 
         if [ ! -d "${oh_my_install_dir}" ]; then
             umask g-w,o-w
@@ -567,6 +570,7 @@ echo -e "\
     LOCALE_ALREADY_SET=${LOCALE_ALREADY_SET}\n\
     EXISTING_NON_ROOT_USER=${EXISTING_NON_ROOT_USER}\n\
     RC_SNIPPET_ALREADY_ADDED=${RC_SNIPPET_ALREADY_ADDED}\n\
+    ZSH_RC_SNIPPET_ALREADY_ADDED=${ZSH_RC_SNIPPET_ALREADY_ADDED}\n\
     ZSH_ALREADY_INSTALLED=${ZSH_ALREADY_INSTALLED}" > "${MARKER_FILE}"
 
 echo "Done!"

--- a/test/common-utils/configure_zsh_as_default_shell.sh
+++ b/test/common-utils/configure_zsh_as_default_shell.sh
@@ -9,6 +9,7 @@ source dev-container-features-test-lib
 check "default-shell-is-zsh" bash -c "getent passwd $(whoami) | awk -F: '{ print $7 }' | grep '/bin/zsh'"
 # check it overrides the ~/.zshrc with default dev containers template
 check "default-zshrc-is-dev-container-template" bash -c "cat ~/.zshrc | grep ZSH_THEME | grep devcontainers"
+check "zsh-path-contains-local-bin" zsh -l -c "echo $PATH | grep '/home/devcontainer/.local/bin'"
 
 # Report result
 reportResults

--- a/test/common-utils/configure_zsh_as_default_shell.sh
+++ b/test/common-utils/configure_zsh_as_default_shell.sh
@@ -11,5 +11,6 @@ check "default-shell-is-zsh" bash -c "getent passwd $(whoami) | awk -F: '{ print
 check "default-zshrc-is-dev-container-template" bash -c "cat ~/.zshrc | grep ZSH_THEME | grep devcontainers"
 check "zsh-path-contains-local-bin" zsh -l -c "echo $PATH | grep '/home/devcontainer/.local/bin'"
 
+cat /etc/zshrc
 # Report result
 reportResults

--- a/test/common-utils/configure_zsh_as_default_shell.sh
+++ b/test/common-utils/configure_zsh_as_default_shell.sh
@@ -11,6 +11,5 @@ check "default-shell-is-zsh" bash -c "getent passwd $(whoami) | awk -F: '{ print
 check "default-zshrc-is-dev-container-template" bash -c "cat ~/.zshrc | grep ZSH_THEME | grep devcontainers"
 check "zsh-path-contains-local-bin" zsh -l -c "echo $PATH | grep '/home/devcontainer/.local/bin'"
 
-cat /etc/zshrc
 # Report result
 reportResults

--- a/test/common-utils/scenarios.json
+++ b/test/common-utils/scenarios.json
@@ -108,12 +108,14 @@
         }
     },
     "configure_zsh_as_default_shell": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "image": "ubuntu",
         "features": {
             "common-utils": {
+                "installZsh": true,
                 "configureZshAsDefaultShell": true
             }
-        }
+        },
+        "remoteUser": "devcontainer"
     },
     "configure_zsh_no_template_second_step": {
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",


### PR DESCRIPTION
Bug fixes: 
- We were incorrectly adding [rc_snippet.sh](https://github.com/devcontainers/features/blob/main/src/common-utils/scripts/rc_snippet.sh) for zsh. 
- `zsh` uses `.zprofile` instead of `.profile`. Hence, we source `.profile` within `~/.zprofile`. See https://superuser.com/questions/187639/zsh-not-hitting-profile/187673#187673