### PR TITLE
[Ruby]- rvm - fallback code fix

### DIFF
--- a/src/ruby/devcontainer-feature.json
+++ b/src/ruby/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "name": "Ruby (via rvm)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/ruby",
     "description": "Installs Ruby, rvm, rbenv, common Ruby utilities, and needed dependencies.",

--- a/src/ruby/install.sh
+++ b/src/ruby/install.sh
@@ -30,8 +30,6 @@ keyserver hkp://keyserver.pgp.com"
 
 set -e
 
-trap 'echo "Last executed command failed at line ${LINENO}"' ERR
-
 # Clean up
 rm -rf /var/lib/apt/lists/*
 

--- a/src/ruby/install.sh
+++ b/src/ruby/install.sh
@@ -229,11 +229,11 @@ get_previous_version() {
     check_packages jq
 
     message=$(echo "$output" | jq -r '.message')
-    
+
     if [[ $message == "API rate limit exceeded"* ]]; then
         echo -e "\nAn attempt to find latest version using GitHub Api Failed... \nReason: ${message}"
         echo -e "\nAttempting to find latest version using GitHub tags."
-        find_prev_version_from_git_tags prev_version "$url" "tags/v"
+        find_prev_version_from_git_tags prev_version "$url" "tags/v" "_"
         declare -g ${variable_name}="${prev_version}"
     else 
         echo -e "\nAttempting to find latest version using GitHub Api."
@@ -252,7 +252,6 @@ get_github_api_repo_url() {
 # Figure out correct version of a three part version number is not passed
 ruby_url="https://github.com/ruby/ruby"
 find_version_from_git_tags RUBY_VERSION $ruby_url "tags/v" "_"
-RUBY_VERSION="3.3.1"
 
 set_rvm_install_args() {
     if [ "${RUBY_VERSION}" = "none" ]; then
@@ -278,7 +277,7 @@ set_rvm_install_args() {
 install_previous_version() {
     repo_url=$(get_github_api_repo_url "$ruby_url")
     get_previous_version "${ruby_url}" "${repo_url}" RUBY_VERSION
-    set_rvm_install_args "$RUBY_VERSION"
+    set_rvm_install_args
     curl -sSL https://get.rvm.io | bash -s stable --ignore-dotfiles ${RVM_INSTALL_ARGS} --with-default-gems="${DEFAULT_GEMS}" 2>&1
 }
 
@@ -298,7 +297,7 @@ else
     receive_gpg_keys RVM_GPG_KEYS
     # Determine appropriate settings for rvm installer
 
-    set_rvm_install_args "$RUBY_VERSION"
+    set_rvm_install_args
 
     # Create rvm group as a system group to reduce the odds of conflict with local user UIDs
     if ! cat /etc/group | grep -e "^rvm:" > /dev/null 2>&1; then
@@ -312,7 +311,7 @@ else
     rm -rf ${GNUPGHOME}
 fi
 
-if [ "${INSTALL_RUBY_TOOLS}" = "true" ]; then
+if [ "${INSTALL_RUBY_TOOLS}" = "true" ]; then   
     # Non-root user may not have "gem" in path when script is run and no ruby version
     # is installed by rvm, so handle this by using root's default gem in this case
     ROOT_GEM="$(which gem || echo "")"

--- a/test/ruby/ruby_fallback_test.sh
+++ b/test/ruby/ruby_fallback_test.sh
@@ -218,6 +218,7 @@ ruby_url="https://github.com/ruby/ruby"
 RUBY_VERSION="3.1.xyz"
 
 set_rvm_install_args() {
+    RUBY_VERSION=$1
     if [ "${RUBY_VERSION}" = "none" ]; then
         RVM_INSTALL_ARGS=""
     elif [[ "$(ruby -v)" = *"${RUBY_VERSION}"* ]]; then
@@ -242,7 +243,7 @@ install_previous_version() {
     mode=$1
     repo_url=$(get_github_api_repo_url "$ruby_url")
     get_previous_version "${ruby_url}" "${repo_url}" RUBY_VERSION $mode
-    set_rvm_install_args
+    set_rvm_install_args $RUBY_VERSION
     curl -sSL https://get.rvm.io | bash -s stable --ignore-dotfiles ${RVM_INSTALL_ARGS} --with-default-gems="${DEFAULT_GEMS}" 2>&1
 }
 
@@ -251,9 +252,7 @@ install_rvm() {
     # Install RVM
     receive_gpg_keys RVM_GPG_KEYS
     # Determine appropriate settings for rvm installer
-
-    set_rvm_install_args
-
+    set_rvm_install_args $RUBY_VERSION
     # Create rvm group as a system group to reduce the odds of conflict with local user UIDs
     if ! cat /etc/group | grep -e "^rvm:" > /dev/null 2>&1; then
         groupadd -r rvm

--- a/test/ruby/ruby_fallback_test.sh
+++ b/test/ruby/ruby_fallback_test.sh
@@ -1,26 +1,17 @@
-#!/usr/bin/env bash
-#-------------------------------------------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
-#-------------------------------------------------------------------------------------------------------------
-#
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/ruby.md
-# Maintainer: The VS Code and Codespaces Teams
+#!/bin/bash
 
-RUBY_VERSION="${VERSION:-"latest"}"
+set -e
 
-USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
-UPDATE_RC="${UPDATE_RC:-"true"}"
-INSTALL_RUBY_TOOLS="${INSTALL_RUBY_TOOLS:-"true"}"
+# Optional: Import test library
+source dev-container-features-test-lib
 
-# Comma-separated list of ruby versions to be installed (with rvm)
-# alongside RUBY_VERSION, but not set as default.
-ADDITIONAL_VERSIONS="${ADDITIONALVERSIONS:-""}"
+USERNAME="${_REMOTE_USER:-"automatic"}"
+set -x
+echo -e "\nRuby version installed by ruby feature ..."
+check "ruby" ruby -v
+check "rake" bash -c "gem list | grep rake"
 
-# Note: ruby-debug-ide will install the right version of debase if missing and
-# installing debase directly fails on Ruby 3.1.0 as of 1/7/2022, so omitting.
-# installing ruby-debug-ide on debian fails, so omitting.
-DEFAULT_GEMS="rake"
+trap 'echo "Last executed command failed at line ${LINENO}"' ERR
 
 RVM_GPG_KEYS="409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"
 GPG_KEY_SERVERS="keyserver hkp://keyserver.ubuntu.com
@@ -28,22 +19,13 @@ keyserver hkp://keyserver.ubuntu.com:80
 keyserver hkps://keys.openpgp.org
 keyserver hkp://keyserver.pgp.com"
 
-set -e
-
-trap 'echo "Last executed command failed at line ${LINENO}"' ERR
-
 # Clean up
-rm -rf /var/lib/apt/lists/*
+sudo rm -rf /var/lib/apt/lists/*
 
-if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
-    exit 1
-fi
-
-# Ensure that login shells get the correct path if the user updated the PATH using ENV.
-rm -f /etc/profile.d/00-restore-env.sh
-echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
-chmod +x /etc/profile.d/00-restore-env.sh
+# if [ "$(id -u)" -ne 0 ]; then
+#     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+#     exit 1
+# fi
 
 # Determine the appropriate non-root user
 if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
@@ -62,15 +44,28 @@ elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
     USERNAME=root
 fi
 
-updaterc() {
-    if [ "${UPDATE_RC}" = "true" ]; then
-        echo "Updating /etc/bash.bashrc and /etc/zsh/zshrc..."
-        if [[ "$(cat /etc/bash.bashrc)" != *"$1"* ]]; then
-            echo -e "$1" >> /etc/bash.bashrc
-        fi
-        if [ -f "/etc/zsh/zshrc" ] && [[ "$(cat /etc/zsh/zshrc)" != *"$1"* ]]; then
-            echo -e "$1" >> /etc/zsh/zshrc
-        fi
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+architecture="$(uname -m)"
+if [ "${architecture}" != "amd64" ] && [ "${architecture}" != "x86_64" ] && [ "${architecture}" != "arm64" ] && [ "${architecture}" != "aarch64" ]; then
+    echo "(!) Architecture $architecture unsupported"
+    exit 1
+fi
+
+apt_get_update()
+{
+    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        sudo apt-get update -y
+    fi
+}
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" > /dev/null 2>&1; then
+        apt_get_update
+        sudo apt-get -y install --no-install-recommends "$@"
     fi
 }
 
@@ -84,8 +79,8 @@ receive_gpg_keys() {
 
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"
-    mkdir -p ${GNUPGHOME}
-    chmod 700 ${GNUPGHOME}
+    sudo mkdir -p ${GNUPGHOME}
+    sudo chmod 700 ${GNUPGHOME}
     echo -e "disable-ipv6\n${GPG_KEY_SERVERS}" > ${GNUPGHOME}/dirmngr.conf
     # GPG key download sometimes fails for some reason and retrying fixes it.
     local retry_count=0
@@ -183,52 +178,26 @@ find_prev_version_from_git_tags() {
     set -e
 }
 
-apt_get_update()
-{
-    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
-        echo "Running apt-get update..."
-        apt-get update -y
-    fi
-}
-
-# Checks if packages are installed and installs them if not
-check_packages() {
-    if ! dpkg -s "$@" > /dev/null 2>&1; then
-        apt_get_update
-        apt-get -y install --no-install-recommends "$@"
-    fi
-}
-
-# Ensure apt is in non-interactive to avoid prompts
-export DEBIAN_FRONTEND=noninteractive
-
-architecture="$(uname -m)"
-if [ "${architecture}" != "amd64" ] && [ "${architecture}" != "x86_64" ] && [ "${architecture}" != "arm64" ] && [ "${architecture}" != "aarch64" ]; then
-    echo "(!) Architecture $architecture unsupported"
-    exit 1
-fi
-
-# Install dependencies
-check_packages curl ca-certificates software-properties-common build-essential gnupg2 libreadline-dev \
-    procps dirmngr gawk autoconf automake bison libffi-dev libgdbm-dev libncurses5-dev \
-    libsqlite3-dev libtool libyaml-dev pkg-config sqlite3 zlib1g-dev libgmp-dev libssl-dev
-if ! type git > /dev/null 2>&1; then
-    check_packages git
-fi
-
 # Function to fetch the version released prior to the latest version
 get_previous_version() {
     local url=$1
     local repo_url=$2
     local variable_name=$3
+    local mode=$4
     prev_version=${!variable_name}
     
-    output=$(curl -s "$repo_url");
+    output=$(sudo curl -s "$repo_url");
 
     #install jq
     check_packages jq
 
     message=$(echo "$output" | jq -r '.message')
+
+    if [[ $mode == "mode1" ]]; then
+        message="API rate limit exceeded"
+    else 
+        message=""
+    fi
     
     if [[ $message == "API rate limit exceeded"* ]]; then
         echo -e "\nAn attempt to find latest version using GitHub Api Failed... \nReason: ${message}"
@@ -251,8 +220,8 @@ get_github_api_repo_url() {
 
 # Figure out correct version of a three part version number is not passed
 ruby_url="https://github.com/ruby/ruby"
-find_version_from_git_tags RUBY_VERSION $ruby_url "tags/v" "_"
-RUBY_VERSION="3.3.1"
+
+RUBY_VERSION="3.3.xyz"
 
 set_rvm_install_args() {
     if [ "${RUBY_VERSION}" = "none" ]; then
@@ -276,119 +245,54 @@ set_rvm_install_args() {
 }
 
 install_previous_version() {
+    mode=$1
     repo_url=$(get_github_api_repo_url "$ruby_url")
-    get_previous_version "${ruby_url}" "${repo_url}" RUBY_VERSION
+    get_previous_version "${ruby_url}" "${repo_url}" RUBY_VERSION $mode
     set_rvm_install_args "$RUBY_VERSION"
-    curl -sSL https://get.rvm.io | bash -s stable --ignore-dotfiles ${RVM_INSTALL_ARGS} --with-default-gems="${DEFAULT_GEMS}" 2>&1
+    sudo curl -sSL https://get.rvm.io | bash -s stable --ignore-dotfiles ${RVM_INSTALL_ARGS} --with-default-gems="${DEFAULT_GEMS}" 2>&1
 }
 
-# Just install Ruby if RVM already installed
-if rvm --version > /dev/null; then
-    echo "Ruby Version Manager already exists."
-    if [[ "$(ruby -v)" = *"${RUBY_VERSION}"* ]]; then
-        echo "(!) Ruby is already installed with version ${RUBY_VERSION}. Skipping..."
-    elif [ "${RUBY_VERSION}" != "none" ]; then
-        echo "Installing specified Ruby version."
-        su ${USERNAME} -c "rvm install ruby ${RUBY_VERSION}"
-    fi
-    SKIP_GEM_INSTALL="false"
-    SKIP_RBENV_RBUILD="true"
-else
-    # Install RVM
-    receive_gpg_keys RVM_GPG_KEYS
-    # Determine appropriate settings for rvm installer
-
-    set_rvm_install_args "$RUBY_VERSION"
-
-    # Create rvm group as a system group to reduce the odds of conflict with local user UIDs
-    if ! cat /etc/group | grep -e "^rvm:" > /dev/null 2>&1; then
-        groupadd -r rvm
-    fi
-    # Install rvm
-    curl -sSL https://get.rvm.io | bash -s stable --ignore-dotfiles ${RVM_INSTALL_ARGS} --with-default-gems="${DEFAULT_GEMS}" 2>&1 || install_previous_version
-    usermod -aG rvm ${USERNAME}
-    source /usr/local/rvm/scripts/rvm
-    rvm fix-permissions system
-    rm -rf ${GNUPGHOME}
-fi
-
-if [ "${INSTALL_RUBY_TOOLS}" = "true" ]; then
-    # Non-root user may not have "gem" in path when script is run and no ruby version
-    # is installed by rvm, so handle this by using root's default gem in this case
-    ROOT_GEM="$(which gem || echo "")"
-    ${ROOT_GEM} install ${DEFAULT_GEMS}
-fi
-
-# VS Code server usually first in the path, so silence annoying rvm warning (that does not apply) and then source it
-updaterc "if ! grep rvm_silence_path_mismatch_check_flag \$HOME/.rvmrc > /dev/null 2>&1; then echo 'rvm_silence_path_mismatch_check_flag=1' >> \$HOME/.rvmrc; fi\nsource /usr/local/rvm/scripts/rvm > /dev/null 2>&1"
-
-# Additional ruby versions to be installed but not be set as default.
-if [ ! -z "${ADDITIONAL_VERSIONS}" ]; then
-    OLDIFS=$IFS
-    IFS=","
-        read -a additional_versions <<< "$ADDITIONAL_VERSIONS"
-        for version in "${additional_versions[@]}"; do
-            # Figure out correct version of a three part version number is not passed
-            find_version_from_git_tags version $ruby_url "tags/v" "_"
-            source /usr/local/rvm/scripts/rvm
-            rvm install ruby ${version}
-        done
-    IFS=$OLDIFS
-fi
-
-# Install rbenv/ruby-build for good measure
-if [ "${SKIP_RBENV_RBUILD}" != "true" ]; then
-
-    if [[ ! -d "/usr/local/share/rbenv" ]]; then
-        git clone --depth=1 \
-            -c core.eol=lf \
-            -c core.autocrlf=false \
-            -c fsck.zeroPaddedFilemode=ignore \
-            -c fetch.fsck.zeroPaddedFilemode=ignore \
-            -c receive.fsck.zeroPaddedFilemode=ignore \
-            https://github.com/rbenv/rbenv.git /usr/local/share/rbenv
-    fi
-
-    if [[ ! -d "/usr/local/share/ruby-build" ]]; then
-        git clone --depth=1 \
-            -c core.eol=lf \
-            -c core.autocrlf=false \
-            -c fsck.zeroPaddedFilemode=ignore \
-            -c fetch.fsck.zeroPaddedFilemode=ignore \
-            -c receive.fsck.zeroPaddedFilemode=ignore \
-            https://github.com/rbenv/ruby-build.git /usr/local/share/ruby-build
-        mkdir -p /root/.rbenv/plugins
-
-        ln -s /usr/local/share/ruby-build /root/.rbenv/plugins/ruby-build
-    fi
-
-    if [ "${USERNAME}" != "root" ]; then
-        mkdir -p /home/${USERNAME}/.rbenv/plugins
-
-        if [[ ! -d "/home/${USERNAME}/.rbenv/plugins/ruby-build" ]]; then
-            ln -s /usr/local/share/ruby-build /home/${USERNAME}/.rbenv/plugins/ruby-build
+install_ruby() {
+    mode=$1
+    if rvm --version > /dev/null; then
+        echo "Ruby Version Manager already exists."
+        if [[ "$(ruby -v)" = *"${RUBY_VERSION}"* ]]; then
+            echo "(!) Ruby is already installed with version ${RUBY_VERSION}. Skipping..."
+        elif [ "${RUBY_VERSION}" != "none" ]; then
+            echo "Installing specified Ruby version."
+            su ${USERNAME} -c "rvm install ruby ${RUBY_VERSION}"
         fi
+        SKIP_GEM_INSTALL="false"
+        SKIP_RBENV_RBUILD="true"
+    else
+        # Install RVM
+        receive_gpg_keys RVM_GPG_KEYS
+        # Determine appropriate settings for rvm installer
 
-        # Oryx expects ruby to be installed in this specific path, else it breaks the oryx magic for ruby projects.
-        if [ ! -f /usr/local/rvm/gems/default/bin/ruby ]; then
-            ln -s /usr/local/rvm/rubies/default/bin/ruby /usr/local/rvm/gems/default/bin
+        set_rvm_install_args "$RUBY_VERSION"
+
+        # Create rvm group as a system group to reduce the odds of conflict with local user UIDs
+        if ! cat /etc/group | grep -e "^rvm:" > /dev/null 2>&1; then
+            groupadd -r rvm
         fi
-
-        chown -R "${USERNAME}:rvm" "/home/${USERNAME}/.rbenv/"
-        chmod -R g+r+w "/home/${USERNAME}/.rbenv"
-        find "/home/${USERNAME}/.rbenv" -type d | xargs -n 1 chmod g+s
+        # Install rvm
+        sudo curl -sSL https://get.rvm.io | bash -s stable --ignore-dotfiles ${RVM_INSTALL_ARGS} --with-default-gems="${DEFAULT_GEMS}" 2>&1 || install_previous_version "$mode"
+        sudo usermod -aG rvm ${USERNAME}
+        sudo source /usr/local/rvm/scripts/rvm
+        sudo rvm fix-permissions system
+        sudo rm -rf ${GNUPGHOME}
     fi
-fi
+}
 
-chown -R "${USERNAME}:rvm" "/usr/local/rvm/"
-chmod -R g+r+w "/usr/local/rvm/"
-find "/usr/local/rvm/" -type d | xargs -n 1 chmod g+s
+install_ruby "mode1"
+echo -e "\nRuby version installed by ruby test for fallback ... (mode: 1 - install using find_prev_version_from_git_tags):"
+check "ruby" ruby -v
+check "rake" bash -c "gem list | grep rake"
 
-# Clean up
-rvm cleanup all
-${ROOT_GEM} cleanup
-
-# Clean up
-rm -rf /var/lib/apt/lists/*
-
-echo "Done!"
+install_ruby "mode2"
+echo -e "\nRuby version installed by ruby test for fallback ... (mode: 1 - install using GitHub Api):"
+check "ruby" ruby -v
+check "rake" bash -c "gem list | grep rake"
+set +x
+# Report result
+reportResults

--- a/test/ruby/scenarios.json
+++ b/test/ruby/scenarios.json
@@ -13,5 +13,13 @@
         "features": {
             "ruby": {}
         }
+    },
+    "ruby_fallback_test": {
+        "image": "mcr.microsoft.com/devcontainers/base:bullseye",
+        "features": {
+            "ruby": {
+                "version": "latest"
+            }
+        }
     }
 }


### PR DESCRIPTION
  **Feature name**:
 
 * Ruby
 
 **Description**:
 
 This PR adds the following functionality:
 
 * Added a second installation method using `find_prev_version_from_git_tags()` to install if rate limit for the user accessing GitHub api is reached and installation begins to fail using this fallback method as well
 
 _Changelog_:
 
 * Updated installation file `install.sh`
 * Updated corresponding test
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected