### PR TITLE
Fix rustup-init sha256sum check

### DIFF
--- a/src/rust/devcontainer-feature.json
+++ b/src/rust/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "rust",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "name": "Rust",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/rust",
     "description": "Installs Rust, common Rust utilities, and their required dependencies",

--- a/src/rust/install.sh
+++ b/src/rust/install.sh
@@ -186,7 +186,9 @@ else
     curl -sSL --proto '=https' --tlsv1.2 "https://static.rust-lang.org/rustup/dist/${download_architecture}-unknown-linux-gnu/rustup-init" -o /tmp/rustup/target/${download_architecture}-unknown-linux-gnu/release/rustup-init
     curl -sSL --proto '=https' --tlsv1.2 "https://static.rust-lang.org/rustup/dist/${download_architecture}-unknown-linux-gnu/rustup-init.sha256" -o /tmp/rustup/rustup-init.sha256
     cd /tmp/rustup
+    cp /tmp/rustup/target/${download_architecture}-unknown-linux-gnu/release/rustup-init  /tmp/rustup/rustup-init
     sha256sum -c rustup-init.sha256
+    rm /tmp/rustup/rustup-init
     chmod +x target/${download_architecture}-unknown-linux-gnu/release/rustup-init
     target/${download_architecture}-unknown-linux-gnu/release/rustup-init -y --no-modify-path --profile ${RUSTUP_PROFILE} ${default_toolchain_arg}
     cd ~

--- a/src/rust/install.sh
+++ b/src/rust/install.sh
@@ -188,7 +188,6 @@ else
     cd /tmp/rustup
     cp /tmp/rustup/target/${download_architecture}-unknown-linux-gnu/release/rustup-init  /tmp/rustup/rustup-init
     sha256sum -c rustup-init.sha256
-    rm /tmp/rustup/rustup-init
     chmod +x target/${download_architecture}-unknown-linux-gnu/release/rustup-init
     target/${download_architecture}-unknown-linux-gnu/release/rustup-init -y --no-modify-path --profile ${RUSTUP_PROFILE} ${default_toolchain_arg}
     cd ~


### PR DESCRIPTION
Description:

`sha256sum rustup-init.sha256sum` expects there to be a file name `rustup-init` in the same directory as ` rustup-init.sha256sum`
Instead of messing with the original download path, I just copy the binary to the path where the sha256sum is placed, check it and then delete it. There might be a more efficient way with pipes or similar. 

Tests passing on my machine
```
Test Passed!
🧪 Executing duplicate test for feature 'rust'...
⚠️ Skipping duplicate test for rust because '/home/bstrausser/Git/features/test/rust/duplicate.sh' does not exist.
🧹 Cleaning up 2 test containers...
🧹 Removing container a7c1a0e866f3...
🧹 Removing container 01a2b8770ce2...



  ================== TEST REPORT ==================
✅ Passed:      'rust'
✅ Passed:      'rust_at_pinned_version'

```

closes: https://github.com/devcontainers/features/issues/961

