### PR TITLE
Resolve slow key retrieval when some GPG key servers are not reachable

### DIFF
--- a/src/git-lfs/devcontainer-feature.json
+++ b/src/git-lfs/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "git-lfs",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "name": "Git Large File Support (LFS)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/git-lfs",
     "description": "Installs Git Large File Support (Git LFS) along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like git and curl.",

--- a/src/git-lfs/install.sh
+++ b/src/git-lfs/install.sh
@@ -62,11 +62,12 @@ find_version_from_git_tags() {
 
 # Get the list of GPG key servers that are reachable
 get_gpg_key_servers() {
-    declare -A keyservers_curl_map
-    keyservers_curl_map["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
-    keyservers_curl_map["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
-    keyservers_curl_map["hkps://keys.openpgp.org"]="https://keys.openpgp.org:443"
-    keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+    declare -A keyservers_curl_map=(
+        ["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
+        ["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
+        ["hkps://keys.openpgp.org"]="https://keys.openpgp.org"
+        ["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+    )
 
     local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable

--- a/src/git-lfs/install.sh
+++ b/src/git-lfs/install.sh
@@ -75,7 +75,7 @@ get_gpg_key_servers() {
         curl_args="--proxy ${KEYSERVER_PROXY}"
     fi
 
-    for keyserver in ${!keyservers_curl_map[@]}; do
+    for keyserver in "${!keyservers_curl_map[@]}"; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
         if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
             echo "keyserver ${keyserver}"

--- a/src/git/devcontainer-feature.json
+++ b/src/git/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "git",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "name": "Git (from source)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/git",
     "description": "Install an up-to-date version of Git, built from source as needed. Useful for when you want the latest and greatest features. Auto-detects latest stable version and installs needed dependencies.",

--- a/src/git/install.sh
+++ b/src/git/install.sh
@@ -66,11 +66,12 @@ clean_up
 
 # Get the list of GPG key servers that are reachable
 get_gpg_key_servers() {
-    declare -A keyservers_curl_map
-    keyservers_curl_map["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
-    keyservers_curl_map["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
-    keyservers_curl_map["hkps://keys.openpgp.org"]="https://keys.openpgp.org:443"
-    keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+    declare -A keyservers_curl_map=(
+        ["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
+        ["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
+        ["hkps://keys.openpgp.org"]="https://keys.openpgp.org"
+        ["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+    )
 
     local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable

--- a/src/git/install.sh
+++ b/src/git/install.sh
@@ -11,10 +11,6 @@ GIT_VERSION=${VERSION} # 'system' checks the base image first, else installs 'la
 USE_PPA_IF_AVAILABLE=${PPA}
 
 GIT_CORE_PPA_ARCHIVE_GPG_KEY=E1DD270288B4E6030699E45FA1715D88E1DF1F24
-GPG_KEY_SERVERS="keyserver hkp://keyserver.ubuntu.com
-keyserver hkp://keyserver.ubuntu.com:80
-keyserver hkps://keys.openpgp.org
-keyserver hkp://keyserver.pgp.com"
 
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
@@ -68,6 +64,38 @@ clean_up() {
 }
 clean_up
 
+# Get the list of GPG key servers that are reachable
+get_gpg_key_servers() {
+    declare -A keyservers_curl_map
+    keyservers_curl_map["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
+    keyservers_curl_map["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
+    keyservers_curl_map["hkps://keys.openpgp.org"]="https://keys.openpgp.org:443"
+    keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+
+    local curl_args=""
+    if [ ! -z "${KEYSERVER_PROXY}" ]; then
+        curl_args="--proxy ${KEYSERVER_PROXY}"
+    fi
+
+    local keyserver_list=""
+    for keyserver in ${!keyservers_curl_map[@]}; do
+        local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
+        if curl -s ${curl_args} --max-time 3 ${keyserver_curl_url} > /dev/null; then
+            keyserver_list="${keyserver_list}keyserver ${keyserver}"
+            keyserver_list+=$'\n'
+        else
+            echo "(*) Keyserver ${keyserver} is not reachable." >&2
+        fi
+    done
+
+    if [ -z "${keyserver_list}" ]; then
+        echo "(!) No keyserver is reachable." >&2
+        exit 1
+    fi
+    
+    echo "${keyserver_list}"
+}
+
 # Import the specified key in a variable name passed in as 
 receive_gpg_keys() {
     local keys=${!1}
@@ -77,11 +105,13 @@ receive_gpg_keys() {
         keyring_args="--no-default-keyring --keyring $2"
     fi
 
+    check_packages curl
+    
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"
     mkdir -p ${GNUPGHOME}
     chmod 700 ${GNUPGHOME}
-    echo -e "disable-ipv6\n${GPG_KEY_SERVERS}" > ${GNUPGHOME}/dirmngr.conf
+    echo -e "disable-ipv6\n$(get_gpg_key_servers)" > ${GNUPGHOME}/dirmngr.conf
     # GPG key download sometimes fails for some reason and retrying fixes it.
     local retry_count=0
     local gpg_ok="false"

--- a/src/git/install.sh
+++ b/src/git/install.sh
@@ -73,27 +73,26 @@ get_gpg_key_servers() {
     keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
 
     local curl_args=""
+    local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
+
     if [ ! -z "${KEYSERVER_PROXY}" ]; then
         curl_args="--proxy ${KEYSERVER_PROXY}"
     fi
 
-    local keyserver_list=""
     for keyserver in ${!keyservers_curl_map[@]}; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
-        if curl -s ${curl_args} --max-time 3 ${keyserver_curl_url} > /dev/null; then
-            keyserver_list="${keyserver_list}keyserver ${keyserver}"
-            keyserver_list+=$'\n'
+        if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
+            echo "keyserver ${keyserver}"
+            keyserver_reachable=true
         else
             echo "(*) Keyserver ${keyserver} is not reachable." >&2
         fi
     done
 
-    if [ -z "${keyserver_list}" ]; then
+    if ! $keyserver_reachable; then
         echo "(!) No keyserver is reachable." >&2
         exit 1
     fi
-    
-    echo "${keyserver_list}"
 }
 
 # Import the specified key in a variable name passed in as 
@@ -105,7 +104,10 @@ receive_gpg_keys() {
         keyring_args="--no-default-keyring --keyring $2"
     fi
 
-    check_packages curl
+    # Install curl
+    if ! type curl > /dev/null 2>&1; then
+        check_packages curl
+    fi
     
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"

--- a/src/git/install.sh
+++ b/src/git/install.sh
@@ -79,7 +79,7 @@ get_gpg_key_servers() {
         curl_args="--proxy ${KEYSERVER_PROXY}"
     fi
 
-    for keyserver in ${!keyservers_curl_map[@]}; do
+    for keyserver in "${!keyservers_curl_map[@]}"; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
         if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
             echo "keyserver ${keyserver}"

--- a/src/github-cli/devcontainer-feature.json
+++ b/src/github-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "github-cli",
-    "version": "1.0.12",
+    "version": "1.0.13",
     "name": "GitHub CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/github-cli",
     "description": "Installs the GitHub CLI. Auto-detects latest version and installs needed dependencies.",

--- a/src/github-cli/install.sh
+++ b/src/github-cli/install.sh
@@ -24,11 +24,12 @@ fi
 
 # Get the list of GPG key servers that are reachable
 get_gpg_key_servers() {
-    declare -A keyservers_curl_map
-    keyservers_curl_map["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
-    keyservers_curl_map["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
-    keyservers_curl_map["hkps://keys.openpgp.org"]="https://keys.openpgp.org:443"
-    keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+    declare -A keyservers_curl_map=(
+        ["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
+        ["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
+        ["hkps://keys.openpgp.org"]="https://keys.openpgp.org"
+        ["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+    )
 
     local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable

--- a/src/github-cli/install.sh
+++ b/src/github-cli/install.sh
@@ -31,27 +31,26 @@ get_gpg_key_servers() {
     keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
 
     local curl_args=""
+    local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
+
     if [ ! -z "${KEYSERVER_PROXY}" ]; then
         curl_args="--proxy ${KEYSERVER_PROXY}"
     fi
 
-    local keyserver_list=""
     for keyserver in ${!keyservers_curl_map[@]}; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
-        if curl -s ${curl_args} --max-time 3 ${keyserver_curl_url} > /dev/null; then
-            keyserver_list="${keyserver_list}keyserver ${keyserver}"
-            keyserver_list+=$'\n'
+        if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
+            echo "keyserver ${keyserver}"
+            keyserver_reachable=true
         else
             echo "(*) Keyserver ${keyserver} is not reachable." >&2
         fi
     done
 
-    if [ -z "${keyserver_list}" ]; then
+    if ! $keyserver_reachable; then
         echo "(!) No keyserver is reachable." >&2
         exit 1
     fi
-    
-    echo "${keyserver_list}"
 }
 
 # Import the specified key in a variable name passed in as 
@@ -62,7 +61,10 @@ receive_gpg_keys() {
         keyring_args="--no-default-keyring --keyring $2"
     fi
 
-    check_packages curl
+    # Install curl
+    if ! type curl > /dev/null 2>&1; then
+        check_packages curl
+    fi
 
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"

--- a/src/github-cli/install.sh
+++ b/src/github-cli/install.sh
@@ -37,7 +37,7 @@ get_gpg_key_servers() {
         curl_args="--proxy ${KEYSERVER_PROXY}"
     fi
 
-    for keyserver in ${!keyservers_curl_map[@]}; do
+    for keyserver in "${!keyservers_curl_map[@]}"; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
         if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
             echo "keyserver ${keyserver}"

--- a/src/github-cli/install.sh
+++ b/src/github-cli/install.sh
@@ -11,10 +11,6 @@ CLI_VERSION=${VERSION:-"latest"}
 INSTALL_DIRECTLY_FROM_GITHUB_RELEASE=${INSTALLDIRECTLYFROMGITHUBRELEASE:-"true"}
 
 GITHUB_CLI_ARCHIVE_GPG_KEY=23F3D4EA75716059
-GPG_KEY_SERVERS="keyserver hkp://keyserver.ubuntu.com
-keyserver hkp://keyserver.ubuntu.com:80
-keyserver hkps://keys.openpgp.org
-keyserver hkp://keyserver.pgp.com"
 
 set -e
 
@@ -26,6 +22,37 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 1
 fi
 
+# Get the list of GPG key servers that are reachable
+get_gpg_key_servers() {
+    declare -A keyservers_curl_map
+    keyservers_curl_map["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
+    keyservers_curl_map["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
+    keyservers_curl_map["hkps://keys.openpgp.org"]="https://keys.openpgp.org:443"
+    keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+
+    local curl_args=""
+    if [ ! -z "${KEYSERVER_PROXY}" ]; then
+        curl_args="--proxy ${KEYSERVER_PROXY}"
+    fi
+
+    local keyserver_list=""
+    for keyserver in ${!keyservers_curl_map[@]}; do
+        local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
+        if curl -s ${curl_args} --max-time 3 ${keyserver_curl_url} > /dev/null; then
+            keyserver_list="${keyserver_list}keyserver ${keyserver}"
+            keyserver_list+=$'\n'
+        else
+            echo "(*) Keyserver ${keyserver} is not reachable." >&2
+        fi
+    done
+
+    if [ -z "${keyserver_list}" ]; then
+        echo "(!) No keyserver is reachable." >&2
+        exit 1
+    fi
+    
+    echo "${keyserver_list}"
+}
 
 # Import the specified key in a variable name passed in as 
 receive_gpg_keys() {
@@ -35,11 +62,13 @@ receive_gpg_keys() {
         keyring_args="--no-default-keyring --keyring $2"
     fi
 
+    check_packages curl
+
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"
     mkdir -p ${GNUPGHOME}
     chmod 700 ${GNUPGHOME}
-    echo -e "disable-ipv6\n${GPG_KEY_SERVERS}" > ${GNUPGHOME}/dirmngr.conf
+    echo -e "disable-ipv6\n$(get_gpg_key_servers)" > ${GNUPGHOME}/dirmngr.conf
     # GPG key download sometimes fails for some reason and retrying fixes it.
     local retry_count=0
     local gpg_ok="false"

--- a/src/kubectl-helm-minikube/devcontainer-feature.json
+++ b/src/kubectl-helm-minikube/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "kubectl-helm-minikube",
-    "version": "1.1.9",
+    "version": "1.1.10",
     "name": "Kubectl, Helm, and Minikube",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/kubectl-helm-minikube",
     "description": "Installs latest version of kubectl, Helm, and optionally minikube. Auto-detects latest versions and installs needed dependencies.",

--- a/src/kubectl-helm-minikube/install.sh
+++ b/src/kubectl-helm-minikube/install.sh
@@ -245,7 +245,7 @@ get_gpg_key_servers() {
         curl_args="--proxy ${KEYSERVER_PROXY}"
     fi
 
-    for keyserver in ${!keyservers_curl_map[@]}; do
+    for keyserver in "${!keyservers_curl_map[@]}"; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
         if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
             echo "keyserver ${keyserver}"

--- a/src/kubectl-helm-minikube/install.sh
+++ b/src/kubectl-helm-minikube/install.sh
@@ -239,27 +239,26 @@ get_gpg_key_servers() {
     keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
 
     local curl_args=""
+    local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
+
     if [ ! -z "${KEYSERVER_PROXY}" ]; then
         curl_args="--proxy ${KEYSERVER_PROXY}"
     fi
 
-    local keyserver_list=""
     for keyserver in ${!keyservers_curl_map[@]}; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
-        if curl -s ${curl_args} --max-time 3 ${keyserver_curl_url} > /dev/null; then
-            keyserver_list="${keyserver_list}keyserver ${keyserver}"
-            keyserver_list+=$'\n'
+        if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
+            echo "keyserver ${keyserver}"
+            keyserver_reachable=true
         else
             echo "(*) Keyserver ${keyserver} is not reachable." >&2
         fi
     done
 
-    if [ -z "${keyserver_list}" ]; then
+    if ! $keyserver_reachable; then
         echo "(!) No keyserver is reachable." >&2
         exit 1
     fi
-    
-    echo "${keyserver_list}"
 }
 
 if [ ${HELM_VERSION} != "none" ]; then

--- a/src/kubectl-helm-minikube/install.sh
+++ b/src/kubectl-helm-minikube/install.sh
@@ -232,11 +232,12 @@ get_helm() {
 
 # Get the list of GPG key servers that are reachable
 get_gpg_key_servers() {
-    declare -A keyservers_curl_map
-    keyservers_curl_map["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
-    keyservers_curl_map["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
-    keyservers_curl_map["hkps://keys.openpgp.org"]="https://keys.openpgp.org:443"
-    keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+    declare -A keyservers_curl_map=(
+        ["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
+        ["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
+        ["hkps://keys.openpgp.org"]="https://keys.openpgp.org"
+        ["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+    )
 
     local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable

--- a/src/kubectl-helm-minikube/install.sh
+++ b/src/kubectl-helm-minikube/install.sh
@@ -22,10 +22,6 @@ MINIKUBE_SHA256="${MINIKUBE_SHA256:-"automatic"}"
 USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
 
 HELM_GPG_KEYS_URI="https://raw.githubusercontent.com/helm/helm/main/KEYS"
-GPG_KEY_SERVERS="keyserver hkp://keyserver.ubuntu.com
-keyserver hkp://keyserver.ubuntu.com:80
-keyserver hkps://keys.openpgp.org
-keyserver hkp://keyserver.pgp.com"
 
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
@@ -234,6 +230,38 @@ get_helm() {
     curl -sSL "https://github.com/helm/helm/releases/download/${HELM_VERSION}/${helm_filename}.asc" -o "${tmp_helm_filename}.asc"
 }
 
+# Get the list of GPG key servers that are reachable
+get_gpg_key_servers() {
+    declare -A keyservers_curl_map
+    keyservers_curl_map["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
+    keyservers_curl_map["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
+    keyservers_curl_map["hkps://keys.openpgp.org"]="https://keys.openpgp.org:443"
+    keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+
+    local curl_args=""
+    if [ ! -z "${KEYSERVER_PROXY}" ]; then
+        curl_args="--proxy ${KEYSERVER_PROXY}"
+    fi
+
+    local keyserver_list=""
+    for keyserver in ${!keyservers_curl_map[@]}; do
+        local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
+        if curl -s ${curl_args} --max-time 3 ${keyserver_curl_url} > /dev/null; then
+            keyserver_list="${keyserver_list}keyserver ${keyserver}"
+            keyserver_list+=$'\n'
+        else
+            echo "(*) Keyserver ${keyserver} is not reachable." >&2
+        fi
+    done
+
+    if [ -z "${keyserver_list}" ]; then
+        echo "(!) No keyserver is reachable." >&2
+        exit 1
+    fi
+    
+    echo "${keyserver_list}"
+}
+
 if [ ${HELM_VERSION} != "none" ]; then
     # Install Helm, verify signature and checksum
     echo "Downloading Helm..."
@@ -255,7 +283,7 @@ if [ ${HELM_VERSION} != "none" ]; then
     mkdir -p "${GNUPGHOME}"
     chmod 700 ${GNUPGHOME}
     curl -sSL "${HELM_GPG_KEYS_URI}" -o /tmp/helm/KEYS
-    echo -e "disable-ipv6\n${GPG_KEY_SERVERS}" > ${GNUPGHOME}/dirmngr.conf
+    echo -e "disable-ipv6\n$(get_gpg_key_servers)" > ${GNUPGHOME}/dirmngr.conf
     gpg -q --import "/tmp/helm/KEYS"
     if ! gpg --verify "${tmp_helm_filename}.asc" > ${GNUPGHOME}/verify.log 2>&1; then
         echo "Verification failed!"

--- a/src/python/devcontainer-feature.json
+++ b/src/python/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "python",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "name": "Python",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/python",
   "description": "Installs the provided version of Python, as well as PIPX, and other common Python utilities.  JupyterLab is conditionally installed with the python feature. Note: May require source code compilation.",

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -134,27 +134,26 @@ get_gpg_key_servers() {
     keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
 
     local curl_args=""
+    local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
+
     if [ ! -z "${KEYSERVER_PROXY}" ]; then
         curl_args="--proxy ${KEYSERVER_PROXY}"
     fi
 
-    local keyserver_list=""
     for keyserver in ${!keyservers_curl_map[@]}; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
-        if curl -s ${curl_args} --max-time 3 ${keyserver_curl_url} > /dev/null; then
-            keyserver_list="${keyserver_list}keyserver ${keyserver}"
-            keyserver_list+=$'\n'
+        if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
+            echo "keyserver ${keyserver}"
+            keyserver_reachable=true
         else
             echo "(*) Keyserver ${keyserver} is not reachable." >&2
         fi
     done
 
-    if [ -z "${keyserver_list}" ]; then
+    if ! $keyserver_reachable; then
         echo "(!) No keyserver is reachable." >&2
         exit 1
     fi
-    
-    echo "${keyserver_list}"
 }
 
 # Import the specified key in a variable name passed in as
@@ -170,7 +169,10 @@ receive_gpg_keys() {
         keyring_args="${keyring_args} --keyserver-options http-proxy=${KEYSERVER_PROXY}"
     fi
 
-    check_packages curl
+    # Install curl
+    if ! type curl > /dev/null 2>&1; then
+        check_packages curl
+    fi
 
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"
@@ -211,7 +213,10 @@ receive_gpg_keys_centos7() {
         keyring_args="${keyring_args} --keyserver-options http-proxy=${KEYSERVER_PROXY}"
     fi
 
-    check_packages curl
+    # Install curl
+    if ! type curl > /dev/null 2>&1; then
+        check_packages curl
+    fi
 
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -31,7 +31,6 @@ ADDITIONAL_VERSIONS="${ADDITIONALVERSIONS:-""}"
 # Comma-separated list of additional tools to be installed via pipx.
 IFS="," read -r -a DEFAULT_UTILS <<< "${TOOLSTOINSTALL:-flake8,autopep8,black,yapf,mypy,pydocstyle,pycodestyle,bandit,pipenv,virtualenv,pytest}"
 
-
 PYTHON_SOURCE_GPG_KEYS="64E628F8D684696D B26995E310250568 2D347EA6AA65421D FB9921286F5E1540 3A5CA953F73C700D 04C367C218ADD4FF 0EDDC5F26A45C816 6AF053F07D9DC8D2 C9BE28DEE6DF025C 126EB563A74B06BF D9866941EA5BBD71 ED9D77D5 A821E680E5FA6305"
 
 KEYSERVER_PROXY="${HTTPPROXY:-"${HTTP_PROXY:-""}"}"
@@ -128,8 +127,6 @@ updaterc() {
 
 # Get the list of GPG key servers that are reachable
 get_gpg_key_servers() {
-    check_packages curl
-
     declare -A keyservers_curl_map
     keyservers_curl_map["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
     keyservers_curl_map["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
@@ -173,6 +170,8 @@ receive_gpg_keys() {
         keyring_args="${keyring_args} --keyserver-options http-proxy=${KEYSERVER_PROXY}"
     fi
 
+    check_packages curl
+
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"
     mkdir -p ${GNUPGHOME}
@@ -211,6 +210,8 @@ receive_gpg_keys_centos7() {
     if [ ! -z "${KEYSERVER_PROXY}" ]; then
         keyring_args="${keyring_args} --keyserver-options http-proxy=${KEYSERVER_PROXY}"
     fi
+
+    check_packages curl
 
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -127,11 +127,12 @@ updaterc() {
 
 # Get the list of GPG key servers that are reachable
 get_gpg_key_servers() {
-    declare -A keyservers_curl_map
-    keyservers_curl_map["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
-    keyservers_curl_map["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
-    keyservers_curl_map["hkps://keys.openpgp.org"]="https://keys.openpgp.org:443"
-    keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+    declare -A keyservers_curl_map=(
+        ["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
+        ["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
+        ["hkps://keys.openpgp.org"]="https://keys.openpgp.org"
+        ["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+    )
 
     local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -140,7 +140,7 @@ get_gpg_key_servers() {
         curl_args="--proxy ${KEYSERVER_PROXY}"
     fi
 
-    for keyserver in ${!keyservers_curl_map[@]}; do
+    for keyserver in "${!keyservers_curl_map[@]}"; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
         if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
             echo "keyserver ${keyserver}"

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -33,10 +33,6 @@ IFS="," read -r -a DEFAULT_UTILS <<< "${TOOLSTOINSTALL:-flake8,autopep8,black,ya
 
 
 PYTHON_SOURCE_GPG_KEYS="64E628F8D684696D B26995E310250568 2D347EA6AA65421D FB9921286F5E1540 3A5CA953F73C700D 04C367C218ADD4FF 0EDDC5F26A45C816 6AF053F07D9DC8D2 C9BE28DEE6DF025C 126EB563A74B06BF D9866941EA5BBD71 ED9D77D5 A821E680E5FA6305"
-GPG_KEY_SERVERS="keyserver hkp://keyserver.ubuntu.com
-keyserver hkp://keyserver.ubuntu.com:80
-keyserver hkps://keys.openpgp.org
-keyserver hkp://keyserver.pgp.com"
 
 KEYSERVER_PROXY="${HTTPPROXY:-"${HTTP_PROXY:-""}"}"
 
@@ -130,6 +126,40 @@ updaterc() {
     fi
 }
 
+# Get the list of GPG key servers that are reachable
+get_gpg_key_servers() {
+    check_packages curl
+
+    declare -A keyservers_curl_map
+    keyservers_curl_map["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
+    keyservers_curl_map["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
+    keyservers_curl_map["hkps://keys.openpgp.org"]="https://keys.openpgp.org:443"
+    keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+
+    local curl_args=""
+    if [ ! -z "${KEYSERVER_PROXY}" ]; then
+        curl_args="--proxy ${KEYSERVER_PROXY}"
+    fi
+
+    local keyserver_list=""
+    for keyserver in ${!keyservers_curl_map[@]}; do
+        local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
+        if curl -s ${curl_args} --max-time 3 ${keyserver_curl_url} > /dev/null; then
+            keyserver_list="${keyserver_list}keyserver ${keyserver}"
+            keyserver_list+=$'\n'
+        else
+            echo "(*) Keyserver ${keyserver} is not reachable." >&2
+        fi
+    done
+
+    if [ -z "${keyserver_list}" ]; then
+        echo "(!) No keyserver is reachable." >&2
+        exit 1
+    fi
+    
+    echo "${keyserver_list}"
+}
+
 # Import the specified key in a variable name passed in as
 receive_gpg_keys() {
     local keys=${!1}
@@ -147,7 +177,7 @@ receive_gpg_keys() {
     export GNUPGHOME="/tmp/tmp-gnupg"
     mkdir -p ${GNUPGHOME}
     chmod 700 ${GNUPGHOME}
-    echo -e "disable-ipv6\nconnect-timeout 3\n${GPG_KEY_SERVERS}" > ${GNUPGHOME}/dirmngr.conf
+    echo -e "disable-ipv6\n$(get_gpg_key_servers)" > ${GNUPGHOME}/dirmngr.conf
     # GPG key download sometimes fails for some reason and retrying fixes it.
     local retry_count=0
     local gpg_ok="false"
@@ -193,7 +223,7 @@ receive_gpg_keys_centos7() {
     set +e
         echo "(*) Downloading GPG keys..."
         until [ "${gpg_ok}" = "true" ] || [ "${retry_count}" -eq "5" ]; do
-            for keyserver in $(echo "${GPG_KEY_SERVERS}" | sed 's/keyserver //'); do
+            for keyserver in $(echo "$(get_gpg_key_servers)" | sed 's/keyserver //'); do
                 ( echo "${keys}" | xargs -n 1 gpg -q ${keyring_args} --recv-keys --keyserver=${keyserver} ) 2>&1
                 downloaded_keys=$(gpg --list-keys | grep ^pub | wc -l)
                 if [[ ${num_keys} = ${downloaded_keys} ]]; then

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -147,7 +147,7 @@ receive_gpg_keys() {
     export GNUPGHOME="/tmp/tmp-gnupg"
     mkdir -p ${GNUPGHOME}
     chmod 700 ${GNUPGHOME}
-    echo -e "disable-ipv6\n${GPG_KEY_SERVERS}" > ${GNUPGHOME}/dirmngr.conf
+    echo -e "disable-ipv6\nconnect-timeout 3\n${GPG_KEY_SERVERS}" > ${GNUPGHOME}/dirmngr.conf
     # GPG key download sometimes fails for some reason and retrying fixes it.
     local retry_count=0
     local gpg_ok="false"

--- a/src/ruby/devcontainer-feature.json
+++ b/src/ruby/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "name": "Ruby (via rvm)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/ruby",
     "description": "Installs Ruby, rvm, rbenv, common Ruby utilities, and needed dependencies.",

--- a/src/ruby/install.sh
+++ b/src/ruby/install.sh
@@ -23,10 +23,6 @@ ADDITIONAL_VERSIONS="${ADDITIONALVERSIONS:-""}"
 DEFAULT_GEMS="rake"
 
 RVM_GPG_KEYS="409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"
-GPG_KEY_SERVERS="keyserver hkp://keyserver.ubuntu.com
-keyserver hkp://keyserver.ubuntu.com:80
-keyserver hkps://keys.openpgp.org
-keyserver hkp://keyserver.pgp.com"
 
 set -e
 
@@ -72,6 +68,38 @@ updaterc() {
     fi
 }
 
+# Get the list of GPG key servers that are reachable
+get_gpg_key_servers() {
+    declare -A keyservers_curl_map
+    keyservers_curl_map["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
+    keyservers_curl_map["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
+    keyservers_curl_map["hkps://keys.openpgp.org"]="https://keys.openpgp.org:443"
+    keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+
+    local curl_args=""
+    if [ ! -z "${KEYSERVER_PROXY}" ]; then
+        curl_args="--proxy ${KEYSERVER_PROXY}"
+    fi
+
+    local keyserver_list=""
+    for keyserver in ${!keyservers_curl_map[@]}; do
+        local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
+        if curl -s ${curl_args} --max-time 3 ${keyserver_curl_url} > /dev/null; then
+            keyserver_list="${keyserver_list}keyserver ${keyserver}"
+            keyserver_list+=$'\n'
+        else
+            echo "(*) Keyserver ${keyserver} is not reachable." >&2
+        fi
+    done
+
+    if [ -z "${keyserver_list}" ]; then
+        echo "(!) No keyserver is reachable." >&2
+        exit 1
+    fi
+    
+    echo "${keyserver_list}"
+}
+
 # Import the specified key in a variable name passed in as 
 receive_gpg_keys() {
     local keys=${!1}
@@ -80,11 +108,13 @@ receive_gpg_keys() {
         keyring_args="--no-default-keyring --keyring \"$2\""
     fi
 
+    check_packages curl
+
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"
     mkdir -p ${GNUPGHOME}
     chmod 700 ${GNUPGHOME}
-    echo -e "disable-ipv6\n${GPG_KEY_SERVERS}" > ${GNUPGHOME}/dirmngr.conf
+    echo -e "disable-ipv6\n$(get_gpg_key_servers)" > ${GNUPGHOME}/dirmngr.conf
     # GPG key download sometimes fails for some reason and retrying fixes it.
     local retry_count=0
     local gpg_ok="false"

--- a/src/ruby/install.sh
+++ b/src/ruby/install.sh
@@ -77,27 +77,26 @@ get_gpg_key_servers() {
     keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
 
     local curl_args=""
+    local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
+
     if [ ! -z "${KEYSERVER_PROXY}" ]; then
         curl_args="--proxy ${KEYSERVER_PROXY}"
     fi
 
-    local keyserver_list=""
     for keyserver in ${!keyservers_curl_map[@]}; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
-        if curl -s ${curl_args} --max-time 3 ${keyserver_curl_url} > /dev/null; then
-            keyserver_list="${keyserver_list}keyserver ${keyserver}"
-            keyserver_list+=$'\n'
+        if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
+            echo "keyserver ${keyserver}"
+            keyserver_reachable=true
         else
             echo "(*) Keyserver ${keyserver} is not reachable." >&2
         fi
     done
 
-    if [ -z "${keyserver_list}" ]; then
+    if ! $keyserver_reachable; then
         echo "(!) No keyserver is reachable." >&2
         exit 1
     fi
-    
-    echo "${keyserver_list}"
 }
 
 # Import the specified key in a variable name passed in as 
@@ -108,7 +107,10 @@ receive_gpg_keys() {
         keyring_args="--no-default-keyring --keyring \"$2\""
     fi
 
-    check_packages curl
+    # Install curl
+    if ! type curl > /dev/null 2>&1; then
+        check_packages curl
+    fi
 
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"

--- a/src/ruby/install.sh
+++ b/src/ruby/install.sh
@@ -83,7 +83,7 @@ get_gpg_key_servers() {
         curl_args="--proxy ${KEYSERVER_PROXY}"
     fi
 
-    for keyserver in ${!keyservers_curl_map[@]}; do
+    for keyserver in "${!keyservers_curl_map[@]}"; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
         if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
             echo "keyserver ${keyserver}"

--- a/src/ruby/install.sh
+++ b/src/ruby/install.sh
@@ -70,11 +70,12 @@ updaterc() {
 
 # Get the list of GPG key servers that are reachable
 get_gpg_key_servers() {
-    declare -A keyservers_curl_map
-    keyservers_curl_map["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
-    keyservers_curl_map["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
-    keyservers_curl_map["hkps://keys.openpgp.org"]="https://keys.openpgp.org:443"
-    keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+    declare -A keyservers_curl_map=(
+        ["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
+        ["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
+        ["hkps://keys.openpgp.org"]="https://keys.openpgp.org"
+        ["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+    )
 
     local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable

--- a/src/terraform/devcontainer-feature.json
+++ b/src/terraform/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "terraform",
-    "version": "1.3.7",
+    "version": "1.3.8",
     "name": "Terraform, tflint, and TFGrunt",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/terraform",
     "description": "Installs the Terraform CLI and optionally TFLint and Terragrunt. Auto-detects latest version and installs needed dependencies.",

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -58,7 +58,7 @@ get_gpg_key_servers() {
         curl_args="--proxy ${KEYSERVER_PROXY}"
     fi
 
-    for keyserver in ${!keyservers_curl_map[@]}; do
+    for keyserver in "${!keyservers_curl_map[@]}"; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
         if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
             echo "keyserver ${keyserver}"

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -46,10 +46,11 @@ fi
 
 # Get the list of GPG key servers that are reachable
 get_gpg_key_servers() {
-    declare -A keyservers_curl_map
-    keyservers_curl_map["hkps://keyserver.ubuntu.com"]="https://keyserver.ubuntu.com:443"
-    keyservers_curl_map["hkps://keys.openpgp.org"]="https://keys.openpgp.org:443"
-    keyservers_curl_map["hkps://keyserver.pgp.com"]="https://keyserver.pgp.com:443"
+    declare -A keyservers_curl_map=(
+        ["hkps://keyserver.ubuntu.com"]="https://keyserver.ubuntu.com"
+        ["hkps://keys.openpgp.org"]="https://keys.openpgp.org"
+        ["hkps://keyserver.pgp.com"]="https://keyserver.pgp.com"
+    )
 
     local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -52,27 +52,26 @@ get_gpg_key_servers() {
     keyservers_curl_map["hkps://keyserver.pgp.com"]="https://keyserver.pgp.com:443"
 
     local curl_args=""
+    local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
+
     if [ ! -z "${KEYSERVER_PROXY}" ]; then
         curl_args="--proxy ${KEYSERVER_PROXY}"
     fi
 
-    local keyserver_list=""
     for keyserver in ${!keyservers_curl_map[@]}; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
-        if curl -s ${curl_args} --max-time 3 ${keyserver_curl_url} > /dev/null; then
-            keyserver_list="${keyserver_list}keyserver ${keyserver}"
-            keyserver_list+=$'\n'
+        if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
+            echo "keyserver ${keyserver}"
+            keyserver_reachable=true
         else
             echo "(*) Keyserver ${keyserver} is not reachable." >&2
         fi
     done
 
-    if [ -z "${keyserver_list}" ]; then
+    if ! $keyserver_reachable; then
         echo "(!) No keyserver is reachable." >&2
         exit 1
     fi
-    
-    echo "${keyserver_list}"
 }
 
 # Import the specified key in a variable name passed in as 
@@ -86,7 +85,10 @@ receive_gpg_keys() {
 	keyring_args="${keyring_args} --keyserver-options http-proxy=${KEYSERVER_PROXY}"
     fi
 
-    check_packages curl
+    # Install curl
+    if ! type curl > /dev/null 2>&1; then
+        check_packages curl
+    fi
 
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -28,9 +28,6 @@ TERRAFORM_DOCS_SHA256="${TERRAFORM_DOCS_SHA256:-"automatic"}"
 
 TERRAFORM_GPG_KEY="72D7468F"
 TFLINT_GPG_KEY_URI="https://raw.githubusercontent.com/terraform-linters/tflint/v0.46.1/8CE69160EB3F2FE9.key"
-GPG_KEY_SERVERS="keyserver hkps://keyserver.ubuntu.com
-keyserver hkps://keys.openpgp.org
-keyserver hkps://keyserver.pgp.com"
 KEYSERVER_PROXY="${HTTPPROXY:-"${HTTP_PROXY:-""}"}"
 
 architecture="$(uname -m)"
@@ -47,6 +44,37 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 1
 fi
 
+# Get the list of GPG key servers that are reachable
+get_gpg_key_servers() {
+    declare -A keyservers_curl_map
+    keyservers_curl_map["hkps://keyserver.ubuntu.com"]="https://keyserver.ubuntu.com:443"
+    keyservers_curl_map["hkps://keys.openpgp.org"]="https://keys.openpgp.org:443"
+    keyservers_curl_map["hkps://keyserver.pgp.com"]="https://keyserver.pgp.com:443"
+
+    local curl_args=""
+    if [ ! -z "${KEYSERVER_PROXY}" ]; then
+        curl_args="--proxy ${KEYSERVER_PROXY}"
+    fi
+
+    local keyserver_list=""
+    for keyserver in ${!keyservers_curl_map[@]}; do
+        local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
+        if curl -s ${curl_args} --max-time 3 ${keyserver_curl_url} > /dev/null; then
+            keyserver_list="${keyserver_list}keyserver ${keyserver}"
+            keyserver_list+=$'\n'
+        else
+            echo "(*) Keyserver ${keyserver} is not reachable." >&2
+        fi
+    done
+
+    if [ -z "${keyserver_list}" ]; then
+        echo "(!) No keyserver is reachable." >&2
+        exit 1
+    fi
+    
+    echo "${keyserver_list}"
+}
+
 # Import the specified key in a variable name passed in as 
 receive_gpg_keys() {
     local keys=${!1}
@@ -58,11 +86,13 @@ receive_gpg_keys() {
 	keyring_args="${keyring_args} --keyserver-options http-proxy=${KEYSERVER_PROXY}"
     fi
 
+    check_packages curl
+
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"
     mkdir -p ${GNUPGHOME}
     chmod 700 ${GNUPGHOME}
-    echo -e "disable-ipv6\n${GPG_KEY_SERVERS}" > ${GNUPGHOME}/dirmngr.conf
+    echo -e "disable-ipv6\n$(get_gpg_key_servers)" > ${GNUPGHOME}/dirmngr.conf
     # GPG key download sometimes fails for some reason and retrying fixes it.
     local retry_count=0
     local gpg_ok="false"

--- a/test/python/install_cpython_fallback_prev_version_test.sh
+++ b/test/python/install_cpython_fallback_prev_version_test.sh
@@ -102,27 +102,26 @@ get_gpg_key_servers() {
     keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
 
     local curl_args=""
+    local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
+
     if [ ! -z "${KEYSERVER_PROXY}" ]; then
         curl_args="--proxy ${KEYSERVER_PROXY}"
     fi
 
-    local keyserver_list=""
     for keyserver in ${!keyservers_curl_map[@]}; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
-        if curl -s ${curl_args} --max-time 3 ${keyserver_curl_url} > /dev/null; then
-            keyserver_list="${keyserver_list}keyserver ${keyserver}"
-            keyserver_list+=$'\n'
+        if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
+            echo "keyserver ${keyserver}"
+            keyserver_reachable=true
         else
             echo "(*) Keyserver ${keyserver} is not reachable." >&2
         fi
     done
 
-    if [ -z "${keyserver_list}" ]; then
+    if ! $keyserver_reachable; then
         echo "(!) No keyserver is reachable." >&2
         exit 1
     fi
-    
-    echo "${keyserver_list}"
 }
 
 # Import the specified key in a variable name passed in as 
@@ -138,7 +137,10 @@ receive_gpg_keys() {
         keyring_args="${keyring_args} --keyserver-options http-proxy=${KEYSERVER_PROXY}"
     fi
 
-    check_packages curl
+    # Install curl
+    if ! type curl > /dev/null 2>&1; then
+        check_packages curl
+    fi
 
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"
@@ -179,7 +181,10 @@ receive_gpg_keys_centos7() {
         keyring_args="${keyring_args} --keyserver-options http-proxy=${KEYSERVER_PROXY}"
     fi
 
-    check_packages curl
+    # Install curl
+    if ! type curl > /dev/null 2>&1; then
+        check_packages curl
+    fi
 
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"

--- a/test/python/install_cpython_fallback_prev_version_test.sh
+++ b/test/python/install_cpython_fallback_prev_version_test.sh
@@ -108,7 +108,7 @@ get_gpg_key_servers() {
         curl_args="--proxy ${KEYSERVER_PROXY}"
     fi
 
-    for keyserver in ${!keyservers_curl_map[@]}; do
+    for keyserver in "${!keyservers_curl_map[@]}"; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
         if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
             echo "keyserver ${keyserver}"

--- a/test/python/install_cpython_fallback_prev_version_test.sh
+++ b/test/python/install_cpython_fallback_prev_version_test.sh
@@ -95,11 +95,12 @@ check_packages() {
 
 # Get the list of GPG key servers that are reachable
 get_gpg_key_servers() {
-    declare -A keyservers_curl_map
-    keyservers_curl_map["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
-    keyservers_curl_map["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
-    keyservers_curl_map["hkps://keys.openpgp.org"]="https://keys.openpgp.org:443"
-    keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+    declare -A keyservers_curl_map=(
+        ["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
+        ["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
+        ["hkps://keys.openpgp.org"]="https://keys.openpgp.org"
+        ["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+    )
 
     local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable

--- a/test/python/install_cpython_fallback_prev_version_test.sh
+++ b/test/python/install_cpython_fallback_prev_version_test.sh
@@ -93,6 +93,38 @@ check_packages() {
     esac
 }
 
+# Get the list of GPG key servers that are reachable
+get_gpg_key_servers() {
+    declare -A keyservers_curl_map
+    keyservers_curl_map["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
+    keyservers_curl_map["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
+    keyservers_curl_map["hkps://keys.openpgp.org"]="https://keys.openpgp.org:443"
+    keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+
+    local curl_args=""
+    if [ ! -z "${KEYSERVER_PROXY}" ]; then
+        curl_args="--proxy ${KEYSERVER_PROXY}"
+    fi
+
+    local keyserver_list=""
+    for keyserver in ${!keyservers_curl_map[@]}; do
+        local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
+        if curl -s ${curl_args} --max-time 3 ${keyserver_curl_url} > /dev/null; then
+            keyserver_list="${keyserver_list}keyserver ${keyserver}"
+            keyserver_list+=$'\n'
+        else
+            echo "(*) Keyserver ${keyserver} is not reachable." >&2
+        fi
+    done
+
+    if [ -z "${keyserver_list}" ]; then
+        echo "(!) No keyserver is reachable." >&2
+        exit 1
+    fi
+    
+    echo "${keyserver_list}"
+}
+
 # Import the specified key in a variable name passed in as 
 receive_gpg_keys() {
     local keys=${!1}
@@ -106,11 +138,13 @@ receive_gpg_keys() {
         keyring_args="${keyring_args} --keyserver-options http-proxy=${KEYSERVER_PROXY}"
     fi
 
+    check_packages curl
+
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"
     mkdir -p ${GNUPGHOME}
     chmod 700 ${GNUPGHOME}
-    echo -e "disable-ipv6\n${GPG_KEY_SERVERS}" > ${GNUPGHOME}/dirmngr.conf
+    echo -e "disable-ipv6\n$(get_gpg_key_servers)" > ${GNUPGHOME}/dirmngr.conf
     # GPG key download sometimes fails for some reason and retrying fixes it.
     local retry_count=0
     local gpg_ok="false"
@@ -145,6 +179,8 @@ receive_gpg_keys_centos7() {
         keyring_args="${keyring_args} --keyserver-options http-proxy=${KEYSERVER_PROXY}"
     fi
 
+    check_packages curl
+
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"
     mkdir -p ${GNUPGHOME}
@@ -156,7 +192,7 @@ receive_gpg_keys_centos7() {
     set +e
         echo "(*) Downloading GPG keys..."
         until [ "${gpg_ok}" = "true" ] || [ "${retry_count}" -eq "5" ]; do
-            for keyserver in $(echo "${GPG_KEY_SERVERS}" | sed 's/keyserver //'); do
+            for keyserver in $(echo "$(get_gpg_key_servers)" | sed 's/keyserver //'); do
                 ( echo "${keys}" | xargs -n 1 gpg -q ${keyring_args} --recv-keys --keyserver=${keyserver} ) 2>&1
                 downloaded_keys=$(gpg --list-keys | grep ^pub | wc -l)
                 if [[ ${num_keys} = ${downloaded_keys} ]]; then

--- a/test/ruby/ruby_fallback_test.sh
+++ b/test/ruby/ruby_fallback_test.sh
@@ -13,10 +13,6 @@ check "ruby" ruby -v
 trap 'echo "Last executed command failed at line ${LINENO}"' ERR
 
 RVM_GPG_KEYS="409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"
-GPG_KEY_SERVERS="keyserver hkp://keyserver.ubuntu.com
-keyserver hkp://keyserver.ubuntu.com:80
-keyserver hkps://keys.openpgp.org
-keyserver hkp://keyserver.pgp.com"
 
 # Clean up
 rm -rf /var/lib/apt/lists/*
@@ -63,6 +59,38 @@ check_packages() {
     fi
 }
 
+# Get the list of GPG key servers that are reachable
+get_gpg_key_servers() {
+    declare -A keyservers_curl_map
+    keyservers_curl_map["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
+    keyservers_curl_map["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
+    keyservers_curl_map["hkps://keys.openpgp.org"]="https://keys.openpgp.org:443"
+    keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+
+    local curl_args=""
+    if [ ! -z "${KEYSERVER_PROXY}" ]; then
+        curl_args="--proxy ${KEYSERVER_PROXY}"
+    fi
+
+    local keyserver_list=""
+    for keyserver in ${!keyservers_curl_map[@]}; do
+        local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
+        if curl -s ${curl_args} --max-time 3 ${keyserver_curl_url} > /dev/null; then
+            keyserver_list="${keyserver_list}keyserver ${keyserver}"
+            keyserver_list+=$'\n'
+        else
+            echo "(*) Keyserver ${keyserver} is not reachable." >&2
+        fi
+    done
+
+    if [ -z "${keyserver_list}" ]; then
+        echo "(!) No keyserver is reachable." >&2
+        exit 1
+    fi
+    
+    echo "${keyserver_list}"
+}
+
 # Import the specified key in a variable name passed in as 
 receive_gpg_keys() {
     local keys=${!1}
@@ -71,11 +99,13 @@ receive_gpg_keys() {
         keyring_args="--no-default-keyring --keyring \"$2\""
     fi
 
+    check_packages curl
+
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"
     mkdir -p ${GNUPGHOME}
     chmod 700 ${GNUPGHOME}
-    echo -e "disable-ipv6\n${GPG_KEY_SERVERS}" | tee ${GNUPGHOME}/dirmngr.conf > /dev/null
+    echo -e "disable-ipv6\n$(get_gpg_key_servers)" | tee ${GNUPGHOME}/dirmngr.conf > /dev/null
     # GPG key download sometimes fails for some reason and retrying fixes it.
     local retry_count=0
     local gpg_ok="false"

--- a/test/ruby/ruby_fallback_test.sh
+++ b/test/ruby/ruby_fallback_test.sh
@@ -61,11 +61,12 @@ check_packages() {
 
 # Get the list of GPG key servers that are reachable
 get_gpg_key_servers() {
-    declare -A keyservers_curl_map
-    keyservers_curl_map["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
-    keyservers_curl_map["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
-    keyservers_curl_map["hkps://keys.openpgp.org"]="https://keys.openpgp.org:443"
-    keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+    declare -A keyservers_curl_map=(
+        ["hkp://keyserver.ubuntu.com"]="http://keyserver.ubuntu.com:11371"
+        ["hkp://keyserver.ubuntu.com:80"]="http://keyserver.ubuntu.com"
+        ["hkps://keys.openpgp.org"]="https://keys.openpgp.org"
+        ["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
+    )
 
     local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable

--- a/test/ruby/ruby_fallback_test.sh
+++ b/test/ruby/ruby_fallback_test.sh
@@ -68,27 +68,26 @@ get_gpg_key_servers() {
     keyservers_curl_map["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
 
     local curl_args=""
+    local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
+
     if [ ! -z "${KEYSERVER_PROXY}" ]; then
         curl_args="--proxy ${KEYSERVER_PROXY}"
     fi
 
-    local keyserver_list=""
     for keyserver in ${!keyservers_curl_map[@]}; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
-        if curl -s ${curl_args} --max-time 3 ${keyserver_curl_url} > /dev/null; then
-            keyserver_list="${keyserver_list}keyserver ${keyserver}"
-            keyserver_list+=$'\n'
+        if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
+            echo "keyserver ${keyserver}"
+            keyserver_reachable=true
         else
             echo "(*) Keyserver ${keyserver} is not reachable." >&2
         fi
     done
 
-    if [ -z "${keyserver_list}" ]; then
+    if ! $keyserver_reachable; then
         echo "(!) No keyserver is reachable." >&2
         exit 1
     fi
-    
-    echo "${keyserver_list}"
 }
 
 # Import the specified key in a variable name passed in as 
@@ -99,7 +98,10 @@ receive_gpg_keys() {
         keyring_args="--no-default-keyring --keyring \"$2\""
     fi
 
-    check_packages curl
+    # Install curl
+    if ! type curl > /dev/null 2>&1; then
+        check_packages curl
+    fi
 
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"

--- a/test/ruby/ruby_fallback_test.sh
+++ b/test/ruby/ruby_fallback_test.sh
@@ -74,7 +74,7 @@ get_gpg_key_servers() {
         curl_args="--proxy ${KEYSERVER_PROXY}"
     fi
 
-    for keyserver in ${!keyservers_curl_map[@]}; do
+    for keyserver in "${!keyservers_curl_map[@]}"; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
         if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
             echo "keyserver ${keyserver}"


### PR DESCRIPTION
At the moment, if the host environment cannot reach first key server over port 11371, it takes 1 minute to retrieve individual keys from the other listed key servers. For the Python feature, the installation script retrieves 13 keys, so the total time to retrieve all the keys is 13 minutes. The delay could be further extended if subsequent servers also cannot be reached.

The reason it takes 1 minute rather than the 15 second default timeout in `dirmngr` is that I believe `dirmngr` internally tries the connection to the same keyserver 4 times before it moves on to a different server. Essentially, this multiplies the timeout delay by 4.

Instead of relying on the `dirmngr` timeout mechanism, the change implements a check for keyserver reachability using `curl` before the list is passed on to `dirmngr`.

If no keyservers are identified, the script will intentionally fail. If some keyservers are not reachable, the script will log this information, enabling users to more easily identify and resolve network issues in their environments.

Related issues: 
https://github.com/devcontainers/features/issues/686
https://github.com/devcontainers/features/issues/337
https://github.com/devcontainers/features/issues/323


**Affected features:**
- git-lfs
- git
- github-cli
- kubectl-helm-minikube
- python
- ruby
- terraform

I ran tests for all the features locally; most succeeded without issues. The only test that failed was `autoPullDisabled` from `git-lfs`, but it also fails with unmodified code, so I suspect something else in my environment is causing the tests to fail, not specific to my changes.