### PR TITLE
Set `DEBIAN_FRONTEND=noninteractive` for nvidia-cuda feature

### DIFF
--- a/src/nvidia-cuda/devcontainer-feature.json
+++ b/src/nvidia-cuda/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "nvidia-cuda",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "name": "NVIDIA CUDA",
   "description": "Installs shared libraries for NVIDIA CUDA.",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/nvidia-cuda",

--- a/src/nvidia-cuda/install.sh
+++ b/src/nvidia-cuda/install.sh
@@ -35,7 +35,7 @@ check_packages() {
 
 export DEBIAN_FRONTEND=noninteractive
 
-check_packages wget ca-certificates liburcu6
+check_packages wget ca-certificates
 
 # Add NVIDIA's package repository to apt so that we can download packages
 # Always use the ubuntu2004 repo because the other repos (e.g., debian11) are missing packages

--- a/src/nvidia-cuda/install.sh
+++ b/src/nvidia-cuda/install.sh
@@ -33,6 +33,8 @@ check_packages() {
     fi
 }
 
+export DEBIAN_FRONTEND=noninteractive
+
 check_packages wget ca-certificates
 
 # Add NVIDIA's package repository to apt so that we can download packages

--- a/src/nvidia-cuda/install.sh
+++ b/src/nvidia-cuda/install.sh
@@ -35,7 +35,7 @@ check_packages() {
 
 export DEBIAN_FRONTEND=noninteractive
 
-check_packages wget ca-certificates
+check_packages wget ca-certificates liburcu6
 
 # Add NVIDIA's package repository to apt so that we can download packages
 # Always use the ubuntu2004 repo because the other repos (e.g., debian11) are missing packages


### PR DESCRIPTION
This PR addresses an issue where the *nvidia-cuda* feature encounters debconf errors during setup due to the `DEBIAN_FRONTEND` environment variable not being set. By exporting `DEBIAN_FRONTEND=noninteractive`, we align this feature with others in the repository and prevent errors related to non-interactive frontend initialization.

Fixes #932 