### PR TITLE
Remove rebornix.Ruby extension

### DIFF
--- a/src/ruby/devcontainer-feature.json
+++ b/src/ruby/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "name": "Ruby (via rvm)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/ruby",
     "description": "Installs Ruby, rvm, rbenv, common Ruby utilities, and needed dependencies.",
@@ -21,7 +21,6 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "rebornix.Ruby",
                 "shopify.ruby-lsp"
             ]
         }


### PR DESCRIPTION
The rebornix.Ruby extension is [now deprecated](https://github.com/rubyide/vscode-ruby/commit/79031948d032e97cf2a5116e27c167ade5125e15). 

This PR removes it from the list of preinstalled extension for the Ruby feature devcontainer.
