### PR TITLE
#963 specific powershell module version install

### DIFF
--- a/src/powershell/devcontainer-feature.json
+++ b/src/powershell/devcontainer-feature.json
@@ -18,7 +18,7 @@
         "modules": {
             "type": "string",
             "default": "",
-            "description": "Optional comma separated list of PowerShell modules to install. Use delimiter `==` and the version to install specific version."
+            "description": "Optional comma separated list of PowerShell modules to install. If you need to install a specific version of a module, use '==' to specify the version (e.g. 'az.resources==2.5.0')"
         },
         "powershellProfileURL": {
             "type": "string",

--- a/src/powershell/devcontainer-feature.json
+++ b/src/powershell/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "powershell",
-    "version": "1.3.6",
+    "version": "1.4.0",
     "name": "PowerShell",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/powershell",
     "description": "Installs PowerShell along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",
@@ -18,7 +18,7 @@
         "modules": {
             "type": "string",
             "default": "",
-            "description": "Optional comma separated list of PowerShell modules to install."
+            "description": "Optional comma separated list of PowerShell modules to install. Use delimiter `==` and the version to install specific version."
         },
         "powershellProfileURL": {
             "type": "string",

--- a/src/powershell/devcontainer-feature.json
+++ b/src/powershell/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "powershell",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "name": "PowerShell",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/powershell",
     "description": "Installs PowerShell along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",

--- a/src/powershell/install.sh
+++ b/src/powershell/install.sh
@@ -248,16 +248,19 @@ if [ ${#POWERSHELL_MODULES[@]} -gt 0 ]; then
     modules=(`echo ${POWERSHELL_MODULES} | tr ',' ' '`)
     for i in "${modules[@]}"
     do
-        IFS=':' read -ra module_parts <<< "$i"
+        IFS='==' read -ra module_parts <<< "$i"  
+        module_name="${module_parts[0]}"  
+        args="-Name ${module_name} -AllowClobber -Force -Scope AllUsers"  
+
         if [ "${#module_parts[@]}" -eq 2 ]; then
-            module_name="${module_parts[0]}"
             module_version="${module_parts[1]}"
-            echo "Installing ${module_name} version ${module_version}"
-            pwsh -Command "Install-Module -Name ${module_name} -RequiredVersion ${module_version} -AllowClobber -Force -Scope AllUsers" || continue
+            echo "Installing ${module_name} v${module_version}"
+            args+=" -RequiredVersion ${module_version}"
         else
-            echo "Installing module : ${i} , version : latest"
-            pwsh -Command "Install-Module -Name ${i} -AllowClobber -Force -Scope AllUsers" || continue
+            echo "Installing latest version for ${i} module"
         fi
+
+        pwsh -Command "Install-Module $args" || continue
     done
 fi
 

--- a/src/powershell/install.sh
+++ b/src/powershell/install.sh
@@ -256,7 +256,7 @@ if [ ${#POWERSHELL_MODULES[@]} -gt 0 ]; then
             echo "Installing ${module_name} v${module_version}"
             args+=" -RequiredVersion ${module_version}"
         else
-            echo "Installing latest version for ${i} module.."
+            echo "Installing latest version for ${i} module"
         fi
 
         pwsh -Command "Install-Module $args" || continue

--- a/src/powershell/install.sh
+++ b/src/powershell/install.sh
@@ -251,7 +251,6 @@ if [ ${#POWERSHELL_MODULES[@]} -gt 0 ]; then
         module_parts=(`echo ${i} | tr '==' ' '`)
         module_name="${module_parts[0]}"  
         args="-Name ${module_name} -AllowClobber -Force -Scope AllUsers"  
-        echo "${#module_parts[@]}"
         if [ "${#module_parts[@]}" -eq 2 ]; then
             module_version="${module_parts[1]}"
             echo "Installing ${module_name} v${module_version}.."

--- a/src/powershell/install.sh
+++ b/src/powershell/install.sh
@@ -253,7 +253,7 @@ if [ ${#POWERSHELL_MODULES[@]} -gt 0 ]; then
         args="-Name ${module_name} -AllowClobber -Force -Scope AllUsers"  
         if [ "${#module_parts[@]}" -eq 2 ]; then
             module_version="${module_parts[1]}"
-            echo "Installing ${module_name} v${module_version}.."
+            echo "Installing ${module_name} v${module_version}"
             args+=" -RequiredVersion ${module_version}"
         else
             echo "Installing latest version for ${i} module.."

--- a/src/powershell/install.sh
+++ b/src/powershell/install.sh
@@ -242,14 +242,22 @@ if [ "${use_github}" = "true" ]; then
     install_using_github
 fi
 
-# If PowerShell modules are requested, loop through and install 
+# If PowerShell modules are requested, loop through and install
 if [ ${#POWERSHELL_MODULES[@]} -gt 0 ]; then
     echo "Installing PowerShell Modules: ${POWERSHELL_MODULES}"
     modules=(`echo ${POWERSHELL_MODULES} | tr ',' ' '`)
     for i in "${modules[@]}"
     do
-        echo "Installing ${i}"
-        pwsh -Command "Install-Module -Name ${i} -AllowClobber -Force -Scope AllUsers" || continue
+        IFS=':' read -ra module_parts <<< "$i"
+        if [ "${#module_parts[@]}" -eq 2 ]; then
+            module_name="${module_parts[0]}"
+            module_version="${module_parts[1]}"
+            echo "Installing ${module_name} version ${module_version}"
+            pwsh -Command "Install-Module -Name ${module_name} -RequiredVersion ${module_version} -AllowClobber -Force -Scope AllUsers" || continue
+        else
+            echo "Installing module : ${i} , version : latest"
+            pwsh -Command "Install-Module -Name ${i} -AllowClobber -Force -Scope AllUsers" || continue
+        fi
     done
 fi
 

--- a/src/powershell/install.sh
+++ b/src/powershell/install.sh
@@ -248,16 +248,16 @@ if [ ${#POWERSHELL_MODULES[@]} -gt 0 ]; then
     modules=(`echo ${POWERSHELL_MODULES} | tr ',' ' '`)
     for i in "${modules[@]}"
     do
-        IFS='==' read -ra module_parts <<< "$i"  
+        module_parts=(`echo ${i} | tr '==' ' '`)
         module_name="${module_parts[0]}"  
         args="-Name ${module_name} -AllowClobber -Force -Scope AllUsers"  
-
+        echo "${#module_parts[@]}"
         if [ "${#module_parts[@]}" -eq 2 ]; then
             module_version="${module_parts[1]}"
-            echo "Installing ${module_name} v${module_version}"
+            echo "Installing ${module_name} v${module_version}.."
             args+=" -RequiredVersion ${module_version}"
         else
-            echo "Installing latest version for ${i} module"
+            echo "Installing latest version for ${i} module.."
         fi
 
         pwsh -Command "Install-Module $args" || continue

--- a/test/powershell/install_modules_version.sh
+++ b/test/powershell/install_modules_version.sh
@@ -6,9 +6,8 @@ set -e
 source dev-container-features-test-lib
 
 # Extension-specific tests
-check "az.resources" pwsh -Command "(Get-Module -ListAvailable -Name Az.Resources).Version.ToString()"
-check "az.storage" pwsh -Command "(Get-Module -ListAvailable -Name Az.Storage).Version.ToString()"
-check "profile" pwsh -Command "(Get-Variable $env:ProfileLoaded).Value"
+check "az.resources" pwsh -Command "(Get-Module -ListAvailable -Name Az.Resources).Version.ToString()" | grep 2.5.0
+check "az.storage" pwsh -Command "(Get-Module -ListAvailable -Name Az.Storage).Version.ToString()" | grep 4.3.0
 
 # Report result
 reportResults

--- a/test/powershell/install_modules_version.sh
+++ b/test/powershell/install_modules_version.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Import test library for `check` command
+source dev-container-features-test-lib
+
+# Extension-specific tests
+check "az.resources" pwsh -Command "(Get-Module -ListAvailable -Name Az.Resources).Version.ToString()"
+check "az.storage" pwsh -Command "(Get-Module -ListAvailable -Name Az.Storage).Version.ToString()"
+check "profile" pwsh -Command "(Get-Variable $env:ProfileLoaded).Value"
+
+# Report result
+reportResults

--- a/test/powershell/scenarios.json
+++ b/test/powershell/scenarios.json
@@ -3,7 +3,7 @@
     "image": "mcr.microsoft.com/devcontainers/base:jammy",
     "features": {
       "powershell": {
-        "modules": "az.resources, az.storage",
+        "modules": "az.resources:7.1.0, az.storage",
         "powershellProfileURL": "https://raw.githubusercontent.com/codspace/powershell-profile/main/Test-Profile.ps1"
       }
     }

--- a/test/powershell/scenarios.json
+++ b/test/powershell/scenarios.json
@@ -3,7 +3,7 @@
     "image": "mcr.microsoft.com/devcontainers/base:jammy",
     "features": {
       "powershell": {
-        "modules": "az.resources:7.1.0, az.storage",
+        "modules": "az.resources, az.storage",
         "powershellProfileURL": "https://raw.githubusercontent.com/codspace/powershell-profile/main/Test-Profile.ps1"
       }
     }
@@ -13,6 +13,15 @@
     "features": {
       "powershell": {
         "modules": "az.resources, az.storage",
+        "powershellProfileURL": "https://raw.githubusercontent.com/codspace/powershell-profile/main/Test-Profile.ps1"
+      }
+    }
+  },
+  "install_modules_version": {
+    "image": "mcr.microsoft.com/devcontainers/base:jammy",
+    "features": {
+      "powershell": {
+        "modules": "az.resources==2.5.0, az.storage",
         "powershellProfileURL": "https://raw.githubusercontent.com/codspace/powershell-profile/main/Test-Profile.ps1"
       }
     }

--- a/test/powershell/scenarios.json
+++ b/test/powershell/scenarios.json
@@ -21,8 +21,7 @@
     "image": "mcr.microsoft.com/devcontainers/base:jammy",
     "features": {
       "powershell": {
-        "modules": "az.resources==2.5.0, az.storage",
-        "powershellProfileURL": "https://raw.githubusercontent.com/codspace/powershell-profile/main/Test-Profile.ps1"
+        "modules": "az.resources==2.5.0, az.storage==4.3.0"
       }
     }
   }


### PR DESCRIPTION
[Issue 963](https://github.com/devcontainers/features/issues/963)
**Feature Name:**
- Powershell

**Description:**
This PR does the following -
- modules specified in the list has previledges to install specific version of the module which can be mentioned by adding a separator `:` 

_Changelog:_
- Updated install.sh
    - implemented a logic to bifurcate the module and version using a separator `:` in the modules and install the modules latest version if the version is not specified else use the specific version.
- Updated scenarios.json
    - added a version for one of the modules to test the functionality
- Updated devcontainer-feature.json
    - incremented minor version of the feature

**Checklist:**

- [x] It should install the powershell module for the specified version if the version is passed by separator `:`