### PR TITLE
dotnet lts fix

### DIFF
--- a/test/dotnet/install_dotnet_lts.sh
+++ b/test/dotnet/install_dotnet_lts.sh
@@ -13,7 +13,7 @@ source dev-container-features-test-lib
 source dotnet_env.sh
 source dotnet_helpers.sh
 
-expected=$(fetch_latest_version_in_channel "LTS")
+expected=$(fetch_latest_version_in_channel "8.0")
 
 check "Latest LTS version installed" \
 is_dotnet_sdk_version_installed "$expected"


### PR DESCRIPTION
[Issue 1000](https://github.com/devcontainers/features/issues/1000)
**Feature Name:**
- Dotnet

**Description:**
This PR does the following -
- changed the channel for the test from LTS to 8.0 to retrieve the latest sdk version 8.0.302

_Changelog:_
- Updated install_dotnet_lts.sh
    - changed channel to 8.0 

**Checklist:**

- [x] It should pass the test as the test install latest version 8.0.302