### PR TITLE
Fix Bundle Install Permission Issue

### DIFF
--- a/src/ruby/install.sh
+++ b/src/ruby/install.sh
@@ -293,6 +293,7 @@ fi
 chown -R "${USERNAME}:rvm" "/usr/local/rvm/"
 chmod -R g+r+w "/usr/local/rvm/"
 find "/usr/local/rvm/" -type d | xargs -n 1 chmod g+s
+chown -R "${USERNAME}:rvm" "/usr/local/rvm/gems/ruby-*/extensions/*"
 
 # Clean up
 rvm cleanup all


### PR DESCRIPTION
This PR fixes #871 by making USER owner of `extensions` directory so that `bundle install` from current user can download and install gems without permission error.