### PR TITLE
[kubectl-helm-minikube] - helm - alternative fallback method implemented

### DIFF
--- a/src/kubectl-helm-minikube/devcontainer-feature.json
+++ b/src/kubectl-helm-minikube/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "kubectl-helm-minikube",
-    "version": "1.1.8",
+    "version": "1.1.9",
     "name": "Kubectl, Helm, and Minikube",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/kubectl-helm-minikube",
     "description": "Installs latest version of kubectl, Helm, and optionally minikube. Auto-detects latest versions and installs needed dependencies.",


### PR DESCRIPTION
  **Feature name**:
 
 * Kubectl-helm-minikube
 
 **Description**:
 
 This PR introduces adds following functionality:
 
 * helm has now two fallback methods:
    * GitHub Api - has a disadvantage of imposing rate limits for users
    * find_prev_version_from_git_tags() fn - uses /tags of GitHub repo url for a prev. version
 
 _Changelog_:
 
 * Updated install.sh
 * Updated tests
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected