### PR TITLE
Add support for Wolfi to common-utils

### DIFF
--- a/src/common-utils/NOTES.md
+++ b/src/common-utils/NOTES.md
@@ -1,6 +1,6 @@
 ## OS Support
 
-This Feature should work on recent versions of Debian/Ubuntu, RedHat Enterprise Linux, Fedora, RockyLinux, and Alpine Linux.
+This Feature should work on recent versions of Debian/Ubuntu, RedHat Enterprise Linux, Fedora, RockyLinux, Alpine Linux, and Wolfi.
 
 ## Using with dev container images
 

--- a/src/common-utils/README.md
+++ b/src/common-utils/README.md
@@ -27,7 +27,7 @@ Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-r
 
 ## OS Support
 
-This Feature should work on recent versions of Debian/Ubuntu, RedHat Enterprise Linux, Fedora, RockyLinux, and Alpine Linux.
+This Feature should work on recent versions of Debian/Ubuntu, RedHat Enterprise Linux, Fedora, RockyLinux, Alpine Linux, and Wolfi.
 
 ## Using with dev container images
 

--- a/src/common-utils/install.sh
+++ b/src/common-utils/install.sh
@@ -26,9 +26,9 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 1
 fi
 
-# If we're using Alpine, install bash before executing
+# If we're using Alpine/Wolfi, install bash before executing
 . /etc/os-release
-if [ "${ID}" = "alpine" ]; then
+if [ "${ID}" = "alpine" ] || [ "${ID}" = "wolfi" ]; then
     apk add --no-cache bash
 fi
 

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -330,16 +330,12 @@ install_wolfi_packages() {
             krb5-libs \
             less \
             libgcc \
-            libintl \
             libstdc++ \
-            lsof \
             lttng-ust \
             nano \
-            ncdu \
             net-tools \
             openssh-client \
             procps \
-            psmisc \
             rsync \
             sed \
             shadow \
@@ -350,7 +346,6 @@ install_wolfi_packages() {
             userspace-rcu \
             vim \
             wget \
-            which \
             xz \
             zip \
             zlib \

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -621,6 +621,8 @@ fi
 # ****************************
 # ** Utilities and commands **
 # ****************************
+# ensure `/usr/local/bin` exists (not present by default in Wolfi)
+mkdir -p /usr/local/bin
 
 # code shim, it fallbacks to code-insiders if code is not available
 cp -f "${FEATURE_DIR}/bin/code" /usr/local/bin/

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -332,6 +332,8 @@ install_wolfi_packages() {
             libgcc \
             libstdc++ \
             lttng-ust \
+            man-db \
+            man-db-doc \
             nano \
             net-tools \
             openssh-client \
@@ -355,13 +357,6 @@ install_wolfi_packages() {
         LIBSSL1_PKG=libssl1.1
         if [[ $(apk search --no-cache -a $LIBSSL1_PKG | grep $LIBSSL1_PKG) ]]; then
             apk add --no-cache $LIBSSL1_PKG
-        fi
-
-        # Install man pages - package name varies between 3.12 and earlier versions
-        if apk info man > /dev/null 2>&1; then
-            apk add --no-cache man man-pages
-        else
-            apk add --no-cache mandoc man-pages
         fi
 
         # Install git if not already installed (may be more recent than distro version)

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -317,7 +317,6 @@ install_alpine_packages() {
 
 # Wolfi packages
 install_wolfi_packages() {
-    apk update
 
     if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
         apk add --no-cache \

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -337,6 +337,7 @@ install_wolfi_packages() {
             nano \
             net-tools \
             openssh-client \
+            posix-libc-utils \
             procps \
             rsync \
             sed \

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -320,40 +320,41 @@ install_wolfi_packages() {
 
     if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
         apk add --no-cache \
-            openssh-client \
-            gnupg \
-            procps \
-            lsof \
-            htop \
-            net-tools \
-            psmisc \
-            curl \
-            wget \
-            rsync \
             ca-certificates \
+            coreutils \
+            curl \
+            gnupg \
+            grep \
+            htop \
+            jq \
+            krb5-libs \
+            less \
+            libgcc \
+            libintl \
+            libstdc++ \
+            lsof \
+            lttng-ust \
+            nano \
+            ncdu \
+            net-tools \
+            openssh-client \
+            procps \
+            psmisc \
+            rsync \
+            sed \
+            shadow \
+            strace \
+            sudo \
+            tzdata \
             unzip \
+            userspace-rcu \
+            vim \
+            wget \
+            which \
             xz \
             zip \
-            nano \
-            vim \
-            less \
-            jq \
-            libgcc \
-            libstdc++ \
-            krb5-libs \
-            libintl \
-            lttng-ust \
-            tzdata \
-            userspace-rcu \
             zlib \
-            sudo \
-            coreutils \
-            sed \
-            grep \
-            which \
-            ncdu \
-            shadow \
-            strace
+            ;
 
         # # Include libssl1.1 if available (not available for 3.19 and newer)
         LIBSSL1_PKG=libssl1.1

--- a/test/common-utils/scenarios.json
+++ b/test/common-utils/scenarios.json
@@ -127,6 +127,13 @@
             "common-utils": {}
         }
     },
+    "wolfi": {
+        "image": "cgr.dev/chainguard/wolfi-base",
+        "remoteUser": "devcontainer",
+        "features": {
+            "common-utils": {}
+        }
+    },
     "alternate-values": {
         "image": "debian:bullseye",
         "features": {

--- a/test/common-utils/wolfi.sh
+++ b/test/common-utils/wolfi.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+. /etc/os-release
+check "non-root user" test "$(whoami)" = "devcontainer"
+check "distro" test "${ID}" = "wolfi"
+
+# Report result
+reportResults


### PR DESCRIPTION
Adds support for the [Wolfi Linux Distribution](https://github.com/wolfi-dev/) from Chainguard.