### PR TITLE
Fix common-utils installation on RHEL (and friends)

### DIFF
--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -222,7 +222,9 @@ install_redhat_packages() {
         package_list="${package_list} zsh"
     fi
 
-    ${install_cmd} -y install ${package_list}
+    if [ -n "${package_list}" ]; then
+        ${install_cmd} -y install ${package_list}
+    fi
 
     # Get to latest versions of all packages
     if [ "${UPGRADE_PACKAGES}" = "true" ]; then

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -189,11 +189,11 @@ install_redhat_packages() {
             man-db \
             strace"
 
-    # rockylinux:9 installs 'curl-minimal' which clashes with 'curl'
-    # Install 'curl' for every OS except this rockylinux:9
-    if [[ "${ID}" = "rocky" ]] && [[ "${VERSION}" != *"9."* ]]; then
-        package_list="${package_list} curl"
-    fi
+        # rockylinux:9 installs 'curl-minimal' which clashes with 'curl'
+        # Install 'curl' for every OS except this rockylinux:9
+        if [[ "${ID}" = "rocky" ]] && [[ "${VERSION}" != *"9."* ]]; then
+            package_list="${package_list} curl"
+        fi
 
         # Install OpenSSL 1.0 compat if needed
         if ${install_cmd} -q list compat-openssl10 >/dev/null 2>&1; then


### PR DESCRIPTION
On RHEL (and derivatives) the installation of the common-utils feature
could fail if the feature ran before (i.e., `PACKAGES_ALREADY_INSTALLED`
is set) and if either `INSTALL_ZSH` is false, or zsh was installed
earlier and `ZSH_ALREADY_INSTALLED` is true.

In these cases the script the `package_list` is empty, and `dnf`
terminates with the following error message:

```
usage: dnf install [-c [config file]] [-q] [-v] [--version]
                   [--installroot [path]] [--nodocs] [--noplugins]
                   [--enableplugin [plugin]] [--disableplugin [plugin]]
                   [--releasever RELEASEVER] [--setopt SETOPTS]
                   [--skip-broken] [-h] [--allowerasing] [-b | --nobest] [-C]
                   [-R [minutes]] [-d [debug level]] [--debugsolver]
                   [--showduplicates] [-e ERRORLEVEL] [--obsoletes]
                   [--rpmverbosity [debug level name]] [-y] [--assumeno]
                   [--enablerepo [repo]] [--disablerepo [repo] | --repo
                   [repo]] [--enable | --disable] [-x [package]]
                   [--disableexcludes [repo]] [--repofrompath [repo,path]]
                   [--noautoremove] [--nogpgcheck] [--color COLOR] [--refresh]
                   [-4] [-6] [--destdir DESTDIR] [--downloadonly]
                   [--comment COMMENT] [--bugfix] [--enhancement]
                   [--newpackage] [--security] [--advisory ADVISORY]
                   [--bz BUGZILLA] [--cve CVES]
                   [--sec-severity {Critical,Important,Moderate,Low}]
                   [--forcearch ARCH]
                   PACKAGE [PACKAGE ...]
dnf install: error: the following arguments are required: PACKAGE
```

Fix the problem by running `dnf` only with a non-zero `package_list`.
