### PR TITLE
[docker-outside-of-docker] compose-switch can fallback to previous version

### DIFF
--- a/src/docker-outside-of-docker/install.sh
+++ b/src/docker-outside-of-docker/install.sh
@@ -99,6 +99,22 @@ find_version_from_git_tags() {
     echo "${variable_name}=${!variable_name}"
 }
 
+# Function to fetch the previous version of the plugin
+get_previous_version() {
+    repo_url=$1
+    # this would del the assets key and then get the second encountered tag_name's value from the filtered array of objects
+    curl -s "$repo_url" | jq -r 'del(.[].assets) | .[1].tag_name' 
+}
+
+
+install_compose_switch_fallback() {
+    echo -e "\n(!) Failed to fetch the latest artifacts for compose-switch v${compose_switch_version}..."
+    previous_version=$(get_previous_version "https://api.github.com/repos/docker/compose-switch/releases")
+    echo -e "\nAttempting to install ${previous_version}"
+    compose_switch_version=${previous_version#v}
+    curl -fsSL "https://github.com/docker/compose-switch/releases/download/v${compose_switch_version}/docker-compose-linux-${architecture}" -o /usr/local/bin/docker-compose
+}
+
 # Ensure apt is in non-interactive to avoid prompts
 export DEBIAN_FRONTEND=noninteractive
 
@@ -255,7 +271,7 @@ if [ "${DOCKER_DASH_COMPOSE_VERSION}" != "none" ]; then
         echo "(*) Installing compose-switch as docker-compose..."
         compose_switch_version="latest"
         find_version_from_git_tags compose_switch_version "https://github.com/docker/compose-switch"
-        curl -fsSL "https://github.com/docker/compose-switch/releases/download/v${compose_switch_version}/docker-compose-linux-${architecture}" -o /usr/local/bin/docker-compose
+        curl -fsSL "https://github.com/docker/compose-switch/releases/download/v${compose_switch_version}/docker-compose-linux-${architecture}" -o /usr/local/bin/docker-compose || install_compose_switch_fallback
         chmod +x /usr/local/bin/docker-compose
         # TODO: Verify checksum once available: https://github.com/docker/compose-switch/issues/11
     fi

--- a/test/docker-outside-of-docker/docker_build_compose_fallback.sh
+++ b/test/docker-outside-of-docker/docker_build_compose_fallback.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "installs compose-switch as docker-compose" bash -c "[[ -f /usr/local/bin/docker-compose ]]"
+
+# Fetch host/container arch.
+architecture="$(dpkg --print-architecture)"
+
+repo_url="https://api.github.com/repos/docker/compose-switch/releases"
+
+# Function to fetch the latest version of the plugin
+get_latest_version() {
+    sudo curl -s "$repo_url/latest" | jq -r '.tag_name'
+}
+
+# Function to fetch the previous version of the plugin
+get_previous_version() {
+    sudo curl -s "$repo_url" | jq -r 'del(.[].assets) | .[1].tag_name' # this would del the assets key and then get the second encountered tag_name's value from the filtered array of objects
+}
+
+desired_version=$(get_latest_version)
+desired_version=${desired_version#v}
+
+check_docker_compose_version() {
+    
+    # Check if docker-compose-switch is installed and get its version
+    docker_compose_version=$(docker-compose version --short 2>/dev/null)
+
+    if [ -n "$docker_compose_version" ]; then
+        # Docker Compose is installed
+        echo -e "\nInstalled docker-compose version: $docker_compose_version"
+        
+        # Check if installed version matches the desired version
+        if [ "$docker_compose_version" = "$desired_version" ]; then
+            echo -e "\ndocker-compose version $desired_version is installed."
+        else
+            echo -e "\ndocker-compose version $desired_version is not installed."
+        fi
+    else
+        # Docker Compose is not installed
+        echo -e "\ndocker-compose is not installed."
+    fi
+}
+
+check_docker_compose_version
+
+# Function to change the patch number in a semver version
+change_patch_number() {
+    local version="$1"  # Input version
+    local new_patch="$2"  # New patch number
+    # Extract major, minor, and current patch numbers
+    local major=$(echo "$version" | cut -d. -f1)
+    local minor=$(echo "$version" | cut -d. -f2)
+    local current_patch=$(echo "$version" | cut -d. -f3)
+    # Construct the new version with the updated patch number
+    local new_version="$major.$minor.$new_patch"
+    echo "$new_version"
+}
+
+change_version_to_fail() {
+    new_patch_number="xyz" # for testing a tag not found scenario for docker/buildx plugin
+    latest_version=$(get_latest_version)  # can take latest_version from fn get_latest_version
+    compose_version_fallback_test=$(change_patch_number "$latest_version" "$new_patch_number") # for testing a tag not found scenario for docker/buildx plugin
+    echo "${compose_version_fallback_test}"
+}
+
+install_compose_switch_fallback() {
+    echo -e "\n(!) Failed to fetch the latest artifacts for compose-switch ${test_compose_switch_version}..."
+    previous_version=$(get_previous_version)
+    echo -e "\nAttempting to install ${previous_version}"
+    compose_switch_version=${previous_version}
+    sudo curl -fsSL "https://github.com/docker/compose-switch/releases/download/${compose_switch_version}/docker-compose-linux-${architecture}" -o /usr/local/bin/docker-compose
+}
+
+install_compose-switch_as_docker-compose() {
+    echo "(*) Installing compose-switch as docker-compose..."
+    test_compose_switch_version=$(change_version_to_fail)
+    echo -e "\nTesting with $test_compose_switch_version..."
+    sudo curl -fsSL "https://github.com/docker/compose-switch/releases/download/${test_compose_switch_version}/docker-compose-linux-${architecture}" -o /usr/local/bin/docker-compose || install_compose_switch_fallback
+    sudo chmod +x /usr/local/bin/docker-compose
+}
+
+install_compose-switch_as_docker-compose
+
+desired_version=$(get_previous_version)
+desired_version=${desired_version#v}
+
+check_docker_compose_version
+
+check "installs compose-switch as docker-compose" bash -c "[[ -f /usr/local/bin/docker-compose ]]"

--- a/test/docker-outside-of-docker/scenarios.json
+++ b/test/docker-outside-of-docker/scenarios.json
@@ -1,4 +1,14 @@
 {
+    "docker_build_compose_fallback": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu-20.04",
+        "features": {
+            "docker-outside-of-docker": {
+                "moby": false,
+                "dockerDashComposeVersion": "latest"
+            }
+        },
+        "containerUser": "vscode"
+    },
     "docker_init_moby": {
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu-20.04",
         "features": {


### PR DESCRIPTION
 **Feature name**:
 
 * Docker-outside-of-Docker
 
 **Description**:
 
 This PR adds the following functionality:
 
 * Fallback mechanism for docker-compose-switch
 
 _Changelog_:
 
 * Updated `install.sh` for `docker-outside-of-docker` feature.
 * Updated test file `docker_build_compose_fallback.sh` to verify that fallback mechanism works as expected through an added scenario in `scenarios.json`. 
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected