### PR TITLE
Update update-dotnet-install-script.yml which updates vendor dotnet script for oryx

### DIFF
--- a/.github/workflows/update-dotnet-install-script.yml
+++ b/.github/workflows/update-dotnet-install-script.yml
@@ -39,7 +39,7 @@ jobs:
 
           # Add / update and commit
           git add src/dotnet/scripts/vendor/dotnet-install.sh
-          git add src/dotnet/scripts/vendor/dotnet-install.sh
+          git add src/oryx/scripts/vendor/dotnet-install.sh
 
           git commit -m 'Automated dotnet-install script update' || export NO_UPDATES=true
 


### PR DESCRIPTION
From https://github.com/devcontainers/features/pull/936, the Action was able to update dotnet-script for Dotnet, but failed for Oryx. This PR fixes it.