### PR TITLE
Add RHEL support to git feature

### DIFF
--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -189,11 +189,11 @@ install_redhat_packages() {
             man-db \
             strace"
 
-    # rockylinux:9 installs 'curl-minimal' which clashes with 'curl'
-    # Install 'curl' for every OS except this rockylinux:9
-    if [[ "${ID}" = "rocky" ]] && [[ "${VERSION}" != *"9."* ]]; then
-        package_list="${package_list} curl"
-    fi
+        # rockylinux:9 installs 'curl-minimal' which clashes with 'curl'
+        # Install 'curl' for every OS except this rockylinux:9
+        if [[ "${ID}" = "rocky" ]] && [[ "${VERSION}" != *"9."* ]]; then
+            package_list="${package_list} curl"
+        fi
 
         # Install OpenSSL 1.0 compat if needed
         if ${install_cmd} -q list compat-openssl10 >/dev/null 2>&1; then
@@ -222,7 +222,9 @@ install_redhat_packages() {
         package_list="${package_list} zsh"
     fi
 
-    ${install_cmd} -y install ${package_list}
+    if [ -n "${package_list}" ]; then
+        ${install_cmd} -y install ${package_list}
+    fi
 
     # Get to latest versions of all packages
     if [ "${UPGRADE_PACKAGES}" = "true" ]; then

--- a/src/git/NOTES.md
+++ b/src/git/NOTES.md
@@ -2,6 +2,6 @@
 
 ## OS Support
 
-This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+This Feature should work on recent versions of Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, and RockyLinux distributions with the `apt`, `yum`, or `dnf` package manager installed.
 
 `bash` is required to execute the `install.sh` script.

--- a/src/git/README.md
+++ b/src/git/README.md
@@ -22,7 +22,7 @@ Install an up-to-date version of Git, built from source as needed. Useful for wh
 
 ## OS Support
 
-This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+This Feature should work on recent versions of Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, and RockyLinux distributions with the `apt`, `yum`, or `dnf` package manager installed.
 
 `bash` is required to execute the `install.sh` script.
 

--- a/src/git/install.sh
+++ b/src/git/install.sh
@@ -16,15 +16,47 @@ keyserver hkp://keyserver.ubuntu.com:80
 keyserver hkps://keys.openpgp.org
 keyserver hkp://keyserver.pgp.com"
 
-set -e
-
-# Clean up
-rm -rf /var/lib/apt/lists/*
-
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
+
+# Bring in ID, ID_LIKE, VERSION_ID, VERSION_CODENAME
+. /etc/os-release
+# Get an adjusted ID independent of distro variants
+if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
+    ADJUSTED_ID="debian"
+elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"mariner"* ]]; then
+    ADJUSTED_ID="rhel"
+    VERSION_CODENAME="${ID}{$VERSION_ID}"
+else
+    echo "Linux distro ${ID} not supported."
+    exit 1
+fi
+
+if [ ${ADJUSTED_ID} = "rhel" ]; then
+    if type dnf > /dev/null 2>&1; then
+        INSTALL_CMD=dnf
+    elif type microdnf > /dev/null 2>&1; then
+        INSTALL_CMD=microdnf
+    else
+        INSTALL_CMD=yum
+    fi
+fi
+
+# Clean up
+clean_up() {
+    case $ADJUSTED_ID in
+        debian)
+            rm -rf /var/lib/apt/lists/*
+            ;;
+        rhel)
+            rm -rf /var/cache/dnf/*
+            rm -rf /var/cache/yum/*
+            ;;
+    esac
+}
+clean_up
 
 # Import the specified key in a variable name passed in as 
 receive_gpg_keys() {
@@ -61,40 +93,66 @@ receive_gpg_keys() {
     fi
 }
 
-apt_get_update()
-{
-    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
-        echo "Running apt-get update..."
-        apt-get update -y
+pkg_mgr_update() {
+    if type apt >/dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            apt-get update -y
+        fi
+    elif [ ${INSTALL_CMD} = "dnf" ] || [ ${INSTALL_CMD} = "yum" ]; then
+        if [ "$(find /var/cache/${INSTALL_CMD}/* | wc -l)" = "0" ]; then
+            echo "Running ${INSTALL_CMD} check-update ..."
+            ${INSTALL_CMD} check-update
+        fi
     fi
 }
 
+
 # Checks if packages are installed and installs them if not
 check_packages() {
-    if ! dpkg -s "$@" > /dev/null 2>&1; then
-        apt_get_update
-        apt-get -y install --no-install-recommends "$@"
+    if type apt >/dev/null 2>&1; then
+        if ! dpkg -s "$@" > /dev/null 2>&1; then
+            pkg_mgr_update
+            apt-get -y install --no-install-recommends "$@"
+        fi
+    elif [ ${INSTALL_CMD} = "dnf" ] || [ ${INSTALL_CMD} = "yum" ]; then
+        _num_pkgs=$(echo "$@" | tr ' ' \\012 | wc -l)
+        _num_installed=$(${INSTALL_CMD} -C list installed "$@" | sed '1,/^Installed/d' | wc -l)
+        if [ ${_num_pkgs} != ${_num_installed} ]; then
+            pkg_mgr_update
+            ${INSTALL_CMD} -y install "$@"
+        fi
+    elif [ ${INSTALL_CMD} = "microdnf" ]; then
+        ${INSTALL_CMD} -y install \
+            --refresh \
+            --best \
+            --nodocs \
+            --noplugins \
+            --setopt=install_weak_deps=0 \
+            "$@"
+    else
+        echo "Linux distro ${ID} not supported."
+        exit 1
     fi
 }
 
 export DEBIAN_FRONTEND=noninteractive
 
-# Source /etc/os-release to get OS info
-. /etc/os-release
+# Debian / Ubuntu packages
 
 # If the os provided version is "good enough", just install that.
 if [ ${GIT_VERSION} = "os-provided" ] || [ ${GIT_VERSION} = "system" ]; then
     if type git > /dev/null 2>&1; then
         echo "Detected existing system install: $(git version)"
         # Clean up
-        rm -rf /var/lib/apt/lists/*
+        clean_up
         exit 0
     fi
 
-    echo "Installing git from OS apt repository"
+    echo "Installing git from OS apt/dnf/microdnf/yum repository"
     check_packages git
     # Clean up
-    rm -rf /var/lib/apt/lists/*
+    clean_up
     exit 0
 fi
 
@@ -112,7 +170,35 @@ if ([ "${GIT_VERSION}" = "latest" ] || [ "${GIT_VERSION}" = "lts" ] || [ "${GIT_
 fi
 
 # Install required packages to build if missing
-check_packages build-essential curl ca-certificates tar gettext libssl-dev zlib1g-dev libcurl?-openssl-dev libexpat1-dev
+if [ "${ADJUSTED_ID}" = "debian" ]; then
+
+    check_packages build-essential curl ca-certificates tar gettext libssl-dev zlib1g-dev libcurl?-openssl-dev libexpat1-dev
+
+    check_packages libpcre2-dev
+
+    if [ "${VERSION_CODENAME}" = "focal" ] || [ "${VERSION_CODENAME}" = "bullseye" ]; then
+        check_packages libpcre2-posix2
+    elif [ "${VERSION_CODENAME}" = "bionic" ] || [ "${VERSION_CODENAME}" = "buster" ]; then
+        check_packages libpcre2-posix0
+    else
+        check_packages libpcre2-posix3
+    fi
+
+elif [ "${ADJUSTED_ID}" = "rhel" ]; then
+
+    if [ $VERSION_CODENAME = "centos7" ]; then
+        check_packages centos-release-scl 
+        check_packages devtoolset-11
+        source /opt/rh/devtoolset-11/enable
+    else
+        check_packages gcc
+    fi
+
+    check_packages libcurl-devel expat-devel gettext-devel openssl-devel perl-devel zlib-devel cmake pcre2-devel tar gzip
+    if [ $VERSION_ID -lt "9" ]; then
+        check_packages curl
+    fi
+fi
 
 # Partial version matching
 if [ "$(echo "${GIT_VERSION}" | grep -o '\.' | wc -l)" != "2" ]; then
@@ -131,21 +217,11 @@ if [ "$(echo "${GIT_VERSION}" | grep -o '\.' | wc -l)" != "2" ]; then
     fi
 fi
 
-check_packages libpcre2-dev
-
-if [ "${VERSION_CODENAME}" = "focal" ] || [ "${VERSION_CODENAME}" = "bullseye" ]; then
-    check_packages libpcre2-posix2
-elif [ "${VERSION_CODENAME}" = "bionic" ] || [ "${VERSION_CODENAME}" = "buster" ]; then
-    check_packages libpcre2-posix0
-else
-    check_packages libpcre2-posix3
-fi
-
 echo "Downloading source for ${GIT_VERSION}..."
 curl -sL https://github.com/git/git/archive/v${GIT_VERSION}.tar.gz | tar -xzC /tmp 2>&1
 echo "Building..."
 cd /tmp/git-${GIT_VERSION}
 make -s USE_LIBPCRE=YesPlease prefix=/usr/local sysconfdir=/etc all && make -s USE_LIBPCRE=YesPlease prefix=/usr/local sysconfdir=/etc install 2>&1
 rm -rf /tmp/git-${GIT_VERSION}
-rm -rf /var/lib/apt/lists/*
+clean_up
 echo "Done!"

--- a/test/common-utils/alma-8.sh
+++ b/test/common-utils/alma-8.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+. /etc/os-release
+check "non-root user" test "$(whoami)" = "devcontainer"
+check "distro" test "${PLATFORM_ID}" = "platform:el9"
+check "curl" curl --version
+check "jq" jq  --version
+
+# Report result
+reportResults

--- a/test/common-utils/alma-9.sh
+++ b/test/common-utils/alma-9.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+. /etc/os-release
+check "non-root user" test "$(whoami)" = "devcontainer"
+check "distro" test "${PLATFORM_ID}" = "platform:el9"
+check "curl" curl --version
+check "jq" jq  --version
+
+# Report result
+reportResults

--- a/test/common-utils/alma-minimal-8.sh
+++ b/test/common-utils/alma-minimal-8.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+. /etc/os-release
+check "non-root user" test "$(whoami)" = "devcontainer"
+check "distro" test "${PLATFORM_ID}" = "platform:el9"
+check "curl" curl --version
+check "jq" jq  --version
+
+# Report result
+reportResults

--- a/test/common-utils/alma-minimal-9.sh
+++ b/test/common-utils/alma-minimal-9.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+. /etc/os-release
+check "non-root user" test "$(whoami)" = "devcontainer"
+check "distro" test "${PLATFORM_ID}" = "platform:el9"
+check "curl" curl --version
+check "jq" jq  --version
+
+# Report result
+reportResults

--- a/test/common-utils/scenarios.json
+++ b/test/common-utils/scenarios.json
@@ -41,6 +41,34 @@
             "common-utils": {}
         }
     },
+    "alma-minimal-8": {
+        "image": "almalinux:8-minimal",
+        "remoteUser": "devcontainer",
+        "features": {
+            "common-utils": {}
+        }
+    },
+    "alma-minimal-9": {
+        "image": "almalinux:9-minimal",
+        "remoteUser": "devcontainer",
+        "features": {
+            "common-utils": {}
+        }
+    },
+    "alma-8": {
+        "image": "almalinux:8",
+        "remoteUser": "devcontainer",
+        "features": {
+            "common-utils": {}
+        }
+    },
+    "alma-9": {
+        "image": "almalinux:9",
+        "remoteUser": "devcontainer",
+        "features": {
+            "common-utils": {}
+        }
+    },
     "rocky-8": {
         "image": "rockylinux:8",
         "remoteUser": "devcontainer",
@@ -48,7 +76,7 @@
             "common-utils": {}
         }
     },
-    "rocky-9": {
+   "rocky-9": {
         "image": "rockylinux:9",
         "remoteUser": "devcontainer",
         "features": {

--- a/test/git/install_git_from_src_alma-8-minimal.sh
+++ b/test/git/install_git_from_src_alma-8-minimal.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "version" git  --version
+check "gettext-devel" rpm -q gettext-devel
+
+cd /tmp && git clone https://github.com/devcontainers/feature-starter.git
+cd feature-starter
+check "perl" bash -c "git -c grep.patternType=perl grep -q 'a.+b'"
+
+# Report result
+reportResults

--- a/test/git/install_git_from_src_alma-8.sh
+++ b/test/git/install_git_from_src_alma-8.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "version" git  --version
+check "gettext-devel" rpm -q gettext-devel
+
+cd /tmp && git clone https://github.com/devcontainers/feature-starter.git
+cd feature-starter
+check "perl" bash -c "git -c grep.patternType=perl grep -q 'a.+b'"
+
+# Report result
+reportResults

--- a/test/git/install_git_from_src_alma-9-minimal.sh
+++ b/test/git/install_git_from_src_alma-9-minimal.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "version" git  --version
+check "gettext-devel" rpm -q gettext-devel
+
+cd /tmp && git clone https://github.com/devcontainers/feature-starter.git
+cd feature-starter
+check "perl" bash -c "git -c grep.patternType=perl grep -q 'a.+b'"
+
+# Report result
+reportResults

--- a/test/git/install_git_from_src_alma-9.sh
+++ b/test/git/install_git_from_src_alma-9.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "version" git  --version
+check "gettext-devel" rpm -q gettext-devel
+
+cd /tmp && git clone https://github.com/devcontainers/feature-starter.git
+cd feature-starter
+check "perl" bash -c "git -c grep.patternType=perl grep -q 'a.+b'"
+
+# Report result
+reportResults

--- a/test/git/install_git_from_src_centos-7.sh
+++ b/test/git/install_git_from_src_centos-7.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "version" git  --version
+check "gettext-devel" rpm -q gettext-devel
+
+cd /tmp && git clone https://github.com/devcontainers/feature-starter.git
+cd feature-starter
+check "perl" bash -c "git -c grep.patternType=perl grep -q 'a.+b'"
+
+# Report result
+reportResults

--- a/test/git/scenarios.json
+++ b/test/git/scenarios.json
@@ -43,5 +43,50 @@
                 "ppa": "false"
             }
         }
+    },
+    "install_git_from_src_centos-7": {
+        "image": "centos:centos7",
+        "features": {
+            "git": {
+                "version": "latest",
+                "ppa": "false"
+            }
+        }
+    },
+    "install_git_from_src_alma-8": {
+        "image": "almalinux:8",
+        "features": {
+            "git": {
+                "version": "latest",
+                "ppa": "false"
+            }
+        }
+    },
+    "install_git_from_src_alma-9": {
+        "image": "almalinux:9",
+        "features": {
+            "git": {
+                "version": "latest",
+                "ppa": "false"
+            }
+        }
+    },
+    "install_git_from_src_alma-8-minimal": {
+        "image": "almalinux:8-minimal",
+        "features": {
+            "git": {
+                "version": "latest",
+                "ppa": "false"
+            }
+        }
+    },
+    "install_git_from_src_alma-9-minimal": {
+        "image": "almalinux:9-minimal",
+        "features": {
+            "git": {
+                "version": "latest",
+                "ppa": "false"
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR adds RHEL support to git feature.

CentOS 7, RHEL/Alma/Rocky Linux 8 & 9 should all work. Testing was done with centos7, almalinux 8 and almalinux 9.

Includes ability to build feature on alma minimal base images.

resolves #781 