### PR TITLE
allow common-utils to be installed on "minimal" RHEL-based distributions

### DIFF
--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "common-utils",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "name": "Common Utilities",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/common-utils",
     "description": "Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.",

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -155,9 +155,12 @@ install_debian_packages() {
 install_redhat_packages() {
     local package_list=""
     local remove_epel="false"
-    local install_cmd=dnf
-    if ! type dnf > /dev/null 2>&1; then
-        install_cmd=yum
+    local install_cmd=microdnf
+    if ! type microdnf > /dev/null 2>&1; then
+        install_cmd=dnf
+        if ! type dnf > /dev/null 2>&1; then
+            install_cmd=yum
+        fi
     fi
 
     if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then

--- a/test/common-utils/alma-8-minimal.sh
+++ b/test/common-utils/alma-8-minimal.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+. /etc/os-release
+check "non-root user" test "$(whoami)" = "devcontainer"
+check "distro" test "${PLATFORM_ID}" = "platform:el8"
+check "curl" curl --version
+check "jq" jq  --version
+
+# Report result
+reportResults

--- a/test/common-utils/alma-8.sh
+++ b/test/common-utils/alma-8.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+. /etc/os-release
+check "non-root user" test "$(whoami)" = "devcontainer"
+check "distro" test "${PLATFORM_ID}" = "platform:el8"
+check "curl" curl --version
+check "jq" jq  --version
+
+# Report result
+reportResults

--- a/test/common-utils/alma-9-minimal.sh
+++ b/test/common-utils/alma-9-minimal.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+. /etc/os-release
+check "non-root user" test "$(whoami)" = "devcontainer"
+check "distro" test "${PLATFORM_ID}" = "platform:el9"
+check "curl" curl --version
+check "jq" jq  --version
+
+# Report result
+reportResults

--- a/test/common-utils/alma-9.sh
+++ b/test/common-utils/alma-9.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+. /etc/os-release
+check "non-root user" test "$(whoami)" = "devcontainer"
+check "distro" test "${PLATFORM_ID}" = "platform:el9"
+check "curl" curl --version
+check "jq" jq  --version
+
+# Report result
+reportResults

--- a/test/common-utils/rocky-8-minimal.sh
+++ b/test/common-utils/rocky-8-minimal.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+. /etc/os-release
+check "non-root user" test "$(whoami)" = "devcontainer"
+check "distro" test "${PLATFORM_ID}" = "platform:el8"
+check "curl" curl --version
+check "jq" jq  --version
+
+# Report result
+reportResults

--- a/test/common-utils/rocky-9-minimal.sh
+++ b/test/common-utils/rocky-9-minimal.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+. /etc/os-release
+check "non-root user" test "$(whoami)" = "devcontainer"
+check "distro" test "${PLATFORM_ID}" = "platform:el9"
+check "curl" curl --version
+check "jq" jq  --version
+
+# Report result
+reportResults

--- a/test/common-utils/scenarios.json
+++ b/test/common-utils/scenarios.json
@@ -41,6 +41,34 @@
             "common-utils": {}
         }
     },
+    "alma-8": {
+        "image": "almalinux:8",
+        "remoteUser": "devcontainer",
+        "features": {
+            "common-utils": {}
+        }
+    },
+    "alma-9": {
+        "image": "almalinux:9",
+        "remoteUser": "devcontainer",
+        "features": {
+            "common-utils": {}
+        }
+    },
+    "alma-8-minimal": {
+        "image": "almalinux:8-minimal",
+        "remoteUser": "devcontainer",
+        "features": {
+            "common-utils": {}
+        }
+    },
+    "alma-9-minimal": {
+        "image": "almalinux:9-minimal",
+        "remoteUser": "devcontainer",
+        "features": {
+            "common-utils": {}
+        }
+    },
     "rocky-8": {
         "image": "rockylinux:8",
         "remoteUser": "devcontainer",
@@ -50,6 +78,20 @@
     },
     "rocky-9": {
         "image": "rockylinux:9",
+        "remoteUser": "devcontainer",
+        "features": {
+            "common-utils": {}
+        }
+    },
+    "rocky-8-minimal": {
+        "image": "rockylinux:8-minimal",
+        "remoteUser": "devcontainer",
+        "features": {
+            "common-utils": {}
+        }
+    },
+    "rocky-9-minimal": {
+        "image": "rockylinux:9-minimal",
         "remoteUser": "devcontainer",
         "features": {
             "common-utils": {}


### PR DESCRIPTION
Fixes devcontainers/features#810

Allows `microdnf` to be used in addition to `dnf` or `yum` in the RedHat world. 

Tests for minimal base os images that are affected by this fix (almalinux-8-minimal, almalinux-9-minimal, rocky-8-minimal, and rocky-9-minimal).