### PR TITLE
cp command to follow symlink for systemctl

### DIFF
--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "common-utils",
-    "version": "2.4.2",
+    "version": "2.4.3",
     "name": "Common Utilities",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/common-utils",
     "description": "Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.",

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -564,7 +564,7 @@ chmod +rx /usr/local/bin/code
 
 # systemctl shim for Debian/Ubuntu - tells people to use 'service' if systemd is not running
 if [ "${ADJUSTED_ID}" = "debian" ]; then
-    cp -f "${FEATURE_DIR}/bin/systemctl" /usr/local/bin/systemctl
+    cp -fL "${FEATURE_DIR}/bin/systemctl" /usr/local/bin/systemctl
     chmod +rx /usr/local/bin/systemctl
 fi
 


### PR DESCRIPTION
**Dev container name**:
 * common-utils
 **Description**:
 This PR incorporate the following changes:
 * cp command changes with the option -fL to preserve the symlink if exists and also copy the content of the file from where the cp command is executing
 _Changelog_:
 * Updated main.sh
   * changed `cp -f` to `cp -fL`
 **Checklist**:
 * [x]   Checked that applied changes work as expected