### PR TITLE
Proposal: Create a feature to install Bun

### DIFF
--- a/src/bun/NOTES.md
+++ b/src/bun/NOTES.md
@@ -1,0 +1,3 @@
+## OS Support
+
+This Feature should work on all Linux versions.

--- a/src/bun/devcontainer-feature.json
+++ b/src/bun/devcontainer-feature.json
@@ -1,0 +1,19 @@
+{
+    "id": "bun",
+    "version": "1.0.0",
+    "name": "Bun",
+    "description": "Installs Bun. Bun is an all-in-one JavaScript runtime & toolkit designed for speed, complete with a bundler, test runner, and Node.js-compatible package manager.",
+    "installsAfter": [
+      "ghcr.io/devcontainers/features/common-utils"
+    ],
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "The bun version to be installed"
+        }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
+}

--- a/src/bun/install.sh
+++ b/src/bun/install.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+VERSION="${VERSION:-"latest"}"
+export BUN_INSTALL=/usr/local
+
+if [ "$VERSION" = "latest" ]; then
+  curl -fsSL https://bun.sh/install | bash
+else
+  curl -fsSL https://bun.sh/install | bash -s -- "bun-v${VERSION}"
+fi


### PR DESCRIPTION
This PR adds bun as a oficial devcontainers feature. 

Bun is an all-in-one JavaScript runtime & toolkit designed for speed,
complete with a bundler, test runner, and Node.js-compatible package
manager.

This feature can be installed in any linux os. 

Tested locally with a sample app and it worked fine:

```shell
	"features": {
		"./bun/": {}
	},
vscode ➜ /workspaces/vscode-remote-try-go (main) $ bun -v
1.1.4


	"features": {
		"./bun/": {
			"version": "1.0.1"
		}
	},
vscode ➜ /workspaces/vscode-remote-try-go (main) $ bun -v
1.0.1
```