### PR TITLE
upgrade cuda version to 11.7 and cudnn to 8.5.0

### DIFF
--- a/src/nvidia-cuda/devcontainer-feature.json
+++ b/src/nvidia-cuda/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "nvidia-cuda",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "name": "NVIDIA CUDA",
   "description": "Installs shared libraries for NVIDIA CUDA.",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/nvidia-cuda",

--- a/src/nvidia-cuda/install.sh
+++ b/src/nvidia-cuda/install.sh
@@ -12,6 +12,8 @@ INSTALL_TOOLKIT=${INSTALLTOOLKIT}
 CUDA_VERSION=${CUDAVERSION}
 CUDNN_VERSION=${CUDNNVERSION}
 
+. /etc/os-release 
+
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
@@ -32,6 +34,11 @@ check_packages() {
         apt-get -y install --no-install-recommends "$@"
     fi
 }
+
+if [ $VERSION_CODENAME = "bookworm" ] || [ $VERSION_CODENAME = "jammy" ] && [ $CUDA_VERSION \< 11.7 ]; then  
+    echo "(!) Unsupported distribution version '${VERSION_CODENAME}' for CUDA < 11.7"
+    exit 1
+fi  
 
 export DEBIAN_FRONTEND=noninteractive
 

--- a/test/nvidia-cuda/install_cudnn_nvxt_version.sh
+++ b/test/nvidia-cuda/install_cudnn_nvxt_version.sh
@@ -5,11 +5,11 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
-# Check installation of libcudnn8 (8.3.2)
-check "libcudnn.so.8.3.2" test 1 -eq "$(find /usr -name 'libcudnn.so.8.3.2' | wc -l)"
+# Check installation of libcudnn8 (8.5.0)
+check "libcudnn.so.8.5.0" test 1 -eq "$(find /usr -name 'libcudnn.so.8.5.0' | wc -l)"
 
-# Check installation of cuda-nvtx-11-5 (11.5)
-check "cuda-11-5+nvtx" test -e '/usr/local/cuda-11.5/targets/x86_64-linux/include/nvtx3'
+# Check installation of cuda-nvtx-11-7 (11.7)
+check "cuda-11-7+nvtx" test -e '/usr/local/cuda-11.7/targets/x86_64-linux/include/nvtx3'
 
 # Report result
 reportResults

--- a/test/nvidia-cuda/scenarios.json
+++ b/test/nvidia-cuda/scenarios.json
@@ -16,8 +16,8 @@
             "nvidia-cuda": {
                 "installCudnn": true,
                 "installNvtx": true,
-                "cudaVersion": "11.5",
-                "cudnnVersion": "8.3.2.44"
+                "cudaVersion": "11.7",
+                "cudnnVersion": "8.5.0.96"
             }
         }
     }


### PR DESCRIPTION
**Dev container name**:
 * nvidia-cuda

 **Description**:
 [Issue 941](https://github.com/devcontainers/features/issues/941)
 This PR incorporate the following changes:
 * liburcu6 is installed manually with the dpkg.

**_Changelog_**:
 * Updated install.sh
   * added change to download deb package and install using `dpkg -i`

 **Checklist**:
 * [x]   Test case `install_cudnn_nvxt_version` passed.