### PR TITLE
[Docker-outside-of-docker] Increase backlog depth for socat proxy (#789)

### DIFF
--- a/src/docker-outside-of-docker/devcontainer-feature.json
+++ b/src/docker-outside-of-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-outside-of-docker",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "name": "Docker (docker-outside-of-docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker",
     "description": "Re-use the host docker socket, adding the Docker CLI to a container. Feature invokes a script to enable using a forwarded Docker socket within a container to run Docker commands.",

--- a/src/docker-outside-of-docker/install.sh
+++ b/src/docker-outside-of-docker/install.sh
@@ -329,7 +329,7 @@ if [ "${ENABLE_NONROOT_DOCKER}" = "true" ] && [ "${SOURCE_SOCKET}" != "${TARGET_
             log "Enabling socket proxy."
             log "Proxying ${SOURCE_SOCKET} to ${TARGET_SOCKET} for vscode"
             sudoIf rm -rf ${TARGET_SOCKET}
-            (sudoIf socat UNIX-LISTEN:${TARGET_SOCKET},fork,mode=660,user=${USERNAME} UNIX-CONNECT:${SOURCE_SOCKET} 2>&1 | sudoIf tee -a \${SOCAT_LOG} > /dev/null & echo "\$!" | sudoIf tee \${SOCAT_PID} > /dev/null)
+            (sudoIf socat UNIX-LISTEN:${TARGET_SOCKET},fork,mode=660,user=${USERNAME},backlog=128 UNIX-CONNECT:${SOURCE_SOCKET} 2>&1 | sudoIf tee -a \${SOCAT_LOG} > /dev/null & echo "\$!" | sudoIf tee \${SOCAT_PID} > /dev/null)
         else
             log "Socket proxy already running."
         fi


### PR DESCRIPTION
The underlying problem described in #789 is that the main `accept(2)` loop in `socat` is single threaded and is easily overwhelmed by docker compose, which can create connection attempts in multiple cores.

Fortunately the listening socket already has a backlog which we can increase from [socat's default of 5](http://www.dest-unreach.org/socat/doc/socat.html#GROUP_LISTEN).

In this PR I have chosen a depth of 128 as probably high enough for most devcontainer needs. If it isn't high enough this could be made tunable, but reevaluating the proxy implementation might be in order also.