### PR TITLE
[docker] - Install previous version if current tags are missing artifacts

### DIFF
--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "2.10.0",
+    "version": "2.10.1",
     "name": "Docker (Docker-in-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
     "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",


### PR DESCRIPTION
Fixes: https://github.com/devcontainers/features/issues/883

Currently, `docker-in-docker` Feature builds are failing as the latest tag available for docker-compose is [v2.24.7](https://github.com/docker/compose/releases/tag/v2.24.7), however, the corresponding releases are still not available. This PR, attempts to find a previous version in such scenarios