### PR TITLE
[python]-setuptools-GHSA-r9hx-vwmv-q579-remove setuptools-65.5.0-py3-none-any.whl

### DIFF
--- a/src/python/devcontainer-feature.json
+++ b/src/python/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "python",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "name": "Python",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/python",
   "description": "Installs the provided version of Python, as well as PIPX, and other common Python utilities.  JupyterLab is conditionally installed with the python feature. Note: May require source code compilation.",

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -756,6 +756,36 @@ if [[ "${INSTALL_PYTHON_TOOLS}" = "true" ]] && [[ -n "${PYTHON_SRC}" ]]; then
     PY_MAJOR_MINOR_VER=${RUN_TIME_PY_VER_DETECT:7:4};
     if [[ ${VULNERABLE_VERSIONS[*]} =~ $PY_MAJOR_MINOR_VER ]]; then
         rm -rf  ${PIPX_HOME}/shared/lib/"python${PY_MAJOR_MINOR_VER}"/site-packages/setuptools-65.5.0.dist-info
+        if [[ -e "/usr/local/lib/python${PY_MAJOR_MINOR_VER}/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl" ]]; then 
+            # remove the vulnerable setuptools-65.5.0-py3-none-any.whl file
+            rm /usr/local/lib/python${PY_MAJOR_MINOR_VER}/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl
+            # create and change to the setuptools_downloaded directory
+            mkdir setuptools_downloaded
+            cd setuptools_downloaded
+            # download the source distribution for setuptools using pip 
+            pip download setuptools --no-binary :all:
+            ## extract the version from the filename of the downloaded contents
+            # extract the filename of the setuptools-*.tar.gz file
+            filename=$(find . -maxdepth 1 -type f)
+            # Remove .tar.gz extension
+            vers=${filename%.tar.gz}
+            # Remove "./setuptools-" prefix
+            vers=${vers#./setuptools-}
+            # create a directory to store unpacked contents of the source distribution
+            mkdir setuptools_src_dist
+            # extract the contents inside the new directory
+            tar -xzf $filename -C ./setuptools_src_dist
+            # move to the setuptools-* directory inside /setuptools_src_dist
+            cd setuptools_src_dist/"setuptools-${vers}"/
+            # look for setup.py file in the current directory and create a wheel file
+            python setup.py bdist_wheel
+            # move inside the dist directory in pwd
+            cd dist
+            # copy this file to the ensurepip/_bundled directory 
+            cp setuptools-"${vers}"-py3-none-any.whl /usr/local/lib/python${PY_MAJOR_MINOR_VER}/ensurepip/_bundled/
+            # replace the version in __init__.py file with the installed version
+            sed -i "s/_SETUPTOOLS_VERSION = \"65\.5\.0\"/_SETUPTOOLS_VERSION = "\"${vers}"\"/g" /usr/local/lib/"python${PY_MAJOR_MINOR_VER}"/ensurepip/__init__.py
+        fi
     fi
 
     rm -rf /tmp/pip-tmp

--- a/test/python/install_python310_setuptools_vulnerability.sh
+++ b/test/python/install_python310_setuptools_vulnerability.sh
@@ -92,9 +92,41 @@ checkVulnerableFile()
     fi
 }
 
+# print setuptools
+check "all files and folders containing setuptools" bash -c 'find / -name "*setuptools*"'
+
 # only for 3.10
 checkVulnerableDir "/usr/local/py-utils/shared/lib/python3.10/site-packages/setuptools-65.5.0.dist-info" "3.10"
 checkVulnerableFile "/usr/local/lib/python3.10/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl" "3.10"
+
+# Function to check if a package is installed
+checkPackageInstalled() {
+    if python -c "import $1" &>/dev/null; then
+        echo -e "\n✅ Passed! \n$1 is installed"
+    else
+        echo -e "$1 is NOT installed\n"
+        echoStderr "❌ check failed."
+    fi
+}
+
+# Function to install a package using pip
+installPackage() {
+    python3 -m pip install "$1"
+}
+
+checkPipWorkingCorrectly() {
+    echo -e "\n🧪 Testing whether pip install works fine \n"
+    # List of packages to install via pip
+    packages=("numpy" "requests" "matplotlib")
+    # Install packages and check if installation was successful
+    for package in "${packages[@]}"; do
+        echo -e "\n🧪 Testing pip install $package\n"
+        installPackage "$package"
+        checkPackageInstalled "$package"
+    done
+}
+
+checkPipWorkingCorrectly
 
 # Report result
 reportResults

--- a/test/python/install_python310_setuptools_vulnerability.sh
+++ b/test/python/install_python310_setuptools_vulnerability.sh
@@ -78,8 +78,23 @@ checkVulnerableDir()
     fi
 }
 
+checkVulnerableFile()
+{
+    FILE=$1
+    VERSION=$2
+    
+    if [[ -f $FILE ]] ; then
+        echoStderr "❌ check for vulnerable setuptools version failed for python ${VERSION}."
+        return 1
+    else
+        echo "✅ Passed! Either the container does not have vulnerable version or vulnerable version specific file got removed."
+        return 0
+    fi
+}
+
 # only for 3.10
 checkVulnerableDir "/usr/local/py-utils/shared/lib/python3.10/site-packages/setuptools-65.5.0.dist-info" "3.10"
+checkVulnerableFile "/usr/local/lib/python3.10/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl" "3.10"
 
 # Report result
 reportResults

--- a/test/python/install_python310_setuptools_vulnerability.sh
+++ b/test/python/install_python310_setuptools_vulnerability.sh
@@ -64,40 +64,22 @@ check "which pydocstyle" bash -c "which pydocstyle | grep /usr/local/py-utils/bi
 check "which pylint" bash -c "which pylint | grep /usr/local/py-utils/bin/pylint"
 check "which pytest" bash -c "which pytest | grep /usr/local/py-utils/bin/pytest"
 
-checkVulnerableDir() 
+checkVulnerableFile_OR_DIR()
 {
-    DIRECTORY=$1
-    VERSION=$2
-    
-    if [[ -d $DIRECTORY ]] ; then
-        echoStderr "❌ check for vulnerable setuptools version failed for python ${VERSION}."
-        return 1
-    else
-        echo "✅ Passed! Either the container does not have vulnerable version or vulnerable version specific directory got removed."
-        return 0
-    fi
-}
-
-checkVulnerableFile()
-{
-    FILE=$1
-    VERSION=$2
-    
-    if [[ -f $FILE ]] ; then
-        echoStderr "❌ check for vulnerable setuptools version failed for python ${VERSION}."
-        return 1
-    else
-        echo "✅ Passed! Either the container does not have vulnerable version or vulnerable version specific file got removed."
-        return 0
-    fi
+    for arg in "$@"; do
+        if [[ -e $arg ]]; then
+            echo -e "\n✅ Vulnerable:- ${arg} - exists in v3.10 as Vulnerability Patching has been skipped."
+        else
+            echo -e "\n❌ Vulnerable:- ${arg} - don't exist in v3.10 as Vulnerability Patching has not been skipped."
+        fi
+    done
 }
 
 # print setuptools
-check "all files and folders containing setuptools" bash -c 'find / -name "*setuptools*"'
+check "Show All Files/Folders which include setuptools" bash -c 'find / -name "*setuptools*"'
 
 # only for 3.10
-checkVulnerableDir "/usr/local/py-utils/shared/lib/python3.10/site-packages/setuptools-65.5.0.dist-info" "3.10"
-checkVulnerableFile "/usr/local/lib/python3.10/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl" "3.10"
+checkVulnerableFile_OR_DIR "/usr/local/py-utils/shared/lib/python3.10/site-packages/setuptools-65.5.0.dist-info" "/usr/local/lib/python3.10/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl"
 
 # Function to check if a package is installed
 checkPackageInstalled() {

--- a/test/python/install_python310_skipVulnerabilityPatching_true.sh
+++ b/test/python/install_python310_skipVulnerabilityPatching_true.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+FAILED=()
+
+echoStderr()
+{
+    echo "$@" 1>&2
+}
+
+check-version-ge() {
+    LABEL=$1
+    CURRENT_VERSION=$2
+    REQUIRED_VERSION=$3
+    shift
+    echo -e "\n🧪 Testing $LABEL: '$CURRENT_VERSION' is >= '$REQUIRED_VERSION'"
+    local GREATER_VERSION=$((echo ${CURRENT_VERSION}; echo ${REQUIRED_VERSION}) | sort -V | tail -1)
+    if [ "${CURRENT_VERSION}" == "${GREATER_VERSION}" ]; then
+        echo "✅  Passed!"
+        return 0
+    else
+        echoStderr "❌ $LABEL check failed."
+        FAILED+=("$LABEL")
+        return 1
+    fi
+}
+
+checkPythonPackageVersion()
+{
+    PACKAGE=$1
+    REQUIRED_VERSION=$2
+
+    current_version=$(python -c "import importlib.metadata; print(importlib.metadata.version('${PACKAGE}'))")
+    check-version-ge "${PACKAGE}-requirement" "${current_version}" "${REQUIRED_VERSION}"
+}
+
+checkPythonPackageVersion "setuptools" "65.5.1"
+
+# Check that tools can execute - make sure something didn't get messed up in this scenario
+check "autopep8" autopep8 --version
+check "black" black --version
+check "yapf" yapf --version
+check "bandit" bandit --version
+check "flake8" flake8 --version
+check "mypy" mypy --version
+check "pycodestyle" pycodestyle --version
+check "pydocstyle" pydocstyle --version
+check "pylint" pylint --version
+check "pytest" pytest --version
+check "setuptools" pip list | grep setuptools
+
+# Check paths in settings
+check "which autopep8" bash -c "which autopep8 | grep /usr/local/py-utils/bin/autopep8"
+check "which black" bash -c "which black | grep /usr/local/py-utils/bin/black"
+check "which yapf" bash -c "which yapf | grep /usr/local/py-utils/bin/yapf"
+check "which bandit" bash -c "which bandit | grep /usr/local/py-utils/bin/bandit"
+check "which flake8" bash -c "which flake8 | grep /usr/local/py-utils/bin/flake8"
+check "which mypy" bash -c "which mypy | grep /usr/local/py-utils/bin/mypy"
+check "which pycodestyle" bash -c "which pycodestyle | grep /usr/local/py-utils/bin/pycodestyle"
+check "which pydocstyle" bash -c "which pydocstyle | grep /usr/local/py-utils/bin/pydocstyle"
+check "which pylint" bash -c "which pylint | grep /usr/local/py-utils/bin/pylint"
+check "which pytest" bash -c "which pytest | grep /usr/local/py-utils/bin/pytest"
+
+HL="\033[1;33m"
+N="\033[0;37m"
+
+checkVulnerableFile_OR_DIR()
+{
+    for arg in "$@"; do
+        if [[ -e $arg ]]; then
+            echo -e "\n✅${HL} Vulnerable:- ${N}${arg} - ${HL}EXISTS ${N}in v3.10 as skipVulnerabilityPatching=true"
+        else
+            echo -e "\n❌${HL} Vulnerable:- ${arg} - ${N}don't ${HL}EXISTS ${N}in v3.10 as skipVulnerabilityPatching=false"
+        fi
+    done
+}
+
+# print setuptools
+check "Show All Files/Folders which include setuptools" bash -c 'find / -name "*setuptools*"'
+
+# only for 3.10
+checkVulnerableFile_OR_DIR "/usr/local/py-utils/shared/lib/python3.10/site-packages/setuptools-65.5.0.dist-info" "/usr/local/lib/python3.10/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl"
+
+# Function to check if a package is installed
+checkPackageInstalled() {
+    if python -c "import $1" &>/dev/null; then
+        echo -e "\n✅ Passed! \n$1 is installed"
+    else
+        echo -e "$1 is NOT installed\n"
+        echoStderr "❌ check failed."
+    fi
+}
+
+# Function to install a package using pip
+installPackage() {
+    python3 -m pip install "$1"
+}
+
+checkPipWorkingCorrectly() {
+    echo -e "\n🧪 Testing whether pip install works fine \n"
+    # List of packages to install via pip
+    packages=("numpy" "requests" "matplotlib")
+    # Install packages and check if installation was successful
+    for package in "${packages[@]}"; do
+        echo -e "\n🧪 Testing pip install $package\n"
+        installPackage "$package"
+        checkPackageInstalled "$package"
+    done
+}
+
+checkPipWorkingCorrectly
+
+# Report result
+reportResults

--- a/test/python/install_python311_setuptools_vulnerability.sh
+++ b/test/python/install_python311_setuptools_vulnerability.sh
@@ -79,8 +79,23 @@ checkVulnerableDir()
     fi
 }
 
+checkVulnerableFile()
+{
+    FILE=$1
+    VERSION=$2
+    
+    if [[ -f $FILE ]] ; then
+        echoStderr "❌ check for vulnerable setuptools version failed for python ${VERSION}."
+        return 1
+    else
+        echo "✅ Passed! Either the container does not have vulnerable version or vulnerable version specific file got removed."
+        return 0
+    fi
+}
+
 # only for 3.11
 checkVulnerableDir "/usr/local/py-utils/shared/lib/python3.11/site-packages/setuptools-65.5.0.dist-info" "3.11"
+checkVulnerableFile "/usr/local/lib/python3.11/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl" "3.11"
 
 # Report result
 reportResults

--- a/test/python/install_python311_setuptools_vulnerability.sh
+++ b/test/python/install_python311_setuptools_vulnerability.sh
@@ -93,9 +93,41 @@ checkVulnerableFile()
     fi
 }
 
+# print setuptools
+check "all files and folders containing setuptools" bash -c 'find / -name "*setuptools*"'
+
 # only for 3.11
 checkVulnerableDir "/usr/local/py-utils/shared/lib/python3.11/site-packages/setuptools-65.5.0.dist-info" "3.11"
 checkVulnerableFile "/usr/local/lib/python3.11/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl" "3.11"
+
+# Function to check if a package is installed
+checkPackageInstalled() {
+    if python -c "import $1" &>/dev/null; then
+        echo -e "\n✅ Passed! \n$1 is installed"
+    else
+        echo -e "$1 is NOT installed\n"
+        echoStderr "❌ check failed."
+    fi
+}
+
+# Function to install a package using pip
+installPackage() {
+    python3 -m pip install "$1"
+}
+
+checkPipWorkingCorrectly() {
+    echo -e "\n🧪 Testing whether pip install works fine \n"
+    # List of packages to install via pip
+    packages=("numpy" "requests" "matplotlib")
+    # Install packages and check if installation was successful
+    for package in "${packages[@]}"; do
+        echo -e "\n🧪 Testing pip install $package\n"
+        installPackage "$package"
+        checkPackageInstalled "$package"
+    done
+}
+
+checkPipWorkingCorrectly
 
 # Report result
 reportResults

--- a/test/python/install_python311_setuptools_vulnerability.sh
+++ b/test/python/install_python311_setuptools_vulnerability.sh
@@ -65,40 +65,22 @@ check "which pydocstyle" bash -c "which pydocstyle | grep /usr/local/py-utils/bi
 check "which pylint" bash -c "which pylint | grep /usr/local/py-utils/bin/pylint"
 check "which pytest" bash -c "which pytest | grep /usr/local/py-utils/bin/pytest"
 
-checkVulnerableDir() 
+checkVulnerableFile_OR_DIR()
 {
-    DIRECTORY=$1
-    VERSION=$2
-    
-    if [[ -d $DIRECTORY ]] ; then
-        echoStderr "❌ check for vulnerable setuptools version failed for python ${VERSION}."
-        return 1
-    else
-        echo "✅ Passed! Either the container does not have vulnerable version or vulnerable version specific directory got removed."
-        return 0
-    fi
-}
-
-checkVulnerableFile()
-{
-    FILE=$1
-    VERSION=$2
-    
-    if [[ -f $FILE ]] ; then
-        echoStderr "❌ check for vulnerable setuptools version failed for python ${VERSION}."
-        return 1
-    else
-        echo "✅ Passed! Either the container does not have vulnerable version or vulnerable version specific file got removed."
-        return 0
-    fi
+    for arg in "$@"; do
+        if [[ -e $arg ]]; then
+            echo -e "\n✅ Vulnerable:- ${arg} - exists in v3.11 as Vulnerability Patching has been skipped."
+        else
+            echo -e "\n❌ Vulnerable:- ${arg} - don't exist in v3.11 as Vulnerability Patching has not been skipped."
+        fi
+    done
 }
 
 # print setuptools
-check "all files and folders containing setuptools" bash -c 'find / -name "*setuptools*"'
+check "Show All Files/Folders which include setuptools" bash -c 'find / -name "*setuptools*"'
 
 # only for 3.11
-checkVulnerableDir "/usr/local/py-utils/shared/lib/python3.11/site-packages/setuptools-65.5.0.dist-info" "3.11"
-checkVulnerableFile "/usr/local/lib/python3.11/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl" "3.11"
+checkVulnerableFile_OR_DIR "/usr/local/py-utils/shared/lib/python3.11/site-packages/setuptools-65.5.0.dist-info" "/usr/local/lib/python3.11/ensurepip/_bundled/setuptools-65.5.0-py3-none-any.whl"
 
 # Function to check if a package is installed
 checkPackageInstalled() {

--- a/test/python/scenarios.json
+++ b/test/python/scenarios.json
@@ -1,4 +1,14 @@
 {
+    "install_python310_skipVulnerabilityPatching_true": {
+        "image": "python:3.10",
+        "features": {
+            "python": {
+                "version": "none",
+                "installTools": true,
+                "skipVulnerabilityPatching": true
+            }
+        }
+    },
     "install_python310_setuptools_vulnerability": {
         "image": "python:3.10",
         "features": {

--- a/test/python/scenarios.json
+++ b/test/python/scenarios.json
@@ -4,7 +4,8 @@
         "features": {
             "python": {
                 "version": "none",
-                "installTools": true
+                "installTools": true,
+                "skipVulnerabilityPatching": false
             }
         }
     },
@@ -13,7 +14,8 @@
         "features": {
             "python": {
                 "version": "none",
-                "installTools": true
+                "installTools": true,
+                "skipVulnerabilityPatching": false
             }
         }
     },


### PR DESCRIPTION
 **Feature name**:
 
 * Python
 
 **Description**:
 
 This PR patches the following vulnerability:
 
 * [GHSA-r9hx-vwmv-q579](https://github.com/advisories/GHSA-r9hx-vwmv-q579) - related to the `setuptools` package;
 
 _Changelog_:
 
 * Updated `install.sh` file
   * Replaced `setuptools-65.5.0-py3-none-any.whl` with `setuptools-69.1.0-py3-none-any.whl`
     * Downloaded `setuptools` source distribution;
	 * Extracted and built from unzipped source distribution contents, the required file.
	 * Updated `__init__.py` file inside `ensurepip` folder to have the corresponding correct version of `setuptools`.
	 
 * Updated tests to verify that the vulnerable file `setuptools-65.5.0-py3-none-any.whl` no longer exists, which fixes [GHSA-r9hx-vwmv-q579](https://github.com/advisories/GHSA-r9hx-vwmv-q579));
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected