### PR TITLE
[anaconda] support ARM architecture and install latest version

### DIFF
--- a/src/anaconda/install.sh
+++ b/src/anaconda/install.sh
@@ -47,7 +47,15 @@ elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
 fi
 
 architecture="$(uname -m)"
-if [ "${architecture}" != "x86_64" ]; then
+if [ "${architecture}" == "amd64" ]; then
+    CONDA_ARCH="x86_64"
+elif [ "${architecture}" == "x86_64" ]; then
+    CONDA_ARCH="x86_64"
+elif [ "${architecture}" == "arm64" ]; then
+    CONDA_ARCH="aarch64"
+elif [ "${architecture}" == "aarch64" ]; then
+    CONDA_ARCH="aarch64"
+else
     echo "(!) Architecture $architecture unsupported"
     exit 1
 fi
@@ -94,11 +102,11 @@ if ! conda --version &> /dev/null ; then
 
     CONDA_VERSION=$VERSION
     if [ "${VERSION}" = "latest" ] || [ "${VERSION}" = "lts" ]; then
-        CONDA_VERSION="2021.11"
+        CONDA_VERSION="2024.02-1"
     fi
 
     su --login -c "export http_proxy=${http_proxy:-} && export https_proxy=${https_proxy:-} \
-        && wget -q https://repo.anaconda.com/archive/Anaconda3-${CONDA_VERSION}-Linux-x86_64.sh -O /tmp/anaconda-install.sh \
+        && wget -q https://repo.anaconda.com/archive/Anaconda3-${CONDA_VERSION}-Linux-${CONDA_ARCH}.sh -O /tmp/anaconda-install.sh \
         && /bin/bash /tmp/anaconda-install.sh -u -b -p ${CONDA_DIR}" ${USERNAME} 2>&1 
     
     if [ "${VERSION}" = "latest" ] || [ "${VERSION}" = "lts" ]; then


### PR DESCRIPTION
- The anaconda installer is available for ARM and dev containers work on ARM; therefore, elaborate on architecture detection in the anaconda feature to support ARM.
- Update to default to latest version of anaconda.