### PR TITLE
Add RHEL support to node feature.

### DIFF
--- a/src/node/NOTES.md
+++ b/src/node/NOTES.md
@@ -20,6 +20,8 @@ Alternatively, you can start up an interactive shell which will in turn source `
 
 ## OS Support
 
-This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, and RockyLinux distributions with the apt, yum, dnf, or microdnf package manager installed.
+
+RedHat 7 Family (RedHat, CentOS, etc.) must use Node versions < 18.
 
 `bash` is required to execute the `install.sh` script.

--- a/src/node/NOTES.md
+++ b/src/node/NOTES.md
@@ -20,7 +20,7 @@ Alternatively, you can start up an interactive shell which will in turn source `
 
 ## OS Support
 
-Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, and RockyLinux distributions with the apt, yum, dnf, or microdnf package manager installed.
+Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, and Rocky Linux distributions with the apt, yum, dnf, or microdnf package manager installed.
 
 RedHat 7 Family (RedHat, CentOS, etc.) must use Node versions < 18.
 

--- a/src/node/README.md
+++ b/src/node/README.md
@@ -13,12 +13,12 @@ Installs Node.js, nvm, yarn, pnpm, and needed dependencies.
 
 ## Options
 
-| Options Id | Description | Type | Default Value |
-|-----|-----|-----|-----|
-| version | Select or enter a Node.js version to install | string | lts |
-| nodeGypDependencies | Install dependencies to compile native node modules (node-gyp)? | boolean | true |
-| nvmInstallPath | The path where NVM will be installed. | string | /usr/local/share/nvm |
-| nvmVersion | Version of NVM to install. | string | latest |
+| Options Id          | Description                                                     | Type    | Default Value        |
+| ------------------- | --------------------------------------------------------------- | ------- | -------------------- |
+| version             | Select or enter a Node.js version to install                    | string  | lts                  |
+| nodeGypDependencies | Install dependencies to compile native node modules (node-gyp)? | boolean | true                 |
+| nvmInstallPath      | The path where NVM will be installed.                           | string  | /usr/local/share/nvm |
+| nvmVersion          | Version of NVM to install.                                      | string  | latest               |
 
 ## Customizations
 
@@ -48,7 +48,9 @@ Alternatively, you can start up an interactive shell which will in turn source `
 
 ## OS Support
 
-This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, and RockyLinux distributions with the apt, yum, dnf, or microdnf package manager installed.
+
+RedHat 7 Family (RedHat, CentOS, etc.) must use Node versions < 18.
 
 `bash` is required to execute the `install.sh` script.
 

--- a/src/node/README.md
+++ b/src/node/README.md
@@ -13,12 +13,12 @@ Installs Node.js, nvm, yarn, pnpm, and needed dependencies.
 
 ## Options
 
-| Options Id          | Description                                                     | Type    | Default Value        |
-| ------------------- | --------------------------------------------------------------- | ------- | -------------------- |
-| version             | Select or enter a Node.js version to install                    | string  | lts                  |
-| nodeGypDependencies | Install dependencies to compile native node modules (node-gyp)? | boolean | true                 |
-| nvmInstallPath      | The path where NVM will be installed.                           | string  | /usr/local/share/nvm |
-| nvmVersion          | Version of NVM to install.                                      | string  | latest               |
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| version | Select or enter a Node.js version to install | string | lts |
+| nodeGypDependencies | Install dependencies to compile native node modules (node-gyp)? | boolean | true |
+| nvmInstallPath | The path where NVM will be installed. | string | /usr/local/share/nvm |
+| nvmVersion | Version of NVM to install. | string | latest |
 
 ## Customizations
 
@@ -48,9 +48,7 @@ Alternatively, you can start up an interactive shell which will in turn source `
 
 ## OS Support
 
-Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, and RockyLinux distributions with the apt, yum, dnf, or microdnf package manager installed.
-
-RedHat 7 Family (RedHat, CentOS, etc.) must use Node versions < 18.
+This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
 
 `bash` is required to execute the `install.sh` script.
 

--- a/src/node/devcontainer-feature.json
+++ b/src/node/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "node",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "name": "Node.js (via nvm), yarn and pnpm",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/node",
     "description": "Installs Node.js, nvm, yarn, pnpm, and needed dependencies.",

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -21,13 +21,57 @@ UPDATE_RC="${UPDATE_RC:-"true"}"
 
 set -e
 
-# Clean up
-rm -rf /var/lib/apt/lists/*
-
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
+
+# Bring in ID, ID_LIKE, VERSION_ID, VERSION_CODENAME
+. /etc/os-release
+# Get an adjusted ID independent of distro variants
+MAJOR_VERSION_ID=$(echo ${VERSION_ID} | cut -d . -f 1)
+if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
+    ADJUSTED_ID="debian"
+elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"mariner"* ]]; then
+    ADJUSTED_ID="rhel"
+    if [[ "${ID}" = "rhel" ]] || [[ "${ID}" = *"alma"* ]] || [[ "${ID}" = *"rocky"* ]]; then
+        VERSION_CODENAME="rhel${MAJOR_VERSION_ID}"
+    else
+        VERSION_CODENAME="${ID}${MAJOR_VERSION_ID}"
+    fi
+else
+    echo "Linux distro ${ID} not supported."
+    exit 1
+fi
+
+# Setup INSTALL_CMD & PKG_MGR_CMD
+if type apt-get > /dev/null 2>&1; then
+    PKG_MGR_CMD=apt-get
+    INSTALL_CMD="${PKG_MGR_CMD} -y install --no-install-recommends"
+elif type dnf > /dev/null 2>&1; then
+    PKG_MGR_CMD=dnf
+    INSTALL_CMD="${PKG_MGR_CMD} -y install"
+elif type microdnf > /dev/null 2>&1; then
+    PKG_MGR_CMD=microdnf
+    INSTALL_CMD="${PKG_MGR_CMD} -y install --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0"
+else
+    PKG_MGR_CMD=yum
+    INSTALL_CMD="${PKG_MGR_CMD} -y install"
+fi
+
+# Clean up
+clean_up() {
+    case ${ADJUSTED_ID} in
+        debian)
+            rm -rf /var/lib/apt/lists/*
+            ;;
+        rhel)
+            rm -rf /var/cache/dnf/* /var/cache/yum/*
+            rm -f /etc/yum.repos.d/yarn.repo
+            ;;
+    esac
+}
+clean_up
 
 # Ensure that login shells get the correct path if the user updated the PATH using ENV.
 rm -f /etc/profile.d/00-restore-env.sh
@@ -52,30 +96,76 @@ elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
 fi
 
 updaterc() {
+    local _bashrc
+    local _zshrc
     if [ "${UPDATE_RC}" = "true" ]; then
-        echo "Updating /etc/bash.bashrc and /etc/zsh/zshrc..."
-        if [[ "$(cat /etc/bash.bashrc)" != *"$1"* ]]; then
-            echo -e "$1" >> /etc/bash.bashrc
+        case $ADJUSTED_ID in
+            debian)
+                _bashrc=/etc/bash.bashrc
+                _zshrc=/etc/zsh/zshrc
+                ;;
+            rhel)
+                _bashrc=/etc/bashrc
+                _zshrc=/etc/zshrc
+            ;;
+        esac
+        echo "Updating ${_bashrc} and ${_zshrc}..."
+        if [[ "$(cat ${_bashrc})" != *"$1"* ]]; then
+            echo -e "$1" >> "${_bashrc}"
         fi
-        if [ -f "/etc/zsh/zshrc" ] && [[ "$(cat /etc/zsh/zshrc)" != *"$1"* ]]; then
-            echo -e "$1" >> /etc/zsh/zshrc
+        if [ -f "${_zshrc}" ] && [[ "$(cat ${_zshrc})" != *"$1"* ]]; then
+            echo -e "$1" >> "${_zshrc}"
         fi
     fi
 }
 
-apt_get_update() {
-    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
-        echo "Running apt-get update..."
-        apt-get update -y
-    fi
+pkg_mgr_update() {
+    case $ADJUSTED_ID in
+        debian)
+            if [ "$(find /var/lib/apt/lists/* 2>/dev/null | wc -l)" = "0" ]; then
+                echo "Running apt-get update..."
+                ${PKG_MGR_CMD} update -y
+            fi
+            ;;
+        rhel)
+            if [ ${PKG_MGR_CMD} = "microdnf" ]; then
+                if [ "$(ls /var/cache/yum/* 2>/dev/null | wc -l)" = 0 ]; then
+                    echo "Running ${PKG_MGR_CMD} makecache ..."
+                    ${PKG_MGR_CMD} makecache
+                fi
+            else
+                if [ "$(ls /var/cache/${PKG_MGR_CMD}/* 2>/dev/null | wc -l)" = 0 ]; then
+                    echo "Running ${PKG_MGR_CMD} check-update ..."
+                    set +e
+                    ${PKG_MGR_CMD} check-update
+                    rc=$?
+                    # centos 7 sometimes returns a status of 100 when it apears to work.
+                    if [ $rc != 0 ] && [ $rc != 100 ]; then
+                        exit 1
+                    fi
+                    set -e
+                fi
+            fi
+            ;;
+    esac
 }
 
 # Checks if packages are installed and installs them if not
 check_packages() {
-    if ! dpkg -s "$@" > /dev/null 2>&1; then
-        apt_get_update
-        apt-get -y install --no-install-recommends "$@"
-    fi
+    case ${ADJUSTED_ID} in
+        debian)
+            if ! dpkg -s "$@" > /dev/null 2>&1; then
+                pkg_mgr_update
+                ${INSTALL_CMD} "$@"
+            fi
+            ;;
+        rhel)
+            if ! rpm -q "$@" > /dev/null 2>&1; then
+                pkg_mgr_update
+                ${INSTALL_CMD} "$@"
+            fi
+            ;;
+    esac
 }
 
 # Figure out correct version of a three part version number is not passed
@@ -112,33 +202,69 @@ find_version_from_git_tags() {
     echo "${variable_name}=${!variable_name}"
 }
 
+install_yarn() {
+    if [ "${ADJUSTED_ID}" = "debian" ]; then
+        # for backward compatiblity with devcontainer features, install yarn
+        # via apt-get on Debian systems
+        if ! type yarn >/dev/null 2>&1; then
+            # Import key safely (new method rather than deprecated apt-key approach) and install
+            curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarn-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/yarn-archive-keyring.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
+            apt-get update
+            apt-get -y install --no-install-recommends yarn
+        else
+            echo "Yarn is already installed."
+        fi
+    else
+        local _ver=${1:-node}
+        # on non-debian systems, prefer corepack, fallback to npm based install...
+        # Try to leverage corepack if possible
+        # From https://yarnpkg.com:
+        # The preferred way to manage Yarn is by-project and through Corepack, a tool
+        # shipped by default with Node.js. Modern releases of Yarn aren't meant to be
+        # installed globally, or from npm.
+        if ! bash -c ". '${NVM_DIR}/nvm.sh' && nvm use ${_ver} && type yarn >/dev/null 2>&1"; then
+            if bash -c ". '${NVM_DIR}/nvm.sh' && nvm use ${_ver} && type corepack >/dev/null 2>&1"; then
+                su ${USERNAME} -c "umask 0002 && . '${NVM_DIR}/nvm.sh' && nvm use ${_ver} && corepack enable"
+            fi
+            if ! bash -c ". '${NVM_DIR}/nvm.sh' && nvm use ${_ver} && type yarn >/dev/null 2>&1"; then
+                # Yum/DNF want to install nodejs dependencies, we'll use NPM to install yarn
+                su ${USERNAME} -c "umask 0002 && . '${NVM_DIR}/nvm.sh' && nvm use ${_ver} && npm install --global yarn"
+            fi
+        else 
+            echo "Yarn already installed."
+        fi
+    fi
+}
+
 # Ensure apt is in non-interactive to avoid prompts
 export DEBIAN_FRONTEND=noninteractive
 
-. /etc/os-release
-if [[ "bionic" = *"${VERSION_CODENAME}"* ]]; then
-    if [[ "${NODE_VERSION}" =~ "18" ]] || [[ "${NODE_VERSION}" = "lts" ]]; then
-        echo "(!) Unsupported distribution version '${VERSION_CODENAME}' for Node 18. Details: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442"
+if ( [ -n "${VERSION_CODENAME}" ] && [[ "bionic" = *"${VERSION_CODENAME}"* ]] ) || [[ "rhel7" = *"${ADJUSTED_ID}${MAJOR_VERSION_ID}"* ]]; then
+    node_major_version=$(echo "${NODE_VERSION}" | cut -d . -f 1)
+    if [[ "${node_major_version}" -ge 18 ]] || [[ "${NODE_VERSION}" = "lts" ]] || [[ "${NODE_VERSION}" = "latest" ]]; then
+        echo "(!) Unsupported distribution version '${VERSION_CODENAME}' for Node >= 18. Details: https://github.com/nodejs/node/issues/42351#issuecomment-1068424442"
         exit 1
     fi
 fi
 
 # Install dependencies
-check_packages apt-transport-https curl ca-certificates tar gnupg2 dirmngr
+case ${ADJUSTED_ID} in
+    debian)
+        check_packages apt-transport-https curl ca-certificates tar gnupg2 dirmngr
+        ;;
+    rhel)
+        check_packages ca-certificates tar gnupg2 which findutils util-linux tar
+        # minimal RHEL installs may not include curl, or includes curl-minimal instead.
+        # Install curl if the "curl" command is not present.
+        if ! type curl > /dev/null 2>&1; then
+            check_packages curl
+        fi
+        ;;
+esac
 
 if ! type git > /dev/null 2>&1; then
     check_packages git
-fi
-
-# Install yarn
-if type yarn > /dev/null 2>&1; then
-    echo "Yarn already installed."
-else
-    # Import key safely (new method rather than deprecated apt-key approach) and install
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarn-archive-keyring.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/yarn-archive-keyring.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
-    apt-get update
-    apt-get -y install --no-install-recommends yarn
 fi
 
 # Adjust node version if required
@@ -204,6 +330,9 @@ else
     fi
 fi
 
+# Possibly install yarn (puts yarn in per-Node install on RHEL, uses system yarn on Debian)
+install_yarn
+
 # Additional node versions to be installed but not be set as
 # default we can assume the nvm is the group owner of the nvm
 # directory and the sticky bit on directories so any installed
@@ -214,6 +343,8 @@ if [ ! -z "${ADDITIONAL_VERSIONS}" ]; then
         read -a additional_versions <<< "$ADDITIONAL_VERSIONS"
         for ver in "${additional_versions[@]}"; do
             su ${USERNAME} -c "umask 0002 && . '$NVM_DIR/nvm.sh' && nvm install '${ver}'"
+            # possibly install yarn (puts yarn in per-Node install on RHEL, uses system yarn on Debian)
+            install_yarn "${ver}"
         done
 
         # Ensure $NODE_VERSION is on the $PATH
@@ -224,14 +355,17 @@ if [ ! -z "${ADDITIONAL_VERSIONS}" ]; then
 fi
 
 # Install pnpm
-if type pnpm > /dev/null 2>&1; then
+if bash -c ". '${NVM_DIR}/nvm.sh' && type pnpm >/dev/null 2>&1"; then
     echo "pnpm already installed."
 else
-    if type npm > /dev/null 2>&1; then
-        [ ! -z "$http_proxy" ] && npm set proxy="$http_proxy"
-        [ ! -z "$https_proxy" ] && npm set https-proxy="$https_proxy"
-        [ ! -z "$no_proxy" ] && npm set noproxy="$no_proxy"
-        npm install -g pnpm
+    if bash -c ". '${NVM_DIR}/nvm.sh' && type npm >/dev/null 2>&1"; then
+        (
+            . "${NVM_DIR}/nvm.sh"
+            [ ! -z "$http_proxy" ] && npm set proxy="$http_proxy"
+            [ ! -z "$https_proxy" ] && npm set https-proxy="$https_proxy"
+            [ ! -z "$no_proxy" ] && npm set noproxy="$no_proxy"
+            npm install -g pnpm
+        )
     else
         echo "Skip installing pnpm because npm is missing"
     fi
@@ -248,21 +382,29 @@ if [ "${INSTALL_TOOLS_FOR_NODE_GYP}" = "true" ]; then
         to_install="${to_install} gcc"
     fi
     if ! type g++ > /dev/null 2>&1; then
-        to_install="${to_install} g++"
+        if [ ${ADJUSTED_ID} = "debian" ]; then
+            to_install="${to_install} g++"
+        elif [ ${ADJUSTED_ID} = "rhel" ]; then
+            to_install="${to_install} gcc-c++"
+        fi
     fi
     if ! type python3 > /dev/null 2>&1; then
-        to_install="${to_install} python3-minimal"
+        if [ ${ADJUSTED_ID} = "debian" ]; then
+            to_install="${to_install} python3-minimal"
+        elif [ ${ADJUSTED_ID} = "rhel" ]; then
+            to_install="${to_install} python3"
+        fi
     fi
     if [ ! -z "${to_install}" ]; then
-        apt_get_update
-        apt-get -y install ${to_install}
+        pkg_mgr_update
+        check_packages ${to_install}
     fi
 fi
 
 
 # Clean up
 su ${USERNAME} -c "umask 0002 && . '$NVM_DIR/nvm.sh' && nvm clear-cache"
-rm -rf /var/lib/apt/lists/*
+clean_up
 
 # Ensure privs are correct for installed node versions. Unfortunately the
 # way nvm installs node versions pulls privs from the tar which does not

--- a/test/node/alma-8-minimal.sh
+++ b/test/node/alma-8-minimal.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "version" node  --version
+check "pnpm" pnpm -v
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+check "yarn" yarn --version
+
+# Report result
+reportResults

--- a/test/node/alma-8.sh
+++ b/test/node/alma-8.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "version" node  --version
+check "pnpm" pnpm -v
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+check "yarn" yarn --version
+
+# Report result
+reportResults

--- a/test/node/alma-9-minimal.sh
+++ b/test/node/alma-9-minimal.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "version" node  --version
+check "pnpm" pnpm -v
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+check "yarn" yarn --version
+
+# Report result
+reportResults

--- a/test/node/alma-9.sh
+++ b/test/node/alma-9.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "version" node  --version
+check "pnpm" pnpm -v
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+check "yarn" yarn --version
+
+# Report result
+reportResults

--- a/test/node/centos-7.sh
+++ b/test/node/centos-7.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "version" node  --version
+check "pnpm" pnpm -v
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+check "yarn" yarn --version
+
+# Report result
+reportResults

--- a/test/node/fedora.sh
+++ b/test/node/fedora.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "version" node  --version
+check "pnpm" pnpm -v
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+check "yarn" yarn --version
+
+# Report result
+reportResults

--- a/test/node/install_additional_node.sh
+++ b/test/node/install_additional_node.sh
@@ -5,11 +5,11 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
-# 'lts' is some version of node 18 for a while.
-check "version_on_path"  node -v | grep 18
+# 'lts' is now some version of node 20...
+check "version_on_path"  node -v | grep 20
 check "pnpm" pnpm -v
 
-check "v18_installed" ls -1 /usr/local/share/nvm/versions/node | grep 18
+check "v20_installed" ls -1 /usr/local/share/nvm/versions/node | grep 20
 check "v14_installed" ls -1 /usr/local/share/nvm/versions/node | grep 14.19.3
 check "v17_installed" ls -1 /usr/local/share/nvm/versions/node | grep 17.9.1
 

--- a/test/node/install_additional_node_on_rhel_family.sh
+++ b/test/node/install_additional_node_on_rhel_family.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# 'lts' is now some version of node 20...
+check "version_on_path"  node -v | grep 20
+check "pnpm" pnpm -v
+
+check "v20_installed" ls -1 /usr/local/share/nvm/versions/node | grep 20
+check "v14_installed" ls -1 /usr/local/share/nvm/versions/node | grep 14.19.3
+check "v17_installed" ls -1 /usr/local/share/nvm/versions/node | grep 17.9.1
+
+
+# Report result
+reportResults

--- a/test/node/install_nvm_0.39_on_rhel_family.sh
+++ b/test/node/install_nvm_0.39_on_rhel_family.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "version" bash -c "node --version"
+check "pnpm" pnpm -v
+check "nvm version" bash -c ". /usr/local/share/nvm/nvm.sh && nvm --version | grep 0.39"
+
+# Report result
+reportResults

--- a/test/node/mariner.sh
+++ b/test/node/mariner.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "version" node  --version
+check "pnpm" pnpm -v
+# for some reason the "nvm" test switches the default node version on Mariner
+# test yarn before that: it is only enabled in the default node version
+check "yarn" yarn --version_list
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+
+# Report result
+reportResults

--- a/test/node/rocky-8-minimal.sh
+++ b/test/node/rocky-8-minimal.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "version" node  --version
+check "pnpm" pnpm -v
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+check "yarn" yarn --version
+
+# Report result
+reportResults

--- a/test/node/rocky-8.sh
+++ b/test/node/rocky-8.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "version" node  --version
+check "pnpm" pnpm -v
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+check "yarn" yarn --version
+
+# Report result
+reportResults

--- a/test/node/rocky-9-minimal.sh
+++ b/test/node/rocky-9-minimal.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "version" node  --version
+check "pnpm" pnpm -v
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+check "yarn" yarn --version
+
+# Report result
+reportResults

--- a/test/node/rocky-9.sh
+++ b/test/node/rocky-9.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "version" node  --version
+check "pnpm" pnpm -v
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+check "yarn" yarn --version
+
+# Report result
+reportResults

--- a/test/node/scenarios.json
+++ b/test/node/scenarios.json
@@ -8,6 +8,15 @@
             }
         }
     },
+    "install_additional_node_on_rhel_family": {
+        "image": "almalinux:8",
+        "features": {
+            "node": {
+                "version": "lts",
+                "additionalVersions": "v17.9.1,v14.19.3"
+            }
+        }
+    },
     "non_root_user": {
         "image": "mcr.microsoft.com/devcontainers/base",
         "remoteUser": "vscode",
@@ -28,7 +37,27 @@
             }
         }
     },
+    "zsh_default_on_rhel_family": {
+        "image": "almalinux:8",
+        "features": {
+            "node": {
+                "version": "lts"
+            },
+            "common-utils": {
+                "configureZshAsDefaultShell": true
+            }
+        }
+    },
     "version_none": {
+        "image": "mcr.microsoft.com/devcontainers/base",
+        "remoteUser": "vscode",
+        "features": {
+            "node": {
+                "version": "none"
+            }
+        }
+    },
+    "version_none_on_rhel_family": {
         "image": "mcr.microsoft.com/devcontainers/base",
         "remoteUser": "vscode",
         "features": {
@@ -47,6 +76,14 @@
     },
     "install_nvm_0.39": {
         "image": "mcr.microsoft.com/devcontainers/base",
+        "features": {
+            "node": {
+                "nvmVersion": "0.39"
+            }
+        }
+    },
+    "install_nvm_0.39_on_rhel_family": {
+        "image": "almalinux:8",
         "features": {
             "node": {
                 "nvmVersion": "0.39"
@@ -87,6 +124,54 @@
     },
     "alma-9-minimal": {
         "image": "almalinux:9-minimal",
+        "features": {
+            "node": {
+                "version": "lts"
+            }
+        }
+    },
+    "rocky-8": {
+        "image": "rockylinux:8",
+        "features": {
+            "node": {
+                "version": "lts"
+            }
+        }
+    },
+    "rocky-8-minimal": {
+        "image": "rockylinux:8-minimal",
+        "features": {
+            "node": {
+                "version": "lts"
+            }
+        }
+    },
+    "rocky-9": {
+        "image": "rockylinux:9",
+        "features": {
+            "node": {
+                "version": "lts"
+            }
+        }
+    },
+    "rocky-9-minimal": {
+        "image": "rockylinux:9-minimal",
+        "features": {
+            "node": {
+                "version": "lts"
+            }
+        }
+    },
+    "fedora": {
+        "image": "fedora",
+        "features": {
+            "node": {
+                "version": "lts"
+            }
+        }
+    },
+    "mariner": {
+        "image": "mcr.microsoft.com/cbl-mariner/base/core:2.0",
         "features": {
             "node": {
                 "version": "lts"

--- a/test/node/scenarios.json
+++ b/test/node/scenarios.json
@@ -52,5 +52,45 @@
                 "nvmVersion": "0.39"
             }
         }
+    },
+    "centos-7": {
+        "image": "centos:centos7",
+        "features": {
+            "node": {
+                "version": "16"
+            }
+        }
+    },
+    "alma-8": {
+        "image": "almalinux:8",
+        "features": {
+            "node": {
+                "version": "lts"
+            }
+        }
+    },
+    "alma-8-minimal": {
+        "image": "almalinux:8-minimal",
+        "features": {
+            "node": {
+                "version": "lts"
+            }
+        }
+    },
+    "alma-9": {
+        "image": "almalinux:9",
+        "features": {
+            "node": {
+                "version": "lts"
+            }
+        }
+    },
+    "alma-9-minimal": {
+        "image": "almalinux:9-minimal",
+        "features": {
+            "node": {
+                "version": "lts"
+            }
+        }
     }
 }

--- a/test/node/version_none_on_rhel_family.sh
+++ b/test/node/version_none_on_rhel_family.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+
+# Report result
+reportResults

--- a/test/node/zsh_default_on_rhel_family.sh
+++ b/test/node/zsh_default_on_rhel_family.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+
+# Report result
+reportResults


### PR DESCRIPTION
This PR adds RHEL support to node feature.

CentOS 7, RHEL/Alma/Rocky Linux 8 & 9, Mariner, and Fedor should all work. Tests for all of these are included.

resolves #822