### PR TITLE
Fix kubectl zsh completions typo

### DIFF
--- a/src/kubectl-helm-minikube/devcontainer-feature.json
+++ b/src/kubectl-helm-minikube/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "kubectl-helm-minikube",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "name": "Kubectl, Helm, and Minikube",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/kubectl-helm-minikube",
     "description": "Installs latest version of kubectl, Helm, and optionally minikube. Auto-detects latest versions and installs needed dependencies.",

--- a/src/kubectl-helm-minikube/install.sh
+++ b/src/kubectl-helm-minikube/install.sh
@@ -148,7 +148,7 @@ if [ ${KUBECTL_VERSION} != "none" ]; then
     kubectl completion bash > /etc/bash_completion.d/kubectl
 
     # kubectl zsh completion
-    if [ -e "${USERHOME}}/.oh-my-zsh" ]; then
+    if [ -e "${USERHOME}/.oh-my-zsh" ]; then
         mkdir -p "${USERHOME}/.oh-my-zsh/completions"
         kubectl completion zsh > "${USERHOME}/.oh-my-zsh/completions/_kubectl"
         chown -R "${USERNAME}" "${USERHOME}/.oh-my-zsh"


### PR DESCRIPTION
The kubectl-helm-minikube feature wasn't installing ZSH completions due to a typo. This is a quick fix.