### PR TITLE
Ruby: Install `rustc` to enable `yjit`

### DIFF
--- a/src/ruby/install.sh
+++ b/src/ruby/install.sh
@@ -209,7 +209,7 @@ fi
 # Install dependencies
 check_packages curl ca-certificates software-properties-common build-essential gnupg2 libreadline-dev \
     procps dirmngr gawk autoconf automake bison libffi-dev libgdbm-dev libncurses5-dev \
-    libsqlite3-dev libtool libyaml-dev pkg-config sqlite3 zlib1g-dev libgmp-dev libssl-dev
+    libsqlite3-dev libtool libyaml-dev pkg-config sqlite3 zlib1g-dev libgmp-dev libssl-dev rustc
 if ! type git > /dev/null 2>&1; then
     check_packages git
 fi


### PR DESCRIPTION
Ruby 3.2 will install with `yjit` enabled when `rustc` is installed.