### PR TITLE
Update Oryx feature to install if a newer version of .NET is present

### DIFF
--- a/src/oryx/install.sh
+++ b/src/oryx/install.sh
@@ -133,12 +133,12 @@ if dotnet --version > /dev/null ; then
 fi
 
 # Oryx needs to be built with .NET 7
-if [[ "${DOTNET_BINARY}" = "" ]] || [[ "$(dotnet --version)" != *"7"* ]] ; then
-    echo "'dotnet 7' was not detected. Attempting to install .NET 7 to build oryx."
+if [[ "${DOTNET_BINARY}" = "" ]] || [[ "$(dotnet --list-sdks)" != *"7.0."* ]] ; then
+    echo "'.NET 7.0.x' was not detected. Attempting to install .NET 7 to build oryx."
     install_dotnet_using_apt
 
     if ! dotnet --version > /dev/null ; then
-        echo "(!) Please install Dotnet before installing Oryx"
+        echo "(!) Please install .NET before installing Oryx"
         exit 1
     fi
 

--- a/src/oryx/install.sh
+++ b/src/oryx/install.sh
@@ -158,10 +158,10 @@ SOLUTION_FILE_NAME="Oryx.sln"
 echo "Building solution '$SOLUTION_FILE_NAME'..."
 
 cd $GIT_ORYX
-${DOTNET_BINARY} build "$SOLUTION_FILE_NAME" -c Debug
+${DOTNET_BINARY} build --configuration Debug --framework net7.0 "$SOLUTION_FILE_NAME"
 
-${DOTNET_BINARY} publish -property:ValidateExecutableReferencesMatchSelfContained=false -r linux-x64 -o ${BUILD_SCRIPT_GENERATOR} -c Release $GIT_ORYX/src/BuildScriptGeneratorCli/BuildScriptGeneratorCli.csproj
-${DOTNET_BINARY} publish -r linux-x64 -o ${BUILD_SCRIPT_GENERATOR} -c Release $GIT_ORYX/src/BuildServer/BuildServer.csproj
+${DOTNET_BINARY} publish --configuration Release --runtime linux-x64 --output ${BUILD_SCRIPT_GENERATOR} --framework net7.0 --self-contained -property:ValidateExecutableReferencesMatchSelfContained=false $GIT_ORYX/src/BuildScriptGeneratorCli/BuildScriptGeneratorCli.csproj
+${DOTNET_BINARY} publish --configuration Release --runtime linux-x64 --output ${BUILD_SCRIPT_GENERATOR} --framework net7.0 --self-contained $GIT_ORYX/src/BuildServer/BuildServer.csproj
 
 chmod a+x ${BUILD_SCRIPT_GENERATOR}/GenerateBuildScript
 


### PR DESCRIPTION
Oryx fails to install if a newer version of .NET is present.

I suspect this is due to a missing `--framework` argument.

I also took this opportunity to spell out the full name of other `dotnet build` and `dotnet publish` arguments to make it easier to debug for the person that comes next.