### PR TITLE
Reverting get_previous_version logic to get the first tag_name's value from json

### DIFF
--- a/src/kubectl-helm-minikube/devcontainer-feature.json
+++ b/src/kubectl-helm-minikube/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "kubectl-helm-minikube",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "name": "Kubectl, Helm, and Minikube",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/kubectl-helm-minikube",
     "description": "Installs latest version of kubectl, Helm, and optionally minikube. Auto-detects latest versions and installs needed dependencies.",

--- a/src/kubectl-helm-minikube/install.sh
+++ b/src/kubectl-helm-minikube/install.sh
@@ -159,7 +159,7 @@ fi
 get_previous_version() {
     repo_url=$1
     # this would del the assets key and then get the second encountered tag_name's value from the filtered array of objects
-    curl -s "$repo_url" | jq -r 'del(.[].assets) | .[1].tag_name' 
+    curl -s "$repo_url" | jq -r 'del(.[].assets) | .[0].tag_name' 
 }
 
 get_helm() {

--- a/src/kubectl-helm-minikube/install.sh
+++ b/src/kubectl-helm-minikube/install.sh
@@ -158,7 +158,7 @@ fi
 # Function to fetch the version released prior to the latest version
 get_previous_version() {
     repo_url=$1
-    # this would del the assets key and then get the second encountered tag_name's value from the filtered array of objects
+    # this would del the assets key and then get the first encountered tag_name's value from the filtered array of objects
     curl -s "$repo_url" | jq -r 'del(.[].assets) | .[0].tag_name' 
 }
 

--- a/test/docker-in-docker/docker_build_fallback_buildx.sh
+++ b/test/docker-in-docker/docker_build_fallback_buildx.sh
@@ -26,7 +26,8 @@ get_latest_version() {
 
 # Function to fetch the previous version of the plugin
 get_previous_version() {
-    curl -s "$repo_url" | jq -r 'del(.[].assets) | .[0].tag_name' # this would del the assets key and then get the second encountered tag_name's value from the filtered array of objects
+    # this would del the assets key and then get the first encountered tag_name's value from the filtered array of objects
+    curl -s "$repo_url" | jq -r 'del(.[].assets) | .[0].tag_name' 
 }
 
 # Function to change the patch number in a semver version

--- a/test/docker-in-docker/docker_build_fallback_buildx.sh
+++ b/test/docker-in-docker/docker_build_fallback_buildx.sh
@@ -26,7 +26,7 @@ get_latest_version() {
 
 # Function to fetch the previous version of the plugin
 get_previous_version() {
-    curl -s "$repo_url" | jq -r 'del(.[].assets) | .[1].tag_name' # this would del the assets key and then get the second encountered tag_name's value from the filtered array of objects
+    curl -s "$repo_url" | jq -r 'del(.[].assets) | .[0].tag_name' # this would del the assets key and then get the second encountered tag_name's value from the filtered array of objects
 }
 
 # Function to change the patch number in a semver version

--- a/test/kubectl-helm-minikube/install_only_helm_fallback.sh
+++ b/test/kubectl-helm-minikube/install_only_helm_fallback.sh
@@ -57,7 +57,7 @@ change_patch_number() {
 # Function to fetch the previous version of the plugin
 get_previous_version() {
     # this would del the assets key and then get the second encountered tag_name's value from the filtered array of objects
-    curl -s "$repo_url" | jq -r 'del(.[].assets) | .[1].tag_name' 
+    curl -s "$repo_url" | jq -r 'del(.[].assets) | .[0].tag_name' 
 }
 
 get_helm() {


### PR DESCRIPTION
 **Features names**:
 
 * Kubectl-helm-minikube
 
 **Description**:
 
 This PR corrects the existing code with the following functionality:
 
 * `kubectl-helm-minikube` feature was picking up the second to latest tag from json array of releases url, now have changed that to pick the first value for `tag_name` key in the same.
 
 _Changelog_:
 
 * Updated `install.sh` file
 * Updated tests
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected