### PR TITLE
Alpine - Install libssl1.1 only if available

### DIFF
--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -265,7 +265,6 @@ install_alpine_packages() {
             libstdc++ \
             krb5-libs \
             libintl \
-            libssl1.1 \
             lttng-ust \
             tzdata \
             userspace-rcu \
@@ -278,6 +277,12 @@ install_alpine_packages() {
             ncdu \
             shadow \
             strace
+
+        # # Include libssl1.1 if available (not available for 3.19 and newer)
+        LIBSSL1_PKG=libssl1.1
+        if [[ $(apk search --no-cache -a $LIBSSL1_PKG | grep $LIBSSL1_PKG) ]]; then
+            apk add --no-cache $LIBSSL1_PKG
+        fi
 
         # Install man pages - package name varies between 3.12 and earlier versions
         if apk info man > /dev/null 2>&1; then

--- a/test/common-utils/alpine-3-18.sh
+++ b/test/common-utils/alpine-3-18.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+. /etc/os-release
+check "non-root user" test "$(whoami)" = "devcontainer"
+check "distro" test "${ID}" = "alpine"
+check "bashrc" ls /etc/bash/bashrc
+check "libssl1.1 is installed" grep "libssl1.1" <(apk list --no-cache libssl1.1)
+
+# Report result
+reportResults

--- a/test/common-utils/scenarios.json
+++ b/test/common-utils/scenarios.json
@@ -162,6 +162,13 @@
             "common-utils": {}
         }
     },
+    "alpine-3-18": {
+        "image": "alpine:3.18",
+        "remoteUser": "devcontainer",
+        "features": {
+            "common-utils": {}
+        }
+    },
     "devcontainer-info": {
         "build": {
             "dockerfile": "Dockerfile"


### PR DESCRIPTION
Alpine repo for 3.19 does not include the outdated libssl1.1.
This is a blocker for upgrading alpine image to 3.19 https://github.com/devcontainers/images/issues/786, as the image uses on common-utils feature.

Error details:
https://github.com/devcontainers/images/actions/runs/7282516027/job/20100948870?pr=897#step:3:906