### PR TITLE
Docker-in-docker - [Bug fix] : Fix externally-managed-environment python error for "bookworm"

### DIFF
--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "name": "Docker (Docker-in-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
     "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -233,7 +233,7 @@ if [ "${DOCKER_DASH_COMPOSE_VERSION}" != "none" ]; then
         if [ "${target_compose_arch}" = "amd64" ]; then
             target_compose_arch="x86_64"
         fi
-        if [ "${target_compose_arch}" != "x86_64" ]; then
+        if [ "${target_compose_arch}" != "x86_64" ] && [ "${VERSION_CODENAME}" != "bookworm" ]; then
             # Use pip to get a version that runs on this architecture
             check_packages python3-minimal python3-pip libffi-dev python3-venv
             export PIPX_HOME=/usr/local/pipx

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -233,6 +233,7 @@ if [ "${DOCKER_DASH_COMPOSE_VERSION}" != "none" ]; then
         if [ "${target_compose_arch}" = "amd64" ]; then
             target_compose_arch="x86_64"
         fi
+        # https://github.com/devcontainers/features/issues/832
         if [ "${target_compose_arch}" != "x86_64" ] && [ "${VERSION_CODENAME}" != "bookworm" ]; then
             # Use pip to get a version that runs on this architecture
             check_packages python3-minimal python3-pip libffi-dev python3-venv

--- a/test/docker-in-docker/docker_python_bookworm.sh
+++ b/test/docker-in-docker/docker_python_bookworm.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "docker-buildx" bash -c "docker buildx version"
+check "docker-buildx-path" bash -c "ls -la /usr/libexec/docker/cli-plugins/docker-buildx"
+
+check "docker-buildx" docker buildx version
+check "docker-build" docker build ./
+
+check "installs docker-compose v2 install" bash -c "type docker-compose"
+check "docker compose" bash -c "docker compose version | grep -E '2.[0-9]+.[0-9]+'"
+check "docker-compose" bash -c "docker-compose --version | grep -E '2.[0-9]+.[0-9]+'"
+
+check "installs compose-switch as docker-compose" bash -c "[[ -f /usr/local/bin/docker-compose ]]"
+
+# Report result
+reportResults

--- a/test/docker-in-docker/scenarios.json
+++ b/test/docker-in-docker/scenarios.json
@@ -77,6 +77,16 @@
             }
         }
     },
+    "docker_python_bookworm": {
+        "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+        "features": {
+            "docker-in-docker": {
+                "moby": true,
+                "installDockerBuildx": true,
+                "dockerDashComposeVersion": "v2"
+            }
+        }
+    },
     // DO NOT REMOVE: This scenario is used by the docker-in-docker-stress-test workflow
     "docker_with_on_create_command": {
         "image": "mcr.microsoft.com/devcontainers/base:debian",


### PR DESCRIPTION
Closes: https://github.com/devcontainers/features/issues/832

Changes needed to the "docker-in-docker" Feature post Debian bookworm / [PEP 668](https://peps.python.org/pep-0668/#abstract)

If OS is bookworm, install from git releases instead.