### PR TITLE
[ docker-in-docker ] - buildx can fallback to previous version if latest artifact not found

### DIFF
--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "name": "Docker (Docker-in-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
     "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -343,7 +343,8 @@ get_latest_version() {
 get_previous_version() {
     latest_version="$1"
     repo_url=$2
-    curl -s "$repo_url" | jq -r --arg latest "$latest_version" '.[].tag_name | select(. != $latest)' | sort -rV | head -n 1
+    # curl -s "$repo_url" | jq -r --arg latest "$latest_version" '.[].tag_name | select(. != $latest)' | sort -rV | head -n 1   # this helps filter tag_names based on semver specifications, this one was incorrectly installing 0.12.0-rc2 which is the third in the list i.e seeing from top to bottom
+    curl -s "$repo_url" | jq -r 'del(.[].assets) | .[1].tag_name' # this would del the assets key and then get the second encountered tag_name's value from the filtered array of objects
 }
 
 # Function to change the patch number in a semver version

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -343,10 +343,10 @@ fetch_previous_version() {
     if [ $wget_exit_code -ne 0 ]; then # means wget command to fetch latest version failed
         if [ $wget_exit_code -eq 8 ]; then  # failure due to 404: Not Found.
             echo -e "\n(!) Failed to fetch the latest artifacts for docker buildx v${buildx_version}..."
-            echo -e "\nAttempting to install v${previous_version}"
             repo_url="https://api.github.com/repos/docker/buildx/releases" # GitHub repository URL
             previous_version=$(get_previous_version "${repo_url}")
             buildx_file_name="buildx-${previous_version}.linux-${architecture}"
+            echo -e "\nAttempting to install ${previous_version}"
             wget https://github.com/docker/buildx/releases/download/${previous_version}/${buildx_file_name}
         else
             echo "(!) Failed to download docker buildx with exit code: $wget_exit_code"

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -338,20 +338,18 @@ get_previous_version() {
     curl -s "$repo_url" | jq -r 'del(.[].assets) | .[1].tag_name' # this would del the assets key and then get the second encountered tag_name's value from the filtered array of objects
 }
 
-fetch_previous_version() {
+install_previous_version_artifacts() {
     wget_exit_code=$?
-    if [ $wget_exit_code -ne 0 ]; then # means wget command to fetch latest version failed
-        if [ $wget_exit_code -eq 8 ]; then  # failure due to 404: Not Found.
-            echo -e "\n(!) Failed to fetch the latest artifacts for docker buildx v${buildx_version}..."
-            repo_url="https://api.github.com/repos/docker/buildx/releases" # GitHub repository URL
-            previous_version=$(get_previous_version "${repo_url}")
-            buildx_file_name="buildx-${previous_version}.linux-${architecture}"
-            echo -e "\nAttempting to install ${previous_version}"
-            wget https://github.com/docker/buildx/releases/download/${previous_version}/${buildx_file_name}
-        else
-            echo "(!) Failed to download docker buildx with exit code: $wget_exit_code"
-            exit 1
-        fi
+    if [ $wget_exit_code -eq 8 ]; then  # failure due to 404: Not Found.
+        echo -e "\n(!) Failed to fetch the latest artifacts for docker buildx v${buildx_version}..."
+        repo_url="https://api.github.com/repos/docker/buildx/releases" # GitHub repository URL
+        previous_version=$(get_previous_version "${repo_url}")
+        buildx_file_name="buildx-${previous_version}.linux-${architecture}"
+        echo -e "\nAttempting to install ${previous_version}"
+        wget https://github.com/docker/buildx/releases/download/${previous_version}/${buildx_file_name}
+    else
+        echo "(!) Failed to download docker buildx with exit code: $wget_exit_code"
+        exit 1
     fi
 }
  
@@ -362,7 +360,7 @@ if [ "${INSTALL_DOCKER_BUILDX}" = "true" ]; then
     buildx_file_name="buildx-v${buildx_version}.linux-${architecture}"
     
     cd /tmp
-    wget https://github.com/docker/buildx/releases/download/v${buildx_version}/${buildx_file_name} || fetch_previous_version
+    wget https://github.com/docker/buildx/releases/download/v${buildx_version}/${buildx_file_name} || install_previous_version_artifacts
     
     docker_home="/usr/libexec/docker"
     cli_plugins_dir="${docker_home}/cli-plugins"

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -19,6 +19,7 @@ INSTALL_DOCKER_BUILDX="${INSTALLDOCKERBUILDX:-"true"}"
 MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
 DOCKER_MOBY_ARCHIVE_VERSION_CODENAMES="bookworm buster bullseye bionic focal jammy"
 DOCKER_LICENSED_ARCHIVE_VERSION_CODENAMES="bookworm buster bullseye bionic focal hirsute impish jammy"
+FALLBACK="${FALLBACK:-"false"}" # fallback to previous version, for testing purpose only
 
 # Default: Exit on any failure.
 set -e
@@ -139,7 +140,7 @@ else
 fi
 
 # Install dependencies
-check_packages apt-transport-https curl ca-certificates pigz iptables gnupg2 dirmngr wget
+check_packages apt-transport-https curl ca-certificates pigz iptables gnupg2 dirmngr wget jq
 if ! type git > /dev/null 2>&1; then
     check_packages git
 fi
@@ -332,13 +333,63 @@ fi
 
 usermod -aG docker ${USERNAME}
 
+# Function to fetch the latest version of the plugin
+get_latest_version() {
+    repo_url=$1
+    curl -s "$repo_url/latest" | jq -r '.tag_name'
+}
+
+# Function to fetch the version released prior to the latest version
+get_previous_version() {
+    latest_version="$1"
+    repo_url=$2
+    curl -s "$repo_url" | jq -r --arg latest "$latest_version" '.[].tag_name | select(. != $latest)' | sort -rV | head -n 1
+}
+
+# Function to change the patch number in a semver version
+change_patch_number() {
+    local version="$1"  # Input version
+    local new_patch="$2"  # New patch number
+    # Extract major, minor, and current patch numbers
+    local major=$(echo "$version" | cut -d. -f1)
+    local minor=$(echo "$version" | cut -d. -f2)
+    local current_patch=$(echo "$version" | cut -d. -f3)
+    # Construct the new version with the updated patch number
+    local new_version="$major.$minor.$new_patch"
+    echo "$new_version"
+}
+
 if [ "${INSTALL_DOCKER_BUILDX}" = "true" ]; then
     buildx_version="latest"
     find_version_from_git_tags buildx_version "https://github.com/docker/buildx" "refs/tags/v"
-
     echo "(*) Installing buildx ${buildx_version}..."
     buildx_file_name="buildx-v${buildx_version}.linux-${architecture}"
-    cd /tmp && wget "https://github.com/docker/buildx/releases/download/v${buildx_version}/${buildx_file_name}"
+    if [ $FALLBACK = "true" ]; then # flag to initiate testing of fallback feature
+        set -x # for getting detailed logs in case of a failure - flag to mark start of code
+        new_patch_number="42" # for testing a tag not found scenario for docker/buildx plugin
+        buildx_version_fallback_test=$(change_patch_number "$buildx_version" "$new_patch_number") # for testing a tag not found scenario for docker/buildx plugin
+        buildx_file_name="buildx-v${buildx_version_fallback_test}.linux-${architecture}"
+        buildx_version=$buildx_version_fallback_test
+    fi 
+    cd /tmp
+    wget https://github.com/docker/buildx/releases/download/v${buildx_version}/${buildx_file_name} || {
+        wget_exit_code=$?
+        if [ $wget_exit_code -ne 0 ]; then # means wget command to fetch latest version failed
+            if [ $wget_exit_code -eq 8 ]; then  # failure due to 404: Not Found.
+                echo "wget command failed with HTTP error 404 Not Found"
+                repo_url="https://api.github.com/repos/docker/buildx/releases" # GitHub repository URL
+                latest_version=$(get_latest_version "${repo_url}")  # can take latest_version from fn get_latest_version
+                # latest_version="v${buildx_version}" # can also take latest_version from fn find_version_from_git_tags
+                previous_version=$(get_previous_version "${latest_version}" "${repo_url}")
+                buildx_file_name="buildx-${previous_version}.linux-${architecture}"
+                wget https://github.com/docker/buildx/releases/download/${previous_version}/${buildx_file_name}
+            else
+                echo "Wget failed with exit code: $wget_exit_code"
+            fi
+        else 
+            echo -e "Latest Version Fetch - Succeeded.\n"
+        fi
+    }
 
     docker_home="/usr/libexec/docker"
     cli_plugins_dir="${docker_home}/cli-plugins"
@@ -350,6 +401,7 @@ if [ "${INSTALL_DOCKER_BUILDX}" = "true" ]; then
     chown -R "${USERNAME}:docker" "${docker_home}"
     chmod -R g+r+w "${docker_home}"
     find "${docker_home}" -type d -print0 | xargs -n 1 -0 chmod g+s
+    set +x # for getting detailed logs in case of a failure - flag to mark end of code
 fi
 
 tee /usr/local/share/docker-init.sh > /dev/null \

--- a/test/docker-in-docker/docker_build_fallback_buildx.sh
+++ b/test/docker-in-docker/docker_build_fallback_buildx.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "docker-buildx" docker buildx version
+check "docker-build" docker build ./
+check "docker-buildx" bash -c "docker buildx version"
+check "docker-buildx-path" bash -c "ls -la /usr/libexec/docker/cli-plugins/docker-buildx"
+
+# Report result
+reportResults

--- a/test/docker-in-docker/docker_build_fallback_buildx.sh
+++ b/test/docker-in-docker/docker_build_fallback_buildx.sh
@@ -46,8 +46,8 @@ fetch_previous_version() {
     if [ $wget_exit_code -ne 0 ]; then # means wget command to fetch latest version failed
         if [ $wget_exit_code -eq 8 ]; then  # failure due to 404: Not Found.
             echo -e "\n(!) Failed to fetch the latest artifacts for docker buildx ${buildx_version}..."
-            echo -e "\nAttempting to install ${previous_version}"
             previous_version=$(get_previous_version)
+            echo -e "\nAttempting to install ${previous_version}"
             buildx_file_name="buildx-${previous_version}.linux-${architecture}"
             wget https://github.com/docker/buildx/releases/download/${previous_version}/${buildx_file_name}
         else

--- a/test/docker-in-docker/docker_build_fallback_buildx.sh
+++ b/test/docker-in-docker/docker_build_fallback_buildx.sh
@@ -5,6 +5,76 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
+
+# Code to test the made up scenario when latest version of docker/buildx fails on wget command for fetching the artifacts
+repo_url="https://api.github.com/repos/docker/buildx/releases" # GitHub repository URL
+architecture="$(dpkg --print-architecture)"
+
+# Function to fetch the latest version of the plugin
+get_latest_version() {
+    curl -s "$repo_url/latest" | jq -r '.tag_name'
+}
+
+# Function to fetch the previous version of the plugin
+get_previous_version() {
+    curl -s "$repo_url" | jq -r 'del(.[].assets) | .[1].tag_name' # this would del the assets key and then get the second encountered tag_name's value from the filtered array of objects
+}
+
+# Function to change the patch number in a semver version
+change_patch_number() {
+    local version="$1"  # Input version
+    local new_patch="$2"  # New patch number
+    # Extract major, minor, and current patch numbers
+    local major=$(echo "$version" | cut -d. -f1)
+    local minor=$(echo "$version" | cut -d. -f2)
+    local current_patch=$(echo "$version" | cut -d. -f3)
+    # Construct the new version with the updated patch number
+    local new_version="$major.$minor.$new_patch"
+    echo "$new_version"
+}
+
+change_version_to_fail() {
+    latest_version=$1
+    new_patch_number="xyz" # for testing a tag not found scenario for docker/buildx plugin
+    latest_version=$(get_latest_version)  # can take latest_version from fn get_latest_version
+    buildx_version_fallback_test=$(change_patch_number "$latest_version" "$new_patch_number") # for testing a tag not found scenario for docker/buildx plugin
+    echo "${buildx_version_fallback_test}"
+}
+
+fetch_previous_version() {
+    wget_exit_code=$?
+    if [ $wget_exit_code -ne 0 ]; then # means wget command to fetch latest version failed
+        if [ $wget_exit_code -eq 8 ]; then  # failure due to 404: Not Found.
+            echo -e "\n(!) Failed to fetch the latest artifacts for docker buildx ${buildx_version}..."
+            echo -e "\nAttempting to install ${previous_version}"
+            previous_version=$(get_previous_version)
+            buildx_file_name="buildx-${previous_version}.linux-${architecture}"
+            wget https://github.com/docker/buildx/releases/download/${previous_version}/${buildx_file_name}
+        else
+            echo "(!) Failed to download docker buildx with exit code: $wget_exit_code"
+            exit 1
+        fi
+    fi
+}
+    
+test_version=$(change_version_to_fail "$(get_latest_version)")
+buildx_file_name="buildx-${test_version}.linux-${architecture}"
+buildx_version=$test_version
+
+# This wget command will fail as the wrong version won't fetch artifact
+wget https://github.com/docker/buildx/releases/download/${buildx_version}/${buildx_file_name} || fetch_previous_version
+
+docker_home="/usr/libexec/docker"
+cli_plugins_dir="${docker_home}/cli-plugins"
+
+mkdir -p ${cli_plugins_dir}
+mv ${buildx_file_name} ${cli_plugins_dir}/docker-buildx
+chmod +x ${cli_plugins_dir}/docker-buildx
+
+chown -R "${USERNAME}:docker" "${docker_home}"
+chmod -R g+r+w "${docker_home}"
+find "${docker_home}" -type d -print0 | xargs -n 1 -0 chmod g+s
+
 # Definition specific tests
 check "docker-buildx" docker buildx version
 check "docker-build" docker build ./

--- a/test/docker-in-docker/scenarios.json
+++ b/test/docker-in-docker/scenarios.json
@@ -92,7 +92,6 @@
         "features": {
             "docker-in-docker": {
                 "version": "latest",
-                "fallback": true,
                 "installDockerBuildx": true,
                 "moby": "false",
                 "dockerDashComposeVersion": "v2"

--- a/test/docker-in-docker/scenarios.json
+++ b/test/docker-in-docker/scenarios.json
@@ -87,6 +87,18 @@
             }
         }
     },
+    "docker_build_fallback_buildx": {
+        "image": "ubuntu:focal",
+        "features": {
+            "docker-in-docker": {
+                "version": "latest",
+                "fallback": true,
+                "installDockerBuildx": true,
+                "moby": "false",
+                "dockerDashComposeVersion": "v2"
+            }
+        }
+    },
     // DO NOT REMOVE: This scenario is used by the docker-in-docker-stress-test workflow
     "docker_with_on_create_command": {
         "image": "mcr.microsoft.com/devcontainers/base:debian",


### PR DESCRIPTION
 **Feature name**:
 
 * Docker-in-Docker
 
 **Description**:
 
 This PR introduces the following feature:
 
 * `docker/buildx` plugin can fallback to previous version in case of latest tag artifact release not found;
  
 _Changelog_:
 
 * Updated install.sh file
   * Introduced a new flag `fallback` for testing this new feature
   * Code written for fallback to prev. version in case of latest artifact release not found
 * Added a scenario in `scenarios.json` and a corresponding test scenario `docker_build_fallback_buildx`
 
 _Command for testing_:
 
 `devcontainer features test . -f docker-in-docker --skip-autogenerated --filter "docker_build_fallback_buildx" --preserve-test-containers`