### PR TITLE
✨ Add Ubuntu 24 Noble to `docker-in-docker`

### DIFF
--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -44,6 +44,7 @@ jobs:
           [
             "ubuntu:focal",
             "ubuntu:jammy",
+            "ubuntu:noble",
             "debian:11",
             "debian:12",
             "mcr.microsoft.com/devcontainers/base:ubuntu",

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -44,11 +44,11 @@ jobs:
           [
             "ubuntu:focal",
             "ubuntu:jammy",
-            "ubuntu:noble",
             "debian:11",
             "debian:12",
             "mcr.microsoft.com/devcontainers/base:ubuntu",
             "mcr.microsoft.com/devcontainers/base:debian",
+            "mcr.microsoft.com/devcontainers/base:noble"
           ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -51,11 +51,11 @@ jobs:
           [
             "ubuntu:focal",
             "ubuntu:jammy",
-            "ubuntu:noble",
             "debian:11",
             "debian:12",
             "mcr.microsoft.com/devcontainers/base:ubuntu",
             "mcr.microsoft.com/devcontainers/base:debian",
+            "mcr.microsoft.com/devcontainers/base:noble"
           ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -51,6 +51,7 @@ jobs:
           [
             "ubuntu:focal",
             "ubuntu:jammy",
+            "ubuntu:noble",
             "debian:11",
             "debian:12",
             "mcr.microsoft.com/devcontainers/base:ubuntu",

--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "2.10.2",
+    "version": "2.11.0",
     "name": "Docker (Docker-in-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
     "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -18,8 +18,8 @@ USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
 INSTALL_DOCKER_BUILDX="${INSTALLDOCKERBUILDX:-"true"}"
 INSTALL_DOCKER_COMPOSE_SWITCH="${INSTALLDOCKERCOMPOSESWITCH:-"true"}"
 MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
-DOCKER_MOBY_ARCHIVE_VERSION_CODENAMES="bookworm buster bullseye bionic focal jammy"
-DOCKER_LICENSED_ARCHIVE_VERSION_CODENAMES="bookworm buster bullseye bionic focal hirsute impish jammy"
+DOCKER_MOBY_ARCHIVE_VERSION_CODENAMES="bookworm buster bullseye bionic focal jammy noble"
+DOCKER_LICENSED_ARCHIVE_VERSION_CODENAMES="bookworm buster bullseye bionic focal hirsute impish jammy noble"
 
 # Default: Exit on any failure.
 set -e


### PR DESCRIPTION
This pull request resolves https://github.com/devcontainers/features/issues/967 by adding `noble` to the allowed codenames

Also includes a request to include `ubuntu:noble` in the test workflows (https://github-partners.slack.com/archives/C0431R35H37/p1715616382180099?thread_ts=1715589521.243939&cid=C0431R35H37)

Signed-off-by: Jacob Woffenden <jacob@woffenden.io> 