### PR TITLE
Allow installing `yarn` via `corepack` on Debian-based systems, too

### DIFF
--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -19,6 +19,7 @@ This Feature installs the latest .NET SDK, which includes the .NET CLI and the s
 | additionalVersions | Enter additional .NET SDK versions, separated by commas. Use 'latest' for the latest version, 'lts' for the latest LTS version, 'X.Y' or 'X.Y.Z' for a specific version. | string | - |
 | dotnetRuntimeVersions | Enter additional .NET runtime versions, separated by commas. Use 'latest' for the latest version, 'lts' for the latest LTS version, 'X.Y' or 'X.Y.Z' for a specific version. | string | - |
 | aspNetCoreRuntimeVersions | Enter additional ASP.NET Core runtime versions, separated by commas. Use 'latest' for the latest version, 'lts' for the latest LTS version, 'X.Y' or 'X.Y.Z' for a specific version. | string | - |
+| workloads | Enter additional .NET SDK workloads, separated by commas. Use 'dotnet workload search' to learn what workloads are available to install. | string | - |
 
 ## Customizations
 
@@ -30,8 +31,7 @@ This Feature installs the latest .NET SDK, which includes the .NET CLI and the s
 
 Installing only the latest .NET SDK version (the default).
 
-``` json
-{
+``` jsonc
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": "latest" // or "" or {}
 }
@@ -40,7 +40,6 @@ Installing only the latest .NET SDK version (the default).
 Installing an additional SDK version. Multiple versions can be specified as comma-separated values.
 
 ``` json
-{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "additionalVersions": "lts"
@@ -51,7 +50,6 @@ Installing an additional SDK version. Multiple versions can be specified as comm
 Installing specific SDK versions.
 
 ``` json
-{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "version": "6.0",
@@ -63,7 +61,6 @@ Installing specific SDK versions.
 Installing a specific SDK feature band.
 
 ``` json
-{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "version": "6.0.4xx",
@@ -74,7 +71,6 @@ Installing a specific SDK feature band.
 Installing a specific SDK patch version.
 
 ``` json
-{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "version": "6.0.412",
@@ -85,12 +81,21 @@ Installing a specific SDK patch version.
 Installing only the .NET Runtime or the ASP.NET Core Runtime. (The SDK includes all runtimes so this configuration is only useful if you need to run .NET apps without building them from source.)
 
 ``` json
-{
 "features": {
     "ghcr.io/devcontainers/features/dotnet:2": {
         "version": "none",
         "dotnetRuntimeVersions": "latest, lts",
         "aspnetCoreRuntimeVersions": "latest, lts",
+    }
+}
+```
+
+Installing .NET workloads. Multiple workloads can be specified as comma-separated values.
+
+``` json
+"features": {
+    "ghcr.io/devcontainers/features/dotnet:2": {
+      "workloads": "aspire, wasm-tools"
     }
 }
 ```

--- a/src/node/devcontainer-feature.json
+++ b/src/node/devcontainer-feature.json
@@ -40,7 +40,7 @@
         "yarnFromApt": {
             "type": "boolean",
             "default": true,
-            "description": "Whether to install yarn globally via APT on Debian-based systems (Debian, Ubuntu). If false, will set up yarn via corepack. This setting is ignored on other Linux images, where yarn is always installed via corepack."
+            "description": "On Debian & Ubuntu systems, you can choose whether to install Yarn globally via APT. If this option is set to false, Yarn will be set up via Corepack instead. This setting does not apply to other Linux distributions, where Yarn is always installed using Corepack."
         }
     },
     "customizations": {

--- a/src/node/devcontainer-feature.json
+++ b/src/node/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "node",
-    "version": "1.4.1",
+    "version": "1.5.0",
     "name": "Node.js (via nvm), yarn and pnpm",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/node",
     "description": "Installs Node.js, nvm, yarn, pnpm, and needed dependencies.",
@@ -36,6 +36,11 @@
             ],
             "default": "latest",
             "description": "Version of NVM to install."
+        },
+        "yarnFromApt": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to install yarn globally via APT on Debian-based systems (Debian, Ubuntu). If false, will set up yarn via corepack. This setting is ignored on other Linux images, where yarn is always installed via corepack."
         }
     },
     "customizations": {

--- a/src/node/devcontainer-feature.json
+++ b/src/node/devcontainer-feature.json
@@ -40,7 +40,7 @@
         "installYarnUsingApt": {
             "type": "boolean",
             "default": true,
-            "description": "On Debian & Ubuntu systems, you can choose whether to install Yarn globally via APT. If this option is set to false, Yarn will be set up via Corepack instead. This setting does not apply to other Linux distributions, where Yarn is always installed using Corepack."
+            "description": "On Debian & Ubuntu systems, you can choose whether to install Yarn globally via APT. If this option is set to false, Yarn will be set up via Corepack instead. This setting does not apply to other Linux distributions, where Yarn is always installed using Corepack (with a fallback to installation via NPM in case of an error)."
         }
     },
     "customizations": {

--- a/src/node/devcontainer-feature.json
+++ b/src/node/devcontainer-feature.json
@@ -37,7 +37,7 @@
             "default": "latest",
             "description": "Version of NVM to install."
         },
-        "yarnFromApt": {
+        "installYarnUsingApt": {
             "type": "boolean",
             "default": true,
             "description": "On Debian & Ubuntu systems, you can choose whether to install Yarn globally via APT. If this option is set to false, Yarn will be set up via Corepack instead. This setting does not apply to other Linux distributions, where Yarn is always installed using Corepack."

--- a/src/node/devcontainer-feature.json
+++ b/src/node/devcontainer-feature.json
@@ -40,7 +40,7 @@
         "installYarnUsingApt": {
             "type": "boolean",
             "default": true,
-            "description": "On Debian & Ubuntu systems, you can choose whether to install Yarn globally via APT. If this option is set to false, Yarn will be set up via Corepack instead. This setting does not apply to other Linux distributions, where Yarn is always installed using Corepack (with a fallback to installation via NPM in case of an error)."
+            "description": "On Debian and Ubuntu systems, you have the option to install Yarn globally via APT. If you choose not to use this option, Yarn will be set up using Corepack instead. This choice is specific to Debian and Ubuntu; for other Linux distributions, Yarn is always installed using Corepack, with a fallback to installation via NPM if an error occurs."
         }
     },
     "customizations": {

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -11,6 +11,7 @@ export NODE_VERSION="${VERSION:-"lts"}"
 export NVM_VERSION="${NVMVERSION:-"latest"}"
 export NVM_DIR="${NVMINSTALLPATH:-"/usr/local/share/nvm"}"
 INSTALL_TOOLS_FOR_NODE_GYP="${NODEGYPDEPENDENCIES:-true}"
+export YARN_FROM_APT="${YARNFROMAPT:-true}"  # only concerns Debian-based systems
 
 # Comma-separated list of node versions to be installed (with nvm)
 # alongside NODE_VERSION, but not set as default.
@@ -188,7 +189,7 @@ find_version_from_git_tags() {
 }
 
 install_yarn() {
-    if [ "${ADJUSTED_ID}" = "debian" ]; then
+    if [ "${ADJUSTED_ID}" = "debian" ] && [ "${YARN_FROM_APT}" = "true" ]; then
         # for backward compatiblity with existing devcontainer features, install yarn
         # via apt-get on Debian systems
         if ! type yarn >/dev/null 2>&1; then
@@ -202,8 +203,9 @@ install_yarn() {
         fi
     else
         local _ver=${1:-node}
-        # on non-debian systems, prefer corepack, fallback to npm based installation of yarn...
-        # Try to leverage corepack if possible
+        # on non-debian systems or if user opted not to use APT, prefer corepack
+        # Fallback to npm based installation of yarn.
+        # But try to leverage corepack if possible
         # From https://yarnpkg.com:
         # The preferred way to manage Yarn is by-project and through Corepack, a tool
         # shipped by default with Node.js. Modern releases of Yarn aren't meant to be

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -11,7 +11,7 @@ export NODE_VERSION="${VERSION:-"lts"}"
 export NVM_VERSION="${NVMVERSION:-"latest"}"
 export NVM_DIR="${NVMINSTALLPATH:-"/usr/local/share/nvm"}"
 INSTALL_TOOLS_FOR_NODE_GYP="${NODEGYPDEPENDENCIES:-true}"
-export YARN_FROM_APT="${YARNFROMAPT:-true}"  # only concerns Debian-based systems
+export INSTALL_YARN_USING_APT="${INSTALLYARNUSINGAPT:-true}"  # only concerns Debian-based systems
 
 # Comma-separated list of node versions to be installed (with nvm)
 # alongside NODE_VERSION, but not set as default.
@@ -189,7 +189,7 @@ find_version_from_git_tags() {
 }
 
 install_yarn() {
-    if [ "${ADJUSTED_ID}" = "debian" ] && [ "${YARN_FROM_APT}" = "true" ]; then
+    if [ "${ADJUSTED_ID}" = "debian" ] && [ "${INSTALL_YARN_USING_APT}" = "true" ]; then
         # for backward compatiblity with existing devcontainer features, install yarn
         # via apt-get on Debian systems
         if ! type yarn >/dev/null 2>&1; then

--- a/test/node/debian_yarn_from_corepack.sh
+++ b/test/node/debian_yarn_from_corepack.sh
@@ -8,7 +8,7 @@ source dev-container-features-test-lib
 # Definition specific tests
 YARN_VERSION="4.3.0"
 
-# Corepack provides shims for package managers like yarn. When yarn is invoked by the "yarn"
+# Corepack provides shims for package managers like yarn. When yarn is invoked via the "yarn"
 # command, corepack will interactively request permission to download the yarn binary. To
 # avoid this interactive mode and download the binary automatically, we call "corepack use yarn"
 # instead. Once that command completes, "yarn" can be used normally and in a non-interactive mode.

--- a/test/node/debian_yarn_from_corepack.sh
+++ b/test/node/debian_yarn_from_corepack.sh
@@ -8,10 +8,10 @@ source dev-container-features-test-lib
 # Definition specific tests
 YARN_VERSION="4.3.0"
 
-# Corepack provides shims for package managers like yarn. When yarn is invoked via the "yarn"
+# Corepack provides shims for package managers like yarn. The first time yarn is invoked via the "yarn"
 # command, corepack will interactively request permission to download the yarn binary. To
-# avoid this interactive mode and download the binary automatically, we call "corepack use yarn"
-# instead. Once that command completes, "yarn" can be used normally and in a non-interactive mode.
+# avoid this interactive mode and download the binary automatically, we explicitly call "corepack use yarn"
+# instead (doesn't require user input). Once that command completes, "yarn" can be used in a non-interactive mode.
 check "yarn shim location" bash -c ". /usr/local/share/nvm/nvm.sh && type yarn &> /dev/null"
 check "download yarn" bash -c ". /usr/local/share/nvm/nvm.sh && corepack use yarn@${YARN_VERSION}"
 check "yarn version" bash -c ". /usr/local/share/nvm/nvm.sh && yarn --version | grep ${YARN_VERSION}"

--- a/test/node/debian_yarn_from_corepack.sh
+++ b/test/node/debian_yarn_from_corepack.sh
@@ -8,8 +8,13 @@ source dev-container-features-test-lib
 # Definition specific tests
 YARN_VERSION="4.3.0"
 
-check "download yarn" bash -c ". /usr/local/share/nvm/nvm.sh && nvm use lts && corepack use yarn@${YARN_VERSION}"
-check "yarn version" bash -c ". /usr/local/share/nvm/nvm.sh && nvm use lts && yarn --version | grep ${YARN_VERSION}"
+# Corepack provides shims for package managers like yarn. When yarn is invoked by the "yarn"
+# command, corepack will interactively request permission to download the yarn binary. To
+# avoid this interactive mode and download the binary automatically, we call "corepack use yarn"
+# instead. Once that command completes, "yarn" can be used normally and in a non-interactive mode.
+check "yarn shim location" bash -c ". /usr/local/share/nvm/nvm.sh && type yarn &> /dev/null"
+check "download yarn" bash -c ". /usr/local/share/nvm/nvm.sh && corepack use yarn@${YARN_VERSION}"
+check "yarn version" bash -c ". /usr/local/share/nvm/nvm.sh && yarn --version | grep ${YARN_VERSION}"
 
 # Report result
 reportResults

--- a/test/node/debian_yarn_from_corepack.sh
+++ b/test/node/debian_yarn_from_corepack.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+YARN_VERSION="4.3.0"
+
+check "download yarn" bash -c ". /usr/local/share/nvm/nvm.sh && nvm use lts && corepack use yarn@${YARN_VERSION}"
+check "yarn version" bash -c ". /usr/local/share/nvm/nvm.sh && nvm use lts && yarn --version | grep ${YARN_VERSION}"
+
+# Report result
+reportResults

--- a/test/node/scenarios.json
+++ b/test/node/scenarios.json
@@ -185,5 +185,13 @@
                 "version": "lts"
             }
         }
+    },
+    "debian_yarn_from_corepack": {
+        "image": "debian:11",
+        "features": {
+            "node": {
+                "installYarnUsingApt": false
+            }
+        }
     }
 }


### PR DESCRIPTION
The default behavior remains unchanged, but Debian and Ubuntu users can now opt-out from the APT-based installation to get the latest `yarn` via `corepack`.

Closes #1004