### PR TITLE
Oryx: Clean up additional installation of .NET

### DIFF
--- a/src/oryx/devcontainer-feature.json
+++ b/src/oryx/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "oryx",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "name": "Oryx",
     "description": "Installs the oryx CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/oryx",

--- a/test/oryx/install_dotnet_and_oryx.sh
+++ b/test/oryx/install_dotnet_and_oryx.sh
@@ -5,6 +5,9 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
+# Runtimes are listed twice due to 'Microsoft.NETCore.App' and 'Microsoft.AspNetCore.App'
+check "two versions of dotnet runtimes are present" bash -c "[ $(dotnet --list-runtimes | wc -l) -eq 4 ]"
+
 check "Oryx version" oryx --version
 check "Dotnet is not removed if it is not installed by the Oryx Feature" dotnet --version
 


### PR DESCRIPTION
Required to fix universal test failures, see [here](https://github.com/devcontainers/images/actions/runs/8144217851/job/22257847079?pr=981#step:3:41232) - We should completely clean up the additional installation of .NET

We are installing a specific version of .NET due to https://github.com/devcontainers/features/pull/882 