### PR TITLE
Simply adds a number for formatting consistency

### DIFF
--- a/src/docker-outside-of-docker/README.md
+++ b/src/docker-outside-of-docker/README.md
@@ -66,7 +66,7 @@ services:
 
 - The defaults value `./` is added so that the `docker-compose.yaml` file can work when it is run outside of the container
 
-### Change the workspace to `${localWorkspaceFolder}`
+### 2. Change the workspace to `${localWorkspaceFolder}`
 
 - This is useful if we don't want to edit the `docker-compose.yaml` file
 


### PR DESCRIPTION
Currently, **Use the `${localWorkspaceFolder}` as environment variable in your code** is numbered but **Change the workspace to `${localWorkspaceFolder}`** is not, so this PR simply clarifies that the latter is the second option.