### PR TITLE
Fix `.zprofile` is owned by root

### DIFF
--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "common-utils",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "name": "Common Utilities",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/common-utils",
     "description": "Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.",

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -461,6 +461,7 @@ fi
 if [ "${INSTALL_ZSH}" = "true" ]; then
    if [ ! -f "${user_home}/.zprofile" ]; then
         touch "${user_home}/.zprofile"
+        echo 'source $HOME/.profile' >> "${user_home}/.zprofile" # TODO: Reconsider adding '.profile' to '.zprofile'
         chown ${USERNAME}:${group_name} "${user_home}/.zprofile"
     fi
 

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -459,6 +459,11 @@ fi
 
 # Optionally configure zsh and Oh My Zsh!
 if [ "${INSTALL_ZSH}" = "true" ]; then
+   if [ ! -f "${user_home}/.zprofile" ]; then
+        touch "${user_home}/.zprofile"
+        chown ${USERNAME}:${group_name} "${user_home}/.zprofile"
+    fi
+
     if [ "${ZSH_ALREADY_INSTALLED}" != "true" ]; then
         if [ "${ADJUSTED_ID}" = "rhel" ]; then
              global_rc_path="/etc/zshrc"

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -459,10 +459,6 @@ fi
 
 # Optionally configure zsh and Oh My Zsh!
 if [ "${INSTALL_ZSH}" = "true" ]; then
-    if [ ! -f "${user_home}/.zprofile" ] || ! grep -Fxq 'source $HOME/.profile' "${user_home}/.zprofile" ; then
-        echo 'source $HOME/.profile' >> "${user_home}/.zprofile"
-    fi
-
     if [ "${ZSH_ALREADY_INSTALLED}" != "true" ]; then
         if [ "${ADJUSTED_ID}" = "rhel" ]; then
              global_rc_path="/etc/zshrc"

--- a/test/common-utils/configure_zsh_as_default_shell.sh
+++ b/test/common-utils/configure_zsh_as_default_shell.sh
@@ -11,5 +11,7 @@ check "default-shell-is-zsh" bash -c "getent passwd $(whoami) | awk -F: '{ print
 check "default-zshrc-is-dev-container-template" bash -c "cat ~/.zshrc | grep ZSH_THEME | grep devcontainers"
 check "zsh-path-contains-local-bin" zsh -l -c "echo $PATH | grep '/home/devcontainer/.local/bin'"
 
+check "Ensure .zprofile is owned by remoteUser" bash -c "stat -c '%U' home/devcontainer/.zprofile | grep devcontainer"
+
 # Report result
 reportResults

--- a/test/common-utils/configure_zsh_as_default_shell.sh
+++ b/test/common-utils/configure_zsh_as_default_shell.sh
@@ -11,7 +11,7 @@ check "default-shell-is-zsh" bash -c "getent passwd $(whoami) | awk -F: '{ print
 check "default-zshrc-is-dev-container-template" bash -c "cat ~/.zshrc | grep ZSH_THEME | grep devcontainers"
 check "zsh-path-contains-local-bin" zsh -l -c "echo $PATH | grep '/home/devcontainer/.local/bin'"
 
-check "Ensure .zprofile is owned by remoteUser" bash -c "stat -c '%U' home/devcontainer/.zprofile | grep devcontainer"
+check "Ensure .zprofile is owned by remoteUser" bash -c "stat -c '%U' /home/devcontainer/.zprofile | grep devcontainer"
 
 # Report result
 reportResults


### PR DESCRIPTION
We got a report that the `remoteUser`'s .zprofile was owned by root, which was causing subsequent tools to fail to write to that file (eg: updating PATH).  Along the way noticed some interesting changes introduces in #736 that I think might be the cause, or at least appears to be an anti-pattern to me.

This change reverts [a previous change](https://github.com/devcontainers/features/pull/736/files#diff-3e71c0a0669a0410f7dd0d8f2b83f3b6bf6b525d3eabd354f19f32822da669fcR460-R463).  I don't think we should be sourcing a `.profile` at all in `.zprofile` (mixing bash and zsh scripts).  There's perhaps some extra configuration that we need to port over to `.zprofile`, which should be reviewed and added in a follow up change.


context/ [slack](https://github.slack.com/archives/C9XJ6156E/p1701898167089739)