### PR TITLE
[docker-in-docker] : Bug fix - Buildx installation when moby:false

### DIFF
--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "2.7.1",
+    "version": "2.8.0",
     "name": "Docker (Docker-in-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
     "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -317,13 +317,16 @@ if [ "${INSTALL_DOCKER_BUILDX}" = "true" ]; then
     buildx_file_name="buildx-v${buildx_version}.linux-${architecture}"
     cd /tmp && wget "https://github.com/docker/buildx/releases/download/v${buildx_version}/${buildx_file_name}"
 
-    mkdir -p ${_REMOTE_USER_HOME}/.docker/cli-plugins
-    mv ${buildx_file_name} ${_REMOTE_USER_HOME}/.docker/cli-plugins/docker-buildx
-    chmod +x ${_REMOTE_USER_HOME}/.docker/cli-plugins/docker-buildx
+    docker_home="/usr/libexec/docker"
+    cli_plugins_dir="${docker_home}/cli-plugins"
 
-    chown -R "${USERNAME}:docker" "${_REMOTE_USER_HOME}/.docker"
-    chmod -R g+r+w "${_REMOTE_USER_HOME}/.docker"
-    find "${_REMOTE_USER_HOME}/.docker" -type d -print0 | xargs -n 1 -0 chmod g+s
+    mkdir -p ${cli_plugins_dir}
+    mv ${buildx_file_name} ${cli_plugins_dir}/docker-buildx
+    chmod +x ${cli_plugins_dir}/docker-buildx
+
+    chown -R "${USERNAME}:docker" "${docker_home}"
+    chmod -R g+r+w "${docker_home}"
+    find "${docker_home}" -type d -print0 | xargs -n 1 -0 chmod g+s
 fi
 
 tee /usr/local/share/docker-init.sh > /dev/null \

--- a/test/docker-in-docker/docker_build_2.sh
+++ b/test/docker-in-docker/docker_build_2.sh
@@ -8,6 +8,8 @@ source dev-container-features-test-lib
 # Definition specific tests
 check "docker-buildx" docker buildx version
 check "docker-build" docker build ./
+check "docker-buildx" bash -c "docker buildx version"
+check "docker-buildx-path" bash -c "ls -la /usr/libexec/docker/cli-plugins/docker-buildx"
 
 # Report result
 reportResults

--- a/test/docker-in-docker/docker_build_older.sh
+++ b/test/docker-in-docker/docker_build_older.sh
@@ -8,6 +8,8 @@ source dev-container-features-test-lib
 # Definition specific tests
 check "docker-buildx" docker buildx version
 check "docker-build" docker build ./
+check "docker-buildx" bash -c "docker buildx version"
+check "docker-buildx-path" bash -c "ls -la /usr/libexec/docker/cli-plugins/docker-buildx"
 
 # Report result
 reportResults

--- a/test/docker-in-docker/docker_buildx.sh
+++ b/test/docker-in-docker/docker_buildx.sh
@@ -6,13 +6,14 @@ set -e
 source dev-container-features-test-lib
 
 # Definition specific tests
+check "docker-buildx" bash -c "docker buildx version"
+check "docker-buildx-path" bash -c "ls -la /usr/libexec/docker/cli-plugins/docker-buildx"
+
 check "docker-buildx" docker buildx version
 check "docker-build" docker build ./
 
 check "installs docker-compose v1 install" bash -c "type docker-compose"
 check "installs compose-switch" bash -c "[[ -f /usr/local/bin/compose-switch ]]"
-check "docker-buildx" bash -c "docker buildx version"
-check "docker-buildx-path" bash -c "ls -la /usr/libexec/docker/cli-plugins/docker-buildx"
 
 # Report result
 reportResults

--- a/test/docker-in-docker/scenarios.json
+++ b/test/docker-in-docker/scenarios.json
@@ -68,6 +68,15 @@
         },
         "remoteUser": "node"
     },
+    "docker_buildx": {
+        "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+        "features": {
+            "docker-in-docker": {
+                "moby": false,
+                "installDockerBuildx": true
+            }
+        }
+    },
     // DO NOT REMOVE: This scenario is used by the docker-in-docker-stress-test workflow
     "docker_with_on_create_command": {
         "image": "mcr.microsoft.com/devcontainers/base:debian",


### PR DESCRIPTION
Closes https://github.com/devcontainers/features/issues/817

Syncs buildx installation directory when `moby:true` and `moby:false` which also avoids the problem mentioned in https://github.com/devcontainers/features/issues/817#issuecomment-1915916866