### PR TITLE
[Node] - nvm - fallback to previous version - code fix

### DIFF
--- a/src/node/devcontainer-feature.json
+++ b/src/node/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "node",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "name": "Node.js (via nvm), yarn and pnpm",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/node",
     "description": "Installs Node.js, nvm, yarn, pnpm, and needed dependencies.",

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -293,8 +293,11 @@ set -e
 umask 0002
 # Do not update profile - we'll do this manually
 export PROFILE=/dev/null
-curl -so- "https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh" | bash
-
+curl -so- "https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh" | bash ||  {
+    PREV_NVM_VERSION=$(curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+    curl -so- "https://raw.githubusercontent.com/nvm-sh/nvm/\${PREV_NVM_VERSION}/install.sh" | bash
+    NVM_VERSION="\${PREV_NVM_VERSION}"
+}
 source "${NVM_DIR}/nvm.sh"
 if [ "${NODE_VERSION}" != "" ]; then
     nvm alias default "${NODE_VERSION}"

--- a/test/node/nvm_test_fallback.sh
+++ b/test/node/nvm_test_fallback.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+set -e
+
+trap 'echo "Error occurred at line $LINENO"; exit 1' ERR
+source /usr/local/share/nvm/nvm.sh
+#check nvm version
+echo -e "\n✅ nvm version as installed by feature = v$(nvm --version)"; 
+NVM_DIR="/usr/local/share/nvm"
+NODE_VERSION="lts"
+FAKE_NVM_VERSION="1.2.XYZ"
+curl -so- "https://raw.githubusercontent.com/nvm-sh/nvm/v${FAKE_NVM_VERSION}/install.sh" | bash ||  {
+    PREV_NVM_VERSION=$(curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+    curl -so- "https://raw.githubusercontent.com/nvm-sh/nvm/${PREV_NVM_VERSION}/install.sh" | bash
+    NVM_VERSION="${PREV_NVM_VERSION}"
+}
+
+#check nvm version
+echo -e "\n✅ nvm version as installed by test = v$(nvm --version)"; 
+
+# Report result
+reportResults

--- a/test/node/scenarios.json
+++ b/test/node/scenarios.json
@@ -1,4 +1,12 @@
 {
+    "nvm_test_fallback": {
+        "image": "debian:11",
+        "features": {
+            "node": {
+                "version": "lts"
+            }
+        }
+    },
     "install_additional_node": {
         "image": "debian:11",
         "features": {


### PR DESCRIPTION
 **Feature name**:
 
 * Node
 
 **Description**:
 
 This PR introduces the following functionality:
 
 * When the latest tag for `nvm` doesn't have a source binary released yet, then it will continue installing the previous working version for which a source binary will be available
 
 _Changelog_:
 
 * Updated install.sh
 * Updated tests to validate that when a fake `nvm` version is tried to be downloaded with curl command thus representing trying to access a source binary which is not yet deployed by `nvm`, then will pick up the binary for the tag (previous version) which will eventually work successfully.
 * Updated the `devcontainer-feature.json` with an updated patch version for this feature.
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected
 