### PR TITLE
Docker-outside-of-docker: Fix moby-buildx errors

### DIFF
--- a/src/docker-outside-of-docker/devcontainer-feature.json
+++ b/src/docker-outside-of-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-outside-of-docker",
-    "version": "1.3.2",
+    "version": "1.4.0",
     "name": "Docker (docker-outside-of-docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker",
     "description": "Re-use the host docker socket, adding the Docker CLI to a container. Feature invokes a script to enable using a forwarded Docker socket within a container to run Docker commands.",
@@ -19,6 +19,11 @@
             "type": "boolean",
             "default": true,
             "description": "Install OSS Moby build instead of Docker CE"
+        },
+        "mobyBuildxVersion": {
+            "type": "string",
+            "default": "0.12.0",
+            "description": "Install a specific version of moby-buildx when using Moby. (2024-02-09: Microsoft's Package Manifest has mismatching filesize and SHA for 0.12.1; default is last known good version)"
         },
         "dockerDashComposeVersion": {
             "type": "string",

--- a/test/docker-outside-of-docker/docker_init.sh
+++ b/test/docker-outside-of-docker/docker_init.sh
@@ -5,9 +5,6 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
-echo "contents cat /tmp/vscr-docker-from-docker.log"
-cat cat /tmp/vscr-docker-from-docker.log
-
 check "docker buildx" bash -c "docker buildx version"
 check "docker compose" bash -c "docker compose version"
 check "docker-compose" bash -c "docker-compose --version"
@@ -16,11 +13,7 @@ check "docker-init-exists" bash -c "ls /usr/local/share/docker-init.sh"
 check "log-exists" bash -c "ls /tmp/vscr-docker-from-docker.log"
 check "log-contents-for-success" bash -c "cat /tmp/vscr-docker-from-docker.log | grep 'Success'"
 
-sleep 5s
-echo "contents cat /tmp/vscr-docker-from-docker.log"
-cat cat /tmp/vscr-docker-from-docker.log
-
-check "log-contents" bash -c "cat /tmp/vscr-docker-from-docker.log | grep 'Proxying /var/run/docker-host.sock to /var/run/docker.sock for vscode'"
+check "log-contents" bash -c "cat /tmp/vscr-docker-from-docker.log | grep 'Ensuring vscode has access to /var/run/docker-host.sock via /var/run/docker.sock"
 check "docker-ps" bash -c "docker ps >/dev/null"
 
 # Report result

--- a/test/docker-outside-of-docker/docker_init.sh
+++ b/test/docker-outside-of-docker/docker_init.sh
@@ -5,6 +5,9 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
+echo "contents cat /tmp/vscr-docker-from-docker.log"
+cat cat /tmp/vscr-docker-from-docker.log
+
 check "docker buildx" bash -c "docker buildx version"
 check "docker compose" bash -c "docker compose version"
 check "docker-compose" bash -c "docker-compose --version"
@@ -12,6 +15,11 @@ check "docker-compose" bash -c "docker-compose --version"
 check "docker-init-exists" bash -c "ls /usr/local/share/docker-init.sh"
 check "log-exists" bash -c "ls /tmp/vscr-docker-from-docker.log"
 check "log-contents-for-success" bash -c "cat /tmp/vscr-docker-from-docker.log | grep 'Success'"
+
+sleep 5s
+echo "contents cat /tmp/vscr-docker-from-docker.log"
+cat cat /tmp/vscr-docker-from-docker.log
+
 check "log-contents" bash -c "cat /tmp/vscr-docker-from-docker.log | grep 'Proxying /var/run/docker-host.sock to /var/run/docker.sock for vscode'"
 check "docker-ps" bash -c "docker ps >/dev/null"
 

--- a/test/docker-outside-of-docker/docker_init.sh
+++ b/test/docker-outside-of-docker/docker_init.sh
@@ -13,7 +13,7 @@ check "docker-init-exists" bash -c "ls /usr/local/share/docker-init.sh"
 check "log-exists" bash -c "ls /tmp/vscr-docker-from-docker.log"
 check "log-contents-for-success" bash -c "cat /tmp/vscr-docker-from-docker.log | grep 'Success'"
 
-check "log-contents" bash -c "cat /tmp/vscr-docker-from-docker.log | grep 'Ensuring vscode has access to /var/run/docker-host.sock via /var/run/docker.sock"
+check "log-contents" bash -c "cat /tmp/vscr-docker-from-docker.log | grep 'Ensuring vscode has access to /var/run/docker-host.sock via /var/run/docker.sock'"
 check "docker-ps" bash -c "docker ps >/dev/null"
 
 # Report result


### PR DESCRIPTION
Ref: https://github.com/devcontainers/features/issues/842

Currently, docker-outside-of-docker fails due to upstream issue with the `moby-buildx` errors. Fixing that! 
https://github.com/devcontainers/features/issues/837#issuecomment-1936736237 mentions the root cause of why this started happening.
