### PR TITLE
[common-utils] - Bookworm - enabled nonFreePackages option for installing manpages-posix, manpages-posix-dev packages

### DIFF
--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "common-utils",
-    "version": "2.4.1",
+    "version": "2.4.2",
     "name": "Common Utilities",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/common-utils",
     "description": "Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.",

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -104,18 +104,22 @@ install_debian_packages() {
 
     # Needed for adding manpages-posix and manpages-posix-dev which are non-free packages in Debian
     if [ "${ADD_NON_FREE_PACKAGES}" = "true" ]; then
-        # Bring in variables from /etc/os-release like VERSION_CODENAME
-        sed -i -E "s/deb http:\/\/(deb|httpredir)\.debian\.org\/debian ${VERSION_CODENAME} main/deb http:\/\/\1\.debian\.org\/debian ${VERSION_CODENAME} main contrib non-free/" /etc/apt/sources.list
-        sed -i -E "s/deb-src http:\/\/(deb|httredir)\.debian\.org\/debian ${VERSION_CODENAME} main/deb http:\/\/\1\.debian\.org\/debian ${VERSION_CODENAME} main contrib non-free/" /etc/apt/sources.list
-        sed -i -E "s/deb http:\/\/(deb|httpredir)\.debian\.org\/debian ${VERSION_CODENAME}-updates main/deb http:\/\/\1\.debian\.org\/debian ${VERSION_CODENAME}-updates main contrib non-free/" /etc/apt/sources.list
-        sed -i -E "s/deb-src http:\/\/(deb|httpredir)\.debian\.org\/debian ${VERSION_CODENAME}-updates main/deb http:\/\/\1\.debian\.org\/debian ${VERSION_CODENAME}-updates main contrib non-free/" /etc/apt/sources.list
-        sed -i "s/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}\/updates main/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}\/updates main contrib non-free/" /etc/apt/sources.list
-        sed -i "s/deb-src http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}\/updates main/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}\/updates main contrib non-free/" /etc/apt/sources.list
-        sed -i "s/deb http:\/\/deb\.debian\.org\/debian ${VERSION_CODENAME}-backports main/deb http:\/\/deb\.debian\.org\/debian ${VERSION_CODENAME}-backports main contrib non-free/" /etc/apt/sources.list
-        sed -i "s/deb-src http:\/\/deb\.debian\.org\/debian ${VERSION_CODENAME}-backports main/deb http:\/\/deb\.debian\.org\/debian ${VERSION_CODENAME}-backports main contrib non-free/" /etc/apt/sources.list
-        # Handle bullseye location for security https://www.debian.org/releases/bullseye/amd64/release-notes/ch-information.en.html
-        sed -i "s/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}-security main/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}-security main contrib non-free/" /etc/apt/sources.list
-        sed -i "s/deb-src http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}-security main/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}-security main contrib non-free/" /etc/apt/sources.list
+        if [ ! -e "/etc/apt/sources.list" ]; then 
+            sed -i -E "s/Components: main/components: main contrib non-free/" /etc/apt/sources.list.d/debian.sources
+        else
+            # Bring in variables from /etc/os-release like VERSION_CODENAME
+            sed -i -E "s/deb http:\/\/(deb|httpredir)\.debian\.org\/debian ${VERSION_CODENAME} main/deb http:\/\/\1\.debian\.org\/debian ${VERSION_CODENAME} main contrib non-free/" /etc/apt/sources.list
+            sed -i -E "s/deb-src http:\/\/(deb|httredir)\.debian\.org\/debian ${VERSION_CODENAME} main/deb http:\/\/\1\.debian\.org\/debian ${VERSION_CODENAME} main contrib non-free/" /etc/apt/sources.list
+            sed -i -E "s/deb http:\/\/(deb|httpredir)\.debian\.org\/debian ${VERSION_CODENAME}-updates main/deb http:\/\/\1\.debian\.org\/debian ${VERSION_CODENAME}-updates main contrib non-free/" /etc/apt/sources.list
+            sed -i -E "s/deb-src http:\/\/(deb|httpredir)\.debian\.org\/debian ${VERSION_CODENAME}-updates main/deb http:\/\/\1\.debian\.org\/debian ${VERSION_CODENAME}-updates main contrib non-free/" /etc/apt/sources.list
+            sed -i "s/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}\/updates main/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}\/updates main contrib non-free/" /etc/apt/sources.list
+            sed -i "s/deb-src http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}\/updates main/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}\/updates main contrib non-free/" /etc/apt/sources.list
+            sed -i "s/deb http:\/\/deb\.debian\.org\/debian ${VERSION_CODENAME}-backports main/deb http:\/\/deb\.debian\.org\/debian ${VERSION_CODENAME}-backports main contrib non-free/" /etc/apt/sources.list
+            sed -i "s/deb-src http:\/\/deb\.debian\.org\/debian ${VERSION_CODENAME}-backports main/deb http:\/\/deb\.debian\.org\/debian ${VERSION_CODENAME}-backports main contrib non-free/" /etc/apt/sources.list
+            # Handle bullseye location for security https://www.debian.org/releases/bullseye/amd64/release-notes/ch-information.en.html
+            sed -i "s/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}-security main/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}-security main contrib non-free/" /etc/apt/sources.list
+            sed -i "s/deb-src http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}-security main/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}-security main contrib non-free/" /etc/apt/sources.list
+        fi;
         echo "Running apt-get update..."
         package_list="${package_list} manpages-posix manpages-posix-dev"
     fi

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -104,8 +104,8 @@ install_debian_packages() {
 
     # Needed for adding manpages-posix and manpages-posix-dev which are non-free packages in Debian
     if [ "${ADD_NON_FREE_PACKAGES}" = "true" ]; then
-        if [ ! -e "/etc/apt/sources.list" ]; then 
-            sed -i '/Suites: bookworm bookworm-updates/{N;s/Components: main/Components: main non-free non-free-firmware/}' /etc/apt/sources.list.d/debian.sources
+        if [[ ! -e "/etc/apt/sources.list" ]] && [[ -e "/etc/apt/sources.list.d/debian.sources" ]]; then 
+            sed -i '/^URIs: http:\/\/deb.debian.org\/debian$/ { N; N; s/Components: main/Components: main non-free non-free-firmware/ }' /etc/apt/sources.list.d/debian.sources
         else
             # Bring in variables from /etc/os-release like VERSION_CODENAME
             sed -i -E "s/deb http:\/\/(deb|httpredir)\.debian\.org\/debian ${VERSION_CODENAME} main/deb http:\/\/\1\.debian\.org\/debian ${VERSION_CODENAME} main contrib non-free/" /etc/apt/sources.list

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -105,7 +105,7 @@ install_debian_packages() {
     # Needed for adding manpages-posix and manpages-posix-dev which are non-free packages in Debian
     if [ "${ADD_NON_FREE_PACKAGES}" = "true" ]; then
         if [ ! -e "/etc/apt/sources.list" ]; then 
-            sed -i -E "s/Components: main/components: main contrib non-free/" /etc/apt/sources.list.d/debian.sources
+            sed -i -E "s/Components: main/Components: main contrib non-free/g" /etc/apt/sources.list.d/debian.sources
         else
             # Bring in variables from /etc/os-release like VERSION_CODENAME
             sed -i -E "s/deb http:\/\/(deb|httpredir)\.debian\.org\/debian ${VERSION_CODENAME} main/deb http:\/\/\1\.debian\.org\/debian ${VERSION_CODENAME} main contrib non-free/" /etc/apt/sources.list

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -105,7 +105,7 @@ install_debian_packages() {
     # Needed for adding manpages-posix and manpages-posix-dev which are non-free packages in Debian
     if [ "${ADD_NON_FREE_PACKAGES}" = "true" ]; then
         if [ ! -e "/etc/apt/sources.list" ]; then 
-            sed -i -E "s/Components: main/Components: main contrib non-free/g" /etc/apt/sources.list.d/debian.sources
+            sed -i '/Suites: bookworm bookworm-updates/{N;s/Components: main/Components: main non-free non-free-firmware/}' /etc/apt/sources.list.d/debian.sources
         else
             # Bring in variables from /etc/os-release like VERSION_CODENAME
             sed -i -E "s/deb http:\/\/(deb|httpredir)\.debian\.org\/debian ${VERSION_CODENAME} main/deb http:\/\/\1\.debian\.org\/debian ${VERSION_CODENAME} main contrib non-free/" /etc/apt/sources.list

--- a/test/common-utils/bookworm.sh
+++ b/test/common-utils/bookworm.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+. /etc/os-release
+check "non-root user" test "$(whoami)" = "devcontainer"
+check "distro" test "${VERSION_CODENAME}" = "bookworm"
+
+# Report result
+reportResults

--- a/test/common-utils/bookworm.sh
+++ b/test/common-utils/bookworm.sh
@@ -5,6 +5,37 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
+FAILED=()
+echoStderr()
+{
+    echo "$@" 1>&2
+}
+
+checkOSPackages() {
+    LABEL=$1
+    shift
+    echo -e "\n🧪 Testing $LABEL"
+    if dpkg-query --show -f='${Package}: ${Version}\n' "$@"; then 
+        echo "✅  Passed!"
+        return 0
+    else
+        echoStderr "❌ $LABEL check failed."
+        FAILED+=("$LABEL")
+        return 1
+    fi
+}
+
+checkCommon()
+{
+    PACKAGE_LIST="manpages-posix \
+        manpages-posix-dev"
+
+    checkOSPackages "Installation of manpages-posix and manpages-posix-dev (non-free)" ${PACKAGE_LIST}
+}
+
+# Check for manpages-posix, manpages-posix-dev non-free packages
+checkCommon
+
 # Definition specific tests
 . /etc/os-release
 check "non-root user" test "$(whoami)" = "devcontainer"

--- a/test/common-utils/scenarios.json
+++ b/test/common-utils/scenarios.json
@@ -34,6 +34,15 @@
             "common-utils": {}
         }
     },
+    "bookworm": {
+        "image": "debian:bookworm",
+        "remoteUser": "devcontainer",
+        "features": {
+            "common-utils": {
+                "nonFreePackages": "true"
+            }
+        }
+    },
     "centos-7": {
         "image": "centos:7",
         "remoteUser": "devcontainer",


### PR DESCRIPTION
Enabled non-free option in `sources.list.d/debian.sources` file for downloading and installation of `manpages-posix` & `manpages-posix-dev` packages to address [#760](https://github.com/devcontainers/images/issues/760)

Test with cmd: `devcontainer features test . -f common-utils --skip-autogenerated --filter "bookworm"  --preserve-test-containers`