### PR TITLE
dotnet: add ability to install workloads

### DIFF
--- a/src/dotnet/NOTES.md
+++ b/src/dotnet/NOTES.md
@@ -66,7 +66,6 @@ Installing .NET workloads. Multiple workloads can be specified as comma-separate
 ``` json
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
-      "version": "latest",
       "workloads": "aspire, wasm-tools"
     }
 }

--- a/src/dotnet/NOTES.md
+++ b/src/dotnet/NOTES.md
@@ -2,8 +2,7 @@
 
 Installing only the latest .NET SDK version (the default).
 
-``` json
-{
+``` jsonc
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": "latest" // or "" or {}
 }
@@ -12,7 +11,6 @@ Installing only the latest .NET SDK version (the default).
 Installing an additional SDK version. Multiple versions can be specified as comma-separated values.
 
 ``` json
-{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "additionalVersions": "lts"
@@ -23,7 +21,6 @@ Installing an additional SDK version. Multiple versions can be specified as comm
 Installing specific SDK versions.
 
 ``` json
-{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "version": "6.0",
@@ -35,7 +32,6 @@ Installing specific SDK versions.
 Installing a specific SDK feature band.
 
 ``` json
-{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "version": "6.0.4xx",
@@ -46,7 +42,6 @@ Installing a specific SDK feature band.
 Installing a specific SDK patch version.
 
 ``` json
-{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "version": "6.0.412",
@@ -57,12 +52,22 @@ Installing a specific SDK patch version.
 Installing only the .NET Runtime or the ASP.NET Core Runtime. (The SDK includes all runtimes so this configuration is only useful if you need to run .NET apps without building them from source.)
 
 ``` json
-{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "version": "none",
         "dotnetRuntimeVersions": "latest, lts",
         "aspnetCoreRuntimeVersions": "latest, lts",
+    }
+}
+```
+
+Installing .NET workloads. Multiple workloads can be specified as comma-separated values.
+
+``` json
+"features": {
+    "ghcr.io/devcontainers/features/dotnet:2": {
+      "version": "latest",
+      "workloads": "aspire, wasm-tools"
     }
 }
 ```

--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -31,19 +31,18 @@ This Feature installs the latest .NET SDK, which includes the .NET CLI and the s
 Installing only the latest .NET SDK version (the default).
 
 ``` json
-{
 "features": {
-    "ghcr.io/devcontainers/features/dotnet:2": "latest" // or "" or {}
+    "ghcr.io/devcontainers/features/dotnet:2": "latest"
 }
 ```
 
 Installing an additional SDK version. Multiple versions can be specified as comma-separated values.
 
 ``` json
-{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
-        "additionalVersions": "lts"
+      "version": "latest",
+      "additionalVersions": "lts"
     }
 }
 ```
@@ -51,7 +50,6 @@ Installing an additional SDK version. Multiple versions can be specified as comm
 Installing specific SDK versions.
 
 ``` json
-{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "version": "6.0",
@@ -63,7 +61,6 @@ Installing specific SDK versions.
 Installing a specific SDK feature band.
 
 ``` json
-{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "version": "6.0.4xx",
@@ -74,7 +71,6 @@ Installing a specific SDK feature band.
 Installing a specific SDK patch version.
 
 ``` json
-{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "version": "6.0.412",
@@ -85,7 +81,6 @@ Installing a specific SDK patch version.
 Installing only the .NET Runtime or the ASP.NET Core Runtime. (The SDK includes all runtimes so this configuration is only useful if you need to run .NET apps without building them from source.)
 
 ``` json
-{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "version": "none",
@@ -95,12 +90,22 @@ Installing only the .NET Runtime or the ASP.NET Core Runtime. (The SDK includes 
 }
 ```
 
+Installing .NET workloads. Multiple workloads can be specified as comma-separated values.
+
+``` json
+"features": {
+    "ghcr.io/devcontainers/features/dotnet:2": {
+      "version": "latest",
+      "workloads": "aspire, wasm-tools"
+    }
+}
+```
+
 ## OS Support
 
 This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
 
 `bash` is required to execute the `install.sh` script.
-
 
 ---
 

--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -31,18 +31,19 @@ This Feature installs the latest .NET SDK, which includes the .NET CLI and the s
 Installing only the latest .NET SDK version (the default).
 
 ``` json
+{
 "features": {
-    "ghcr.io/devcontainers/features/dotnet:2": "latest"
+    "ghcr.io/devcontainers/features/dotnet:2": "latest" // or "" or {}
 }
 ```
 
 Installing an additional SDK version. Multiple versions can be specified as comma-separated values.
 
 ``` json
+{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
-      "version": "latest",
-      "additionalVersions": "lts"
+        "additionalVersions": "lts"
     }
 }
 ```
@@ -50,6 +51,7 @@ Installing an additional SDK version. Multiple versions can be specified as comm
 Installing specific SDK versions.
 
 ``` json
+{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "version": "6.0",
@@ -61,6 +63,7 @@ Installing specific SDK versions.
 Installing a specific SDK feature band.
 
 ``` json
+{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "version": "6.0.4xx",
@@ -71,6 +74,7 @@ Installing a specific SDK feature band.
 Installing a specific SDK patch version.
 
 ``` json
+{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "version": "6.0.412",
@@ -81,6 +85,7 @@ Installing a specific SDK patch version.
 Installing only the .NET Runtime or the ASP.NET Core Runtime. (The SDK includes all runtimes so this configuration is only useful if you need to run .NET apps without building them from source.)
 
 ``` json
+{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "version": "none",
@@ -90,22 +95,12 @@ Installing only the .NET Runtime or the ASP.NET Core Runtime. (The SDK includes 
 }
 ```
 
-Installing .NET workloads. Multiple workloads can be specified as comma-separated values.
-
-``` json
-"features": {
-    "ghcr.io/devcontainers/features/dotnet:2": {
-      "version": "latest",
-      "workloads": "aspire, wasm-tools"
-    }
-}
-```
-
 ## OS Support
 
 This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
 
 `bash` is required to execute the `install.sh` script.
+
 
 ---
 

--- a/src/dotnet/devcontainer-feature.json
+++ b/src/dotnet/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "dotnet",
-    "version": "2.0.6",
+    "version": "2.1.0",
     "name": "Dotnet CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/dotnet",
     "description": "This Feature installs the latest .NET SDK, which includes the .NET CLI and the shared runtime. Options are provided to choose a different version or additional versions.",

--- a/src/dotnet/devcontainer-feature.json
+++ b/src/dotnet/devcontainer-feature.json
@@ -32,6 +32,11 @@
             "type": "string",
             "default": "",
             "description": "Enter additional ASP.NET Core runtime versions, separated by commas. Use 'latest' for the latest version, 'lts' for the latest LTS version, 'X.Y' or 'X.Y.Z' for a specific version."
+        },
+        "workloads": {
+            "type": "string",
+            "default": "",
+            "description": "Enter additional .NET SDK workloads, separated by commas. Use 'dotnet workload search' to learn what workloads are available to install."
         }
     },
     "containerEnv": {

--- a/src/dotnet/install.sh
+++ b/src/dotnet/install.sh
@@ -10,6 +10,7 @@ DOTNET_VERSION="${VERSION:-"latest"}"
 ADDITIONAL_VERSIONS="${ADDITIONALVERSIONS:-""}"
 DOTNET_RUNTIME_VERSIONS="${DOTNETRUNTIMEVERSIONS:-""}"
 ASPNETCORE_RUNTIME_VERSIONS="${ASPNETCORERUNTIMEVERSIONS:-""}"
+WORKLOADS="${WORKLOADS:-""}"
 
 set -e
 
@@ -69,6 +70,11 @@ for aspNetCoreRuntimeVersion in $(split_csv "$ASPNETCORE_RUNTIME_VERSIONS"); do
     aspNetCoreRuntimeVersions+=("$aspNetCoreRuntimeVersion")
 done
 
+workloads=()
+for workload in $(split_csv "$WORKLOADS"); do
+    workloads+=("$workload")
+done
+
 # Fail fast in case of bad input to avoid unneccesary work
 # v1 of the .NET feature allowed specifying only a major version 'X' like '3'
 # v2 removed this ability
@@ -109,6 +115,10 @@ done
 
 for version in "${aspNetCoreRuntimeVersions[@]}"; do
     install_runtime "aspnetcore" "$version"
+done
+
+for workload in "${workloads[@]}"; do
+    install_workload "$workload"
 done
 
 # Clean up

--- a/src/dotnet/scripts/dotnet-helpers.sh
+++ b/src/dotnet/scripts/dotnet-helpers.sh
@@ -128,7 +128,7 @@ install_workload() {
     # Prevent generating a development certificate
     local DOTNET_GENERATE_ASPNET_CERTIFICATE=false
 
-    echo "Executing dotnet workload install $workload_id --temp-dir /tmp/dotnet-workload-temp-dir"
+    echo "Imstalling .NET workload $workload_id"
     dotnet workload install "$workload_id" --temp-dir /tmp/dotnet-workload-temp-dir
 
     # Clean up

--- a/src/dotnet/scripts/dotnet-helpers.sh
+++ b/src/dotnet/scripts/dotnet-helpers.sh
@@ -128,7 +128,7 @@ install_workload() {
     # Prevent generating a development certificate
     local DOTNET_GENERATE_ASPNET_CERTIFICATE=false
 
-    echo "Imstalling .NET workload $workload_id"
+    echo "Installing .NET workload $workload_id"
     dotnet workload install "$workload_id" --temp-dir /tmp/dotnet-workload-temp-dir
 
     # Clean up

--- a/src/dotnet/scripts/dotnet-helpers.sh
+++ b/src/dotnet/scripts/dotnet-helpers.sh
@@ -116,20 +116,14 @@ install_runtime() {
         --no-path
 }
 
-# Installs a .NET workload
-# Usage: install_workload <workload_id>
+# Installs one or more .NET workloads
+# Usage: install_workload <workload_id> [<workload_id> ...]
 # Reference: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-workload-install
-install_workload() {
-    local workload_id="$1"
+install_workloads() {
+    local workloads="$@"
 
-    # Prevent "Welcome to .NET" message from dotnet
-    local DOTNET_NOLOGO=true
-
-    # Prevent generating a development certificate
-    local DOTNET_GENERATE_ASPNET_CERTIFICATE=false
-
-    echo "Installing .NET workload $workload_id"
-    dotnet workload install "$workload_id" --temp-dir /tmp/dotnet-workload-temp-dir
+    echo "Installing .NET workload(s) $workloads"
+    dotnet workload install $workloads --temp-dir /tmp/dotnet-workload-temp-dir
 
     # Clean up
     rm -r /tmp/dotnet-workload-temp-dir

--- a/src/dotnet/scripts/dotnet-helpers.sh
+++ b/src/dotnet/scripts/dotnet-helpers.sh
@@ -25,7 +25,6 @@ fetch_latest_version_in_channel() {
     else
         wget -qO- "https://dotnetcli.azureedge.net/dotnet/Sdk/$channel/latest.version"
     fi
-    
 }
 
 # Prints the latest dotnet version
@@ -76,12 +75,11 @@ install_sdk() {
     fi
     
     # Currently this script does not make it possible to qualify the version, 'GA' is always implied
-    echo "Executing $DOTNET_INSTALL_SCRIPT --version $version --channel $channel --install-dir $DOTNET_INSTALL_DIR --no-path"
+    echo "Executing $DOTNET_INSTALL_SCRIPT --version $version --channel $channel --install-dir $DOTNET_INSTALL_DIR"
     "$DOTNET_INSTALL_SCRIPT" \
         --version "$version" \
         --channel "$channel" \
-        --install-dir "$DOTNET_INSTALL_DIR" \
-        --no-path
+        --install-dir "$DOTNET_INSTALL_DIR"
 }
 
 # Installs a version of the .NET Runtime
@@ -116,4 +114,23 @@ install_runtime() {
         --channel "$channel" \
         --install-dir "$DOTNET_INSTALL_DIR" \
         --no-path
+}
+
+# Installs a .NET workload
+# Usage: install_workload <workload_id>
+# Reference: https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-workload-install
+install_workload() {
+    local workload_id="$1"
+
+    # Prevent "Welcome to .NET" message from dotnet
+    local DOTNET_NOLOGO=true
+
+    # Prevent generating a development certificate
+    local DOTNET_GENERATE_ASPNET_CERTIFICATE=false
+
+    echo "Executing dotnet workload install $workload_id --temp-dir /tmp/dotnet-workload-temp-dir"
+    dotnet workload install "$workload_id" --temp-dir /tmp/devcontainer-nuget-cache
+
+    # Clean up
+    rm -r /tmp/dotnet-workload-temp-dir
 }

--- a/src/dotnet/scripts/dotnet-helpers.sh
+++ b/src/dotnet/scripts/dotnet-helpers.sh
@@ -129,7 +129,7 @@ install_workload() {
     local DOTNET_GENERATE_ASPNET_CERTIFICATE=false
 
     echo "Executing dotnet workload install $workload_id --temp-dir /tmp/dotnet-workload-temp-dir"
-    dotnet workload install "$workload_id" --temp-dir /tmp/devcontainer-nuget-cache
+    dotnet workload install "$workload_id" --temp-dir /tmp/dotnet-workload-temp-dir
 
     # Clean up
     rm -r /tmp/dotnet-workload-temp-dir

--- a/test/dotnet/dotnet_helpers.sh
+++ b/test/dotnet/dotnet_helpers.sh
@@ -15,7 +15,6 @@ fetch_latest_version_in_channel() {
     else
         wget -qO- "https://dotnetcli.azureedge.net/dotnet/Sdk/$channel/latest.version"
     fi
-    
 }
 
 # Prints the latest dotnet version
@@ -47,7 +46,6 @@ is_dotnet_sdk_version_installed() {
     return $?
 }
 
-
 # Asserts that the specified .NET Runtime version is installed
 # Returns a non-zero exit code if the check fails
 # Usage: is_dotnet_runtime_version_installed <version>
@@ -67,5 +65,15 @@ is_dotnet_runtime_version_installed() {
 is_aspnetcore_runtime_version_installed() {
     local expected="$1"
     dotnet --list-runtimes | grep --fixed-strings --silent "Microsoft.AspNetCore.App $expected"
+    return $?
+}
+
+# Asserts that the specified workload is installed
+# Returns a non-zero exit code if the check fails
+# Usage: is_dotnet_workload_installed <workload_id>
+# Example: is_dotnet_workload_installed "aspire"
+is_dotnet_workload_installed() {
+    local expected="$1"
+    dotnet workload list | grep --fixed-strings --silent "$expected"
     return $?
 }

--- a/test/dotnet/install_dotnet_workloads.sh
+++ b/test/dotnet/install_dotnet_workloads.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
+# Provides the 'check' and 'reportResults' commands.
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib. Syntax is...
+# check <LABEL> <cmd> [args...]
+source dotnet_env.sh
+source dotnet_helpers.sh
+
+check "Aspire is installed" \
+is_dotnet_workload_installed "aspire"
+
+check "WASM tools are installed" \
+is_dotnet_workload_installed "wasm-tools"
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/dotnet/scenarios.json
+++ b/test/dotnet/scenarios.json
@@ -81,5 +81,15 @@
                 "aspnetcoreRuntimeVersions": "latest"
             }
         }
+    },
+    "install_dotnet_workloads": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "remoteUser": "vscode",
+        "features": {
+            "dotnet": {
+                "version": "latest",
+                "workloads": "aspire, wasm-tools"
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR adds a new configuration item `"workloads"` for dotnet, which is a comma-separated list of .NET workload ids.

Run `dotnet workload search` to see which workloads are available to install. Note that some workloads like MAUI cannot be installed in Ubuntu.

This is a non-breaking change, I increased only the minor version of the feature.

(I also improved the README a little bit while adding a new example.)

Resolves #996 