### PR TITLE
Fix PowerShell profile not loading

### DIFF
--- a/src/powershell/devcontainer-feature.json
+++ b/src/powershell/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "powershell",
-    "version": "1.3.4",
+    "version": "1.3.3",
     "name": "PowerShell",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/powershell",
     "description": "Installs PowerShell along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",

--- a/src/powershell/devcontainer-feature.json
+++ b/src/powershell/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "powershell",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "name": "PowerShell",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/powershell",
     "description": "Installs PowerShell along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",
@@ -20,7 +20,7 @@
             "default": "",
             "description": "Optional comma separated list of PowerShell modules to install."
         },
-        "powershellProfileURL ": {
+        "powershellProfileURL": {
             "type": "string",
             "default": "",
             "description": "Optional (publicly accessible) URL to download PowerShell profile."

--- a/src/powershell/devcontainer-feature.json
+++ b/src/powershell/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "powershell",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "name": "PowerShell",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/powershell",
     "description": "Installs PowerShell along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",

--- a/src/powershell/install.sh
+++ b/src/powershell/install.sh
@@ -169,7 +169,7 @@ if [ -n "$POWERSHELL_PROFILE_URL" ]; then
     echo "Downloading PowerShell Profile from: $POWERSHELL_PROFILE_URL"
     # Get profile path from currently installed pwsh
     profilePath=$(pwsh -noni -c '$PROFILE.AllUsersAllHosts')
-    sudo curl -sSL -o "$profilePath" "$POWERSHELL_PROFILE_URL"
+    sudo -E curl -sSL -o "$profilePath" "$POWERSHELL_PROFILE_URL"
 fi
 
 # Clean up

--- a/src/powershell/install.sh
+++ b/src/powershell/install.sh
@@ -12,11 +12,9 @@ set -e
 # Clean up
 rm -rf /var/lib/apt/lists/*
 
-USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
-
 POWERSHELL_VERSION=${VERSION:-"latest"}
 POWERSHELL_MODULES="${MODULES:-""}"
-POWERSHELL_PROFILE_URL="${PROFILE_URL}"
+POWERSHELL_PROFILE_URL="${POWERSHELLPROFILEURL}"
 
 MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
 POWERSHELL_ARCHIVE_ARCHITECTURES="amd64"
@@ -165,26 +163,13 @@ if [ ${#POWERSHELL_MODULES[@]} -gt 0 ]; then
     done
 fi
 
- # Determine the appropriate non-root user 
- if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then 
-     USERNAME="" 
-     POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)") 
-     for CURRENT_USER in "${POSSIBLE_USERS[@]}"; do 
-         if id -u ${CURRENT_USER} > /dev/null 2>&1; then 
-             USERNAME=${CURRENT_USER} 
-             break 
-         fi 
-     done 
-     if [ "${USERNAME}" = "" ]; then 
-         USERNAME=root 
-     fi 
- elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then 
-     USERNAME=root 
- fi 
+
 # If URL for powershell profile is provided, download it to '/opt/microsoft/powershell/7/profile.ps1'
 if [ -n "$POWERSHELL_PROFILE_URL" ]; then
     echo "Downloading PowerShell Profile from: $POWERSHELL_PROFILE_URL"
-    su ${USERNAME} -c "curl -sSL -o '/opt/microsoft/powershell/7/profile.ps1' '$POWERSHELL_PROFILE_URL'"
+    # Get profile path from currently installed pwsh
+    profilePath=$(pwsh -noni -c '$PROFILE.AllUsersAllHosts')
+    sudo curl -sSL -o "$profilePath" "$POWERSHELL_PROFILE_URL"
 fi
 
 # Clean up


### PR DESCRIPTION
Hello @samruddhikhandale, Its me again.

I tested the https://github.com/devcontainers/features/pull/876 and it still does not work. I found out how to test a feature locally and confirm what we are trying to achieve will not work with `su` as `su` will always ask for password when switching to `root` user. The code snippet we added from the node is to figure out non-root user and not to become root user. So, using `sudo` is our only option. I've added `-E` so that should take care of concerns about environment not passed to sudo.

Additionally, I've updated the code to get Profile path from PowerShell itself instead of hardcoding it.

Let me know if you have any questions