### PR TITLE
add `shared` config to build Python shared library

### DIFF
--- a/src/python/devcontainer-feature.json
+++ b/src/python/devcontainer-feature.json
@@ -32,6 +32,11 @@
       "default": false,
       "description": "Optimize Python for performance when compiled (slow)"
     },
+    "shared": {
+      "type": "boolean",
+      "default": false,
+      "description": "Build Python with the shared library files."
+    },
     "installPath": {
       "type": "string",
       "default": "/usr/local/python",

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -10,6 +10,7 @@
 PYTHON_VERSION="${VERSION:-"latest"}" # 'system' or 'os-provided' checks the base image first, else installs 'latest'
 INSTALL_PYTHON_TOOLS="${INSTALLTOOLS:-"true"}"
 OPTIMIZE_BUILD_FROM_SOURCE="${OPTIMIZE:-"false"}"
+SHARED_LIBS="${SHARED:-"false"}"
 PYTHON_INSTALL_PATH="${INSTALLPATH:-"/usr/local/python"}"
 OVERRIDE_DEFAULT_VERSION="${OVERRIDEDEFAULTVERSION:-"true"}"
 
@@ -264,7 +265,11 @@ install_from_source() {
     if [ "${OPTIMIZE_BUILD_FROM_SOURCE}" = "true" ]; then
         config_args="--enable-optimizations"
     fi
-    ./configure --prefix="${INSTALL_PATH}" --with-ensurepip=install ${config_args}
+    local shared_libs=""
+    if [ "${SHARED_LIBS}" = "true" ]; then
+        shared_libs="--enable-shared"
+    fi
+    ./configure --prefix="${INSTALL_PATH}" --with-ensurepip=install ${config_args} ${shared_libs}
     make -j 8
     make install
     cd /tmp


### PR DESCRIPTION
I was trying to use this devcontainer with PyInstaller, and it seems like the build fails due to the Python installation not built with the shared libraries.

## Summary of Changes
1. Provides a new option to control the build flag for the shared libraries

### Concerns / Thoughts
1. Do we want to preserve the original behaviour (ie have the option as false) 
2. Do we want to do something special regarding the MacOS specific commands

## Details

Here are the relevant logs

```
    run()
  File "/workspaces/pyside6-boilerplate/.venv/lib/python3.12/site-packages/PyInstaller/__main__.py", line 198, in run
    run_build(pyi_config, spec_file, **vars(args))
  File "/workspaces/pyside6-boilerplate/.venv/lib/python3.12/site-packages/PyInstaller/__main__.py", line 69, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
  File "/workspaces/pyside6-boilerplate/.venv/lib/python3.12/site-packages/PyInstaller/building/build_main.py", line 1071, in main
    build(specfile, distpath, workpath, clean_build)
  File "/workspaces/pyside6-boilerplate/.venv/lib/python3.12/site-packages/PyInstaller/building/build_main.py", line 1011, in build
    exec(code, spec_namespace)
  File "app.spec", line 13, in <module>
    a = Analysis(
        ^^^^^^^^^
  File "/workspaces/pyside6-boilerplate/.venv/lib/python3.12/site-packages/PyInstaller/building/build_main.py", line 470, in __init__
    self.__postinit__()
  File "/workspaces/pyside6-boilerplate/.venv/lib/python3.12/site-packages/PyInstaller/building/datastruct.py", line 184, in __postinit__
    self.assemble()
  File "/workspaces/pyside6-boilerplate/.venv/lib/python3.12/site-packages/PyInstaller/building/build_main.py", line 581, in assemble
    raise PythonLibraryNotFoundError()
PyInstaller.exceptions.PythonLibraryNotFoundError: Python library not found: libpython3.12.so, libpython3.12.so.1.0
    This means your Python installation does not come with proper shared library files.
    This usually happens due to missing development package, or unsuitable build parameters of the Python installation.

    * On Debian/Ubuntu, you need to install Python development packages:
      * apt-get install python3-dev
      * apt-get install python-dev
    * If you are building Python by yourself, rebuild with `--enable-shared` (or, `--enable-framework` on macOS).
```