### PR TITLE
dotnet: make 'dotnet' available to 'sudo' commands

### DIFF
--- a/src/dotnet/devcontainer-feature.json
+++ b/src/dotnet/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "dotnet",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "name": "Dotnet CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/dotnet",
     "description": "This Feature installs the latest .NET SDK, which includes the .NET CLI and the shared runtime. Options are provided to choose a different version or additional versions.",

--- a/src/dotnet/install.sh
+++ b/src/dotnet/install.sh
@@ -131,8 +131,7 @@ fi
 # Create a symbolic link '/usr/bin/dotnet', to make dotnet available to 'sudo'
 # This is necessary because 'sudo' resets the PATH variable, so it won't search the DOTNET_ROOT directory
 if [ ! -e /usr/bin/dotnet ]; then
-    # Use --force to overwrite any existing link that might already exist in the base image
-    ln --symbolic --force "$DOTNET_ROOT/dotnet" /usr/bin/dotnet
+    ln --symbolic "$DOTNET_ROOT/dotnet" /usr/bin/dotnet
 fi
 
 # Clean up

--- a/src/dotnet/install.sh
+++ b/src/dotnet/install.sh
@@ -128,6 +128,13 @@ if [ ${#workloads[@]} -ne 0 ]; then
     install_workloads "${workloads[@]}"
 fi
 
+# Create a symbolic link '/usr/bin/dotnet', to make dotnet available to 'sudo'
+# This is necessary because 'sudo' resets the PATH variable, so it won't search the DOTNET_ROOT directory
+if [ ! -e /usr/bin/dotnet ]; then
+    # Use --force to overwrite any existing link that might already exist in the base image
+    ln --symbolic --force "$DOTNET_ROOT/dotnet" /usr/bin/dotnet
+fi
+
 # Clean up
 rm -rf /var/lib/apt/lists/*
 rm -rf scripts

--- a/src/dotnet/scripts/dotnet-helpers.sh
+++ b/src/dotnet/scripts/dotnet-helpers.sh
@@ -8,7 +8,6 @@
 # Maintainer: The Dev Container spec maintainers
 DOTNET_SCRIPTS=$(dirname "${BASH_SOURCE[0]}")
 DOTNET_INSTALL_SCRIPT="$DOTNET_SCRIPTS/vendor/dotnet-install.sh"
-DOTNET_INSTALL_DIR='/usr/share/dotnet'
 
 # Prints the latest dotnet version in the specified channel
 # Usage: fetch_latest_version_in_channel <channel> [<runtime>]
@@ -75,11 +74,11 @@ install_sdk() {
     fi
     
     # Currently this script does not make it possible to qualify the version, 'GA' is always implied
-    echo "Executing $DOTNET_INSTALL_SCRIPT --version $version --channel $channel --install-dir $DOTNET_INSTALL_DIR"
+    echo "Executing $DOTNET_INSTALL_SCRIPT --version $version --channel $channel --install-dir $DOTNET_ROOT"
     "$DOTNET_INSTALL_SCRIPT" \
         --version "$version" \
         --channel "$channel" \
-        --install-dir "$DOTNET_INSTALL_DIR"
+        --install-dir "$DOTNET_ROOT"
 }
 
 # Installs a version of the .NET Runtime
@@ -107,12 +106,12 @@ install_runtime() {
         version="$inputVersion"
     fi
     
-    echo "Executing $DOTNET_INSTALL_SCRIPT --runtime $runtime --version $version --channel $channel --install-dir $DOTNET_INSTALL_DIR --no-path"
+    echo "Executing $DOTNET_INSTALL_SCRIPT --runtime $runtime --version $version --channel $channel --install-dir $DOTNET_ROOT --no-path"
     "$DOTNET_INSTALL_SCRIPT" \
         --runtime "$runtime" \
         --version "$version" \
         --channel "$channel" \
-        --install-dir "$DOTNET_INSTALL_DIR" \
+        --install-dir "$DOTNET_ROOT" \
         --no-path
 }
 

--- a/test/dotnet/test.sh
+++ b/test/dotnet/test.sh
@@ -13,6 +13,12 @@ source dev-container-features-test-lib
 source dotnet_env.sh
 source dotnet_helpers.sh
 
+check "dotnet is installed in DOTNET_ROOT and execute permission is granted" \
+test -x "$DOTNET_ROOT/dotnet" 
+
+check "dotnet is symlinked correctly in /usr/bin" \
+test -L /usr/bin/dotnet -a "$(readlink -f /usr/bin/dotnet)" = "$DOTNET_ROOT/dotnet"
+
 expected=$(fetch_latest_version)
 
 check "Latest .NET SDK version installed" \


### PR DESCRIPTION
Hello,

This PR adds a symbolic link from `/usr/bin/dotnet` to `/usr/share/dotnet/dotnet`.

This is necessary to make `sudo dotnet` commands work properly, because `sudo` resets the `PATH` and dotnet will not be found without this symlink.

For example, when setting up HTTPS developer certificates, you need `sudo` to save the certificate to a location owned by root.

``` sh
sudo -E dotnet dev-certs https --export-path /usr/local/share/ca-certificates/https.crt --format pem
sudo update-ca-certificates
```

(Example from https://learn.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-8.0&tabs=visual-studio%2Clinux-ubuntu#ubuntu-trust-the-certificate-for-service-to-service-communication)