### PR TITLE
[desktop-lite] Allow password-less VNC connections

### DIFF
--- a/src/desktop-lite/README.md
+++ b/src/desktop-lite/README.md
@@ -16,10 +16,10 @@ Adds a lightweight Fluxbox based desktop to the container that can be accessed u
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
 | version | Currently Unused! | string | latest |
-| noVncVersion | NoVnc Version | string | 1.2.0 |
-| password | Enter a password for desktop connections | string | vscode |
-| webPort | Enter a port for the VNC web client | string | 6080 |
-| vncPort | Enter a port for the desktop VNC server | string | 5901 |
+| noVncVersion | The noVNC version to use | string | 1.2.0 |
+| password | Enter a password for desktop connections. If `noPassword`, connections from the local host can be established without entering a password | string | vscode |
+| webPort | Enter a port for the VNC web client (noVNC) | string | 6080 |
+| vncPort | Enter a port for the desktop VNC server (TigerVNC) | string | 5901 |
 
 ## Connecting to the desktop
 

--- a/src/desktop-lite/devcontainer-feature.json
+++ b/src/desktop-lite/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "desktop-lite",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "name": "Light-weight Desktop",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/desktop-lite",
     "description": "Adds a lightweight Fluxbox based desktop to the container that can be accessed using a VNC viewer or the web. GUI-based commands executed from the built-in VS code terminal will open on the desktop automatically.",
@@ -19,17 +19,18 @@
                 "1.2.0"
             ],
             "default": "1.2.0",
-            "description": "NoVnc Version"
+            "description": "The noVNC version to use"
         },
         "password": {
             "type": "string",
             "proposals": [
                 "vscode",
                 "codespaces",
-                "password"
+                "password",
+                "noPassword"
             ],
             "default": "vscode",
-            "description": "Enter a password for desktop connections"
+            "description": "Enter a password for desktop connections. If \"noPassword\", connections from the local host can be established without entering a password"
         },
         "webPort": {
             "type": "string",
@@ -37,7 +38,7 @@
                 "6080"
             ],
             "default": "6080",
-            "description": "Enter a port for the VNC web client"
+            "description": "Enter a port for the VNC web client (noVNC)"
         },
         "vncPort": {
             "type": "string",
@@ -45,7 +46,7 @@
                 "5901"
             ],
             "default": "5901",
-            "description": "Enter a port for the desktop VNC server"
+            "description": "Enter a port for the desktop VNC server (TigerVNC)"
         }
     },
     "init": true,

--- a/src/desktop-lite/install.sh
+++ b/src/desktop-lite/install.sh
@@ -9,6 +9,9 @@
 
 NOVNC_VERSION="${NOVNCVERSION:-"1.2.0"}" # TODO: Add in a 'latest' auto-detect and swap name to 'version'
 VNC_PASSWORD=${PASSWORD:-"vscode"}
+if [ "$VNC_PASSWORD" = "noPassword" ]; then
+    unset VNC_PASSWORD
+fi
 NOVNC_PORT="${WEBPORT:-6080}"
 VNC_PORT="${VNCPORT:-5901}"
 
@@ -372,7 +375,13 @@ sudoIf chown root:\${group_name} /tmp/.X11-unix
 if [ "\$(echo "\${VNC_RESOLUTION}" | tr -cd 'x' | wc -c)" = "1" ]; then VNC_RESOLUTION=\${VNC_RESOLUTION}x16; fi
 screen_geometry="\${VNC_RESOLUTION%*x*}"
 screen_depth="\${VNC_RESOLUTION##*x}"
-startInBackgroundIfNotRunning "Xtigervnc" sudoUserIf "tigervncserver \${DISPLAY} -geometry \${screen_geometry} -depth \${screen_depth} -rfbport ${VNC_PORT} -dpi \${VNC_DPI:-96} -localhost -desktop fluxbox -fg -passwd /usr/local/etc/vscode-dev-containers/vnc-passwd"
+
+# Check if VNC_PASSWORD is set and use the appropriate command
+if [ -n "\${VNC_PASSWORD+x}" ]; then
+    startInBackgroundIfNotRunning "Xtigervnc" sudoUserIf "tigervncserver \${DISPLAY} -geometry \${screen_geometry} -depth \${screen_depth} -rfbport ${VNC_PORT} -dpi \${VNC_DPI:-96} -localhost -desktop fluxbox -fg -passwd /usr/local/etc/vscode-dev-containers/vnc-passwd"
+else
+    startInBackgroundIfNotRunning "Xtigervnc" sudoUserIf "tigervncserver \${DISPLAY} -geometry \${screen_geometry} -depth \${screen_depth} -rfbport ${VNC_PORT} -dpi \${VNC_DPI:-96} -localhost -desktop fluxbox -fg -SecurityTypes None"
+fi
 
 # Spin up noVNC if installed and not running.
 if [ -d "/usr/local/novnc" ] && [ "\$(ps -ef | grep /usr/local/novnc/noVNC*/utils/launch.sh | grep -v grep)" = "" ]; then
@@ -388,7 +397,9 @@ exec "\$@"
 log "** SCRIPT EXIT **"
 EOF
 
-echo "${VNC_PASSWORD}" | vncpasswd -f > /usr/local/etc/vscode-dev-containers/vnc-passwd
+if [ -n "${VNC_PASSWORD+x}" ]; then
+    echo "${VNC_PASSWORD}" | vncpasswd -f > /usr/local/etc/vscode-dev-containers/vnc-passwd
+fi
 chmod +x /usr/local/share/desktop-init.sh /usr/local/bin/set-resolution
 
 # Set up fluxbox config
@@ -401,15 +412,23 @@ fi
 # Clean up
 rm -rf /var/lib/apt/lists/*
 
+# Determine the message based on whether VNC_PASSWORD is set
+if [ -n "${VNC_PASSWORD+x}" ]; then
+    PASSWORD_MESSAGE="In both cases, use the password \"${VNC_PASSWORD}\" when connecting"
+else
+    PASSWORD_MESSAGE="In both cases, no password is required."
+fi
+
+# Display the message
 cat << EOF
 
 
 You now have a working desktop! Connect to in one of the following ways:
 
-- Forward port ${NOVNC_PORT} and use a web browser start the noVNC client (recommended)
+- Forward port ${NOVNC_PORT} and use a web browser to start the noVNC client (recommended)
 - Forward port ${VNC_PORT} using VS Code client and connect using a VNC Viewer
 
-In both cases, use the password "${VNC_PASSWORD}" when connecting
+${PASSWORD_MESSAGE}
 
 (*) Done!
 


### PR DESCRIPTION
This allows to use:

```json
    "ghcr.io/devcontainers/features/desktop-lite:1": {
      "password": "noPassword"
    }
```

to start the VNC server such that it won't require authentication when trying to connect.

Closes #611