### PR TITLE
[Java] - features issue #1101 - installs -tem instead -ms for lts installation

### DIFF
--- a/src/git/README.md
+++ b/src/git/README.md
@@ -22,7 +22,7 @@ Install an up-to-date version of Git, built from source as needed. Useful for wh
 
 ## OS Support
 
-This Feature should work on recent versions of Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, and RockyLinux distributions with the `apt`, `yum`, `dnf`, or `microdnf` package manager installed.
+This Feature should work on recent versions of Alpine, Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, and RockyLinux distributions with the `apk`, `apt`, `yum`, `dnf`, or `microdnf` package manager installed.
 
 `bash` is required to execute the `install.sh` script.
 

--- a/src/java/devcontainer-feature.json
+++ b/src/java/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "java",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "name": "Java (via SDKMAN!)",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/java",
   "description": "Installs Java, SDKMAN! (if not installed), and needed dependencies.",

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -214,7 +214,7 @@ sdk_install() {
     local full_version_check=${5:-".*-[a-z]+"}
     local set_as_default=${6:-"true"}
     if [ "${requested_version}" = "none" ]; then return; fi
-    if [ "${requested_version}" = "default" ] || [ ( "${install_type}" = "maven" -o "${install_type}" = "groovy" ) -a ( "${requested_version}" = "latest" ) ]; then
+    if [ "${requested_version}" = "default" ] || { { [ "${install_type}" = "maven" ] || [ "${install_type}" = "groovy" ] } && [ "${requested_version}" = "latest" ]; }; then
         requested_version=""
     elif echo "${requested_version}" | grep -oE "${full_version_check}" > /dev/null 2>&1; then
         echo "${requested_version}"

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -229,7 +229,7 @@ sdk_install() {
     if [ "${set_as_default}" = "true" ]; then
         JAVA_VERSION=${requested_version}
     fi
-    
+
     su ${USERNAME} -c "umask 0002 && . ${SDKMAN_DIR}/bin/sdkman-init.sh && sdk install ${install_type} ${requested_version} && sdk flush archives && sdk flush temp"
 }
 

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -213,10 +213,12 @@ sdk_install() {
     local suffix="${4:-"\\s*"}"
     local full_version_check=${5:-".*-[a-z]+"}
     local set_as_default=${6:-"true"}
+    pkgs=("maven" "gradle" "ant" "groovy")
+    pkg_vals="${pkgs[@]}"
     if [ "${requested_version}" = "none" ]; then return; fi
     if [ "${requested_version}" = "default" ]; then
         requested_version=""
-    elif ( [ "${install_type}" = "maven" ] || [ "${install_type}" = "groovy" ] ) && [ "${requested_version}" = "latest" ]; then
+    elif [[ "${pkg_vals}" =~ "${install_type}" ]] && [ "${requested_version}" = "latest" ]; then
         requested_version=""
     elif echo "${requested_version}" | grep -oE "${full_version_check}" > /dev/null 2>&1; then
         echo "${requested_version}"

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -214,7 +214,7 @@ sdk_install() {
     local full_version_check=${5:-".*-[a-z]+"}
     local set_as_default=${6:-"true"}
     if [ "${requested_version}" = "none" ]; then return; fi
-    if [ "${requested_version}" = "default" ] || { { [ "${install_type}" = "maven" ] || [ "${install_type}" = "groovy" ] } && [ "${requested_version}" = "latest" ]; }; then
+    if [ "${requested_version}" = "default" ] || [ { [ "${install_type}" = "maven" ] || [ "${install_type}" = "groovy" ] } && [ "${requested_version}" = "latest" ] ]; then
         requested_version=""
     elif echo "${requested_version}" | grep -oE "${full_version_check}" > /dev/null 2>&1; then
         echo "${requested_version}"

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -206,7 +206,7 @@ sdk_install() {
     local full_version_check=${5:-".*-[a-z]+"}
     local set_as_default=${6:-"true"}
     if [ "${requested_version}" = "none" ]; then return; fi
-    if [ "${requested_version}" = "default" ]; then
+    if [ "${requested_version}" = "default" ] || [ "${install_type}" = "maven" -o "${install_type}" = "groovy" ]; then
          requested_version=""
     elif echo "${requested_version}" | grep -oE "${full_version_check}" > /dev/null 2>&1; then
         echo "${requested_version}"

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -206,7 +206,7 @@ sdk_install() {
     local full_version_check=${5:-".*-[a-z]+"}
     local set_as_default=${6:-"true"}
     if [ "${requested_version}" = "none" ]; then return; fi
-     # Blank will install latest stable version SDKMAN has
+     # Blank will install default version SDKMAN has
     if [ "${requested_version}" = "default" ]; then
          requested_version=""
     elif echo "${requested_version}" | grep -oE "${full_version_check}" > /dev/null 2>&1; then
@@ -214,7 +214,7 @@ sdk_install() {
     else
         local regex="${prefix}\\K[0-9]+\\.?[0-9]*\\.?[0-9]*${suffix}"
         local version_list=$(su ${USERNAME} -c ". \${SDKMAN_DIR}/bin/sdkman-init.sh && sdk list ${install_type} 2>&1 | grep -oP \"${regex}\" | tr -d ' ' | sort -rV")
-        if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "current" ] || [ "${requested_version}" = "lts" ] || [ "${requested_version}" = "latest" ]; then
+        if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "current" ] || [ "${requested_version}" = "lts" ]; then
             requested_version="$(echo "${version_list}" | head -n 1)"
         else
             set +e

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -9,7 +9,7 @@
 #
 # Syntax: ./java-debian.sh [JDK version] [SDKMAN_DIR] [non-root user] [Add to rc files flag]
 
-JAVA_VERSION="${VERSION:-"lts"}"
+JAVA_VERSION="${VERSION:-"latest"}"
 INSTALL_GRADLE="${INSTALLGRADLE:-"false"}"
 GRADLE_VERSION="${GRADLEVERSION:-"latest"}"
 INSTALL_MAVEN="${INSTALLMAVEN:-"false"}"
@@ -207,14 +207,14 @@ sdk_install() {
     local set_as_default=${6:-"true"}
     if [ "${requested_version}" = "none" ]; then return; fi
      # Blank will install latest stable version SDKMAN has
-    if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "default" ]; then
+    if [ "${requested_version}" = "default" ]; then
          requested_version=""
     elif echo "${requested_version}" | grep -oE "${full_version_check}" > /dev/null 2>&1; then
         echo "${requested_version}"
     else
         local regex="${prefix}\\K[0-9]+\\.?[0-9]*\\.?[0-9]*${suffix}"
         local version_list=$(su ${USERNAME} -c ". \${SDKMAN_DIR}/bin/sdkman-init.sh && sdk list ${install_type} 2>&1 | grep -oP \"${regex}\" | tr -d ' ' | sort -rV")
-        if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "current" ] || [ "${requested_version}" = "lts" ]; then
+        if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "current" ] || [ "${requested_version}" = "lts" ] || [ "${requested_version}" = "latest" ]; then
             requested_version="$(echo "${version_list}" | head -n 1)"
         else
             set +e

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -187,6 +187,16 @@ check_packages() {
     esac
 }
 
+# Use Microsoft JDK for everything but JDK 8 and 18 (unless specified differently with jdkDistro option)
+get_jdk_distro() {
+    VERSION="$1"
+    if [ "${JDK_DISTRO}" = "ms" ]; then
+        if echo "${VERSION}" | grep -E '^8([\s\.]|$)' > /dev/null 2>&1 || echo "${VERSION}" | grep -E '^18([\s\.]|$)' > /dev/null 2>&1; then
+            JDK_DISTRO="tem"
+        fi
+    fi
+}
+
 # Use SDKMAN to install something using a partial version match
 sdk_install() {
     local install_type=$1
@@ -260,6 +270,7 @@ if [ ! -d "${SDKMAN_DIR}" ]; then
     updaterc "export SDKMAN_DIR=${SDKMAN_DIR}\n. \${SDKMAN_DIR}/bin/sdkman-init.sh"
 fi
 
+get_jdk_distro ${JAVA_VERSION}
 sdk_install java ${JAVA_VERSION} "\\s*" "(\\.[a-z0-9]+)*-${JDK_DISTRO}\\s*" ".*-[a-z]+$" "true"
 
 # Additional java versions to be installed but not be set as default.
@@ -268,6 +279,7 @@ if [ ! -z "${ADDITIONAL_VERSIONS}" ]; then
     IFS=","
         read -a additional_versions <<< "$ADDITIONAL_VERSIONS"
         for version in "${additional_versions[@]}"; do
+            get_jdk_distro ${version}
             sdk_install java ${version} "\\s*" "(\\.[a-z0-9]+)*-${JDK_DISTRO}\\s*" ".*-[a-z]+$" "false"
         done
     IFS=$OLDIFS

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -229,6 +229,7 @@ sdk_install() {
     if [ "${set_as_default}" = "true" ]; then
         JAVA_VERSION=${requested_version}
     fi
+    
     su ${USERNAME} -c "umask 0002 && . ${SDKMAN_DIR}/bin/sdkman-init.sh && sdk install ${install_type} ${requested_version} && sdk flush archives && sdk flush temp"
 }
 

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -199,7 +199,6 @@ get_jdk_distro() {
 
 # Use SDKMAN to install something using a partial version match
 sdk_install() {
-    set -x
     local install_type=$1
     local requested_version=$2
     local prefix=$3
@@ -238,7 +237,6 @@ sdk_install() {
     fi
 
     su ${USERNAME} -c "umask 0002 && . ${SDKMAN_DIR}/bin/sdkman-init.sh && sdk install ${install_type} ${requested_version} && sdk flush archives && sdk flush temp"
-    set +x
 }
 
 export DEBIAN_FRONTEND=noninteractive

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -214,7 +214,7 @@ sdk_install() {
     local full_version_check=${5:-".*-[a-z]+"}
     local set_as_default=${6:-"true"}
     if [ "${requested_version}" = "none" ]; then return; fi
-    if [ "${requested_version}" = "default" ] || [ ("${install_type}" = "maven" -o "${install_type}" = "groovy") -a "${requested_version}" = "latest" ]; then
+    if [ "${requested_version}" = "default" ] || [ ( "${install_type}" = "maven" -o "${install_type}" = "groovy" ) -a ( "${requested_version}" = "latest" ) ]; then
         requested_version=""
     elif echo "${requested_version}" | grep -oE "${full_version_check}" > /dev/null 2>&1; then
         echo "${requested_version}"

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -199,7 +199,7 @@ sdk_install() {
      # Blank will install latest stable version SDKMAN has
     if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "default" ]; then
          requested_version=""
-    if echo "${requested_version}" | grep -oE "${full_version_check}" > /dev/null 2>&1; then
+    elif echo "${requested_version}" | grep -oE "${full_version_check}" > /dev/null 2>&1; then
         echo "${requested_version}"
     else
         local regex="${prefix}\\K[0-9]+\\.?[0-9]*\\.?[0-9]*${suffix}"

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -214,8 +214,8 @@ sdk_install() {
     local full_version_check=${5:-".*-[a-z]+"}
     local set_as_default=${6:-"true"}
     if [ "${requested_version}" = "none" ]; then return; fi
-    if [ "${requested_version}" = "default" ] || [ "${install_type}" = "maven" -o "${install_type}" = "groovy" ]; then
-         requested_version=""
+    if [ "${requested_version}" = "default" ] || [ ("${install_type}" = "maven" -o "${install_type}" = "groovy") -a "${requested_version}" = "latest" ]; then
+        requested_version=""
     elif echo "${requested_version}" | grep -oE "${full_version_check}" > /dev/null 2>&1; then
         echo "${requested_version}"
     else

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -215,8 +215,8 @@ sdk_install() {
         local version_list=$(su ${USERNAME} -c ". \${SDKMAN_DIR}/bin/sdkman-init.sh && sdk list ${install_type} 2>&1 | grep -oP \"${regex}\" | tr -d ' ' | sort -rV")
         if [ "${requested_version}" = "lts" ]; then
             check_packages jq
-            all_lts_versions=$(curl -s https://api.adoptopenjdk.net/v3/info/available_releases)
-            major_version=$(echo "$all_lts_versions" | jq -r '.available_lts_releases | sort | .[-1]')
+            all_lts_versions=$(curl -s https://api.adoptium.net/v3/info/available_releases)
+            major_version=$(echo "$all_lts_versions" | jq -r '.most_recent_lts')
             regex="${prefix}\\K${major_version}\\.?[0-9]*\\.?[0-9]*${suffix}"
             version_list=$(su ${USERNAME} -c ". \${SDKMAN_DIR}/bin/sdkman-init.sh && sdk list ${install_type} 2>&1 | grep -oP \"${regex}\" | tr -d ' ' | sort -rV")
             requested_version="$(echo "${version_list}" | head -n 1)"

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -214,7 +214,9 @@ sdk_install() {
     local full_version_check=${5:-".*-[a-z]+"}
     local set_as_default=${6:-"true"}
     if [ "${requested_version}" = "none" ]; then return; fi
-    if [ "${requested_version}" = "default" ] || [ { [ "${install_type}" = "maven" ] || [ "${install_type}" = "groovy" ] } && [ "${requested_version}" = "latest" ] ]; then
+    if [ "${requested_version}" = "default" ]; then
+        requested_version=""
+    elif ( [ "${install_type}" = "maven" ] || [ "${install_type}" = "groovy" ] ) && [ "${requested_version}" = "latest" ]; then
         requested_version=""
     elif echo "${requested_version}" | grep -oE "${full_version_check}" > /dev/null 2>&1; then
         echo "${requested_version}"

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -53,6 +53,14 @@ else
     exit 1
 fi
 
+if [ "${ADJUSTED_ID}" = "rhel" ] && [ "${VERSION_CODENAME-}" = "centos7" ]; then
+    # As of 1 July 2024, mirrorlist.centos.org no longer exists.
+    # Update the repo files to reference vault.centos.org.
+    sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+fi
+
 # Setup INSTALL_CMD & PKG_MGR_CMD
 if type apt-get > /dev/null 2>&1; then
     PKG_MGR_CMD=apt-get

--- a/test/java/install_ant_and_gradle_and_maven_and_groovy.sh
+++ b/test/java/install_ant_and_gradle_and_maven_and_groovy.sh
@@ -16,6 +16,24 @@ EOF
 cd /tmp && ant init
 check "ant-src exists" grep "ant-src" <(ls -la /tmp)
 
+check "contents of tmp directory" ls -l /tmp
+
+current_user=$(whoami)
+
+# Change ownership of the files
+sudo chown $current_user:$current_user /tmp/build-features-src
+sudo chown $current_user:$current_user /tmp/dev-container-features
+
+sudo chmod 777 /tmp/build-features-src
+sudo chmod 777 /tmp/dev-container-features
+
+check "contents of tmp->build-features-src directory" ls -lrt /tmp/build-features-src
+check "contents of tmp->dev-container-features directory" ls -lrt /tmp/dev-container-features
+
+sudo rm -rf /tmp/*
+
+check "contents of tmp directory" ls -l /tmp
+
 check "gradle" gradle --version
 cd /tmp && gradle init --type basic --dsl groovy --incubating --project-name test
 check "GRADLE_USER_HOME exists" grep ".gradle" <(ls -la /root)

--- a/test/java/install_ant_and_gradle_and_maven_and_groovy.sh
+++ b/test/java/install_ant_and_gradle_and_maven_and_groovy.sh
@@ -22,8 +22,6 @@ check "contents of tmp directory" ls -l /tmp
 
 current_user=$(whoami)
 
-check "current_user_name" $current_user
-
 # Change ownership of the files
 sudo chown $current_user:$current_user /tmp/build-features-src
 sudo chown $current_user:$current_user /tmp/dev-container-features

--- a/test/java/install_ant_and_gradle_and_maven_and_groovy.sh
+++ b/test/java/install_ant_and_gradle_and_maven_and_groovy.sh
@@ -16,25 +16,30 @@ EOF
 cd /tmp && ant init
 check "ant-src exists" grep "ant-src" <(ls -la /tmp)
 
+check "gradle" gradle --version
+
 check "contents of tmp directory" ls -l /tmp
 
 current_user=$(whoami)
 
+check "current_user_name" $current_user
+
 # Change ownership of the files
 sudo chown $current_user:$current_user /tmp/build-features-src
 sudo chown $current_user:$current_user /tmp/dev-container-features
+sudo chown $current_user:$current_user /tmp/dev-container-features/devcontainer-features.builtin.env
 
 sudo chmod 777 /tmp/build-features-src
 sudo chmod 777 /tmp/dev-container-features
+sudo chmod 777 /tmp/dev-container-features/devcontainer-features.builtin.env
 
-check "contents of tmp->build-features-src directory" ls -lrt /tmp/build-features-src
-check "contents of tmp->dev-container-features directory" ls -lrt /tmp/dev-container-features
+check "contents of tmp->build-features-src directory" ls -l /tmp/build-features-src
+check "contents of tmp->dev-container-features directory" ls -l /tmp/dev-container-features
 
 sudo rm -rf /tmp/*
 
 check "contents of tmp directory" ls -l /tmp
 
-check "gradle" gradle --version
 cd /tmp && gradle init --type basic --dsl groovy --incubating --project-name test
 check "GRADLE_USER_HOME exists" grep ".gradle" <(ls -la /root)
 

--- a/test/java/install_ant_and_gradle_and_maven_and_groovy.sh
+++ b/test/java/install_ant_and_gradle_and_maven_and_groovy.sh
@@ -17,28 +17,7 @@ cd /tmp && ant init
 check "ant-src exists" grep "ant-src" <(ls -la /tmp)
 
 check "gradle" gradle --version
-
-check "contents of tmp directory" ls -l /tmp
-
-current_user=$(whoami)
-
-# Change ownership of the files
-sudo chown $current_user:$current_user /tmp/build-features-src
-sudo chown $current_user:$current_user /tmp/dev-container-features
-sudo chown $current_user:$current_user /tmp/dev-container-features/devcontainer-features.builtin.env
-
-sudo chmod 777 /tmp/build-features-src
-sudo chmod 777 /tmp/dev-container-features
-sudo chmod 777 /tmp/dev-container-features/devcontainer-features.builtin.env
-
-check "contents of tmp->build-features-src directory" ls -l /tmp/build-features-src
-check "contents of tmp->dev-container-features directory" ls -l /tmp/dev-container-features
-
-sudo rm -rf /tmp/*
-
-check "contents of tmp directory" ls -l /tmp
-
-cd /tmp && gradle init --type basic --dsl groovy --incubating --project-name test
+cd /tmp && gradle init --type basic --dsl groovy --overwrite --incubating --project-name test
 check "GRADLE_USER_HOME exists" grep ".gradle" <(ls -la /root)
 
 check "maven" mvn --version

--- a/test/java/install_ant_and_gradle_and_maven_and_groovy_for_user.sh
+++ b/test/java/install_ant_and_gradle_and_maven_and_groovy_for_user.sh
@@ -23,8 +23,6 @@ check "contents of tmp directory" ls -l /tmp
 
 current_user=$(whoami)
 
-check "current_user_name" $current_user
-
 # Change ownership of the files
 sudo chown $current_user:$current_user /tmp/build-features-src
 sudo chown $current_user:$current_user /tmp/dev-container-features

--- a/test/java/install_ant_and_gradle_and_maven_and_groovy_for_user.sh
+++ b/test/java/install_ant_and_gradle_and_maven_and_groovy_for_user.sh
@@ -10,11 +10,30 @@ check "user is vscode" grep vscode <(whoami)
 check "java" java --version
 
 check "ant" ant -version
+
 cat << EOF > /tmp/build.xml
 <project><target name="init"><mkdir dir="ant-src"/></target></project>
 EOF
 cd /tmp && ant init
 check "ant-src exists" grep "ant-src" <(ls -la /tmp)
+
+check "contents of tmp directory" ls -l /tmp
+
+current_user=$(whoami)
+
+# Change ownership of the files
+sudo chown $current_user:$current_user /tmp/build-features-src
+sudo chown $current_user:$current_user /tmp/dev-container-features
+
+sudo chmod 777 /tmp/build-features-src
+sudo chmod 777 /tmp/dev-container-features
+
+check "contents of tmp->build-features-src directory" ls -lrt /tmp/build-features-src
+check "contents of tmp->dev-container-features directory" ls -lrt /tmp/dev-container-features
+
+sudo rm -rf /tmp/*
+
+check "contents of tmp directory" ls -l /tmp
 
 check "gradle" gradle --version
 cd /tmp && gradle init --type basic --dsl groovy --incubating --project-name test

--- a/test/java/install_ant_and_gradle_and_maven_and_groovy_for_user.sh
+++ b/test/java/install_ant_and_gradle_and_maven_and_groovy_for_user.sh
@@ -17,25 +17,30 @@ EOF
 cd /tmp && ant init
 check "ant-src exists" grep "ant-src" <(ls -la /tmp)
 
+check "gradle" gradle --version
+
 check "contents of tmp directory" ls -l /tmp
 
 current_user=$(whoami)
 
+check "current_user_name" $current_user
+
 # Change ownership of the files
 sudo chown $current_user:$current_user /tmp/build-features-src
 sudo chown $current_user:$current_user /tmp/dev-container-features
+sudo chown $current_user:$current_user /tmp/dev-container-features/devcontainer-features.builtin.env
 
 sudo chmod 777 /tmp/build-features-src
 sudo chmod 777 /tmp/dev-container-features
+sudo chmod 777 /tmp/dev-container-features/devcontainer-features.builtin.env
 
-check "contents of tmp->build-features-src directory" ls -lrt /tmp/build-features-src
-check "contents of tmp->dev-container-features directory" ls -lrt /tmp/dev-container-features
+check "contents of tmp->build-features-src directory" ls -l /tmp/build-features-src
+check "contents of tmp->dev-container-features directory" ls -l /tmp/dev-container-features
 
 sudo rm -rf /tmp/*
 
 check "contents of tmp directory" ls -l /tmp
 
-check "gradle" gradle --version
 cd /tmp && gradle init --type basic --dsl groovy --incubating --project-name test
 check "GRADLE_USER_HOME exists" grep ".gradle" <(ls -la /home/vscode)
 

--- a/test/java/install_ant_and_gradle_and_maven_and_groovy_for_user.sh
+++ b/test/java/install_ant_and_gradle_and_maven_and_groovy_for_user.sh
@@ -18,28 +18,7 @@ cd /tmp && ant init
 check "ant-src exists" grep "ant-src" <(ls -la /tmp)
 
 check "gradle" gradle --version
-
-check "contents of tmp directory" ls -l /tmp
-
-current_user=$(whoami)
-
-# Change ownership of the files
-sudo chown $current_user:$current_user /tmp/build-features-src
-sudo chown $current_user:$current_user /tmp/dev-container-features
-sudo chown $current_user:$current_user /tmp/dev-container-features/devcontainer-features.builtin.env
-
-sudo chmod 777 /tmp/build-features-src
-sudo chmod 777 /tmp/dev-container-features
-sudo chmod 777 /tmp/dev-container-features/devcontainer-features.builtin.env
-
-check "contents of tmp->build-features-src directory" ls -l /tmp/build-features-src
-check "contents of tmp->dev-container-features directory" ls -l /tmp/dev-container-features
-
-sudo rm -rf /tmp/*
-
-check "contents of tmp directory" ls -l /tmp
-
-cd /tmp && gradle init --type basic --dsl groovy --incubating --project-name test
+cd /tmp && gradle init --type basic --dsl groovy --overwrite --incubating --project-name test
 check "GRADLE_USER_HOME exists" grep ".gradle" <(ls -la /home/vscode)
 
 check "maven" mvn --version

--- a/test/java/install_ant_and_gradle_and_maven_and_groovy_for_user_rhel_family.sh
+++ b/test/java/install_ant_and_gradle_and_maven_and_groovy_for_user_rhel_family.sh
@@ -16,20 +16,30 @@ EOF
 cd /tmp && ant init
 check "ant-src exists" grep "ant-src" <(ls -la /tmp)
 
+check "gradle" gradle --version
+
+check "contents of tmp directory" ls -l /tmp
+
 current_user=$(whoami)
 
+check "current_user_name" $current_user
+
+# Change ownership of the files
 sudo chown $current_user:$current_user /tmp/build-features-src
 sudo chown $current_user:$current_user /tmp/dev-container-features
+sudo chown $current_user:$current_user /tmp/dev-container-features/devcontainer-features.builtin.env
 
 sudo chmod 777 /tmp/build-features-src
 sudo chmod 777 /tmp/dev-container-features
+sudo chmod 777 /tmp/dev-container-features/devcontainer-features.builtin.env
 
-check "contents of tmp->build-features-src directory" ls -lrt /tmp/build-features-src
-check "contents of tmp->dev-container-features directory" ls -lrt /tmp/dev-container-features
+check "contents of tmp->build-features-src directory" ls -l /tmp/build-features-src
+check "contents of tmp->dev-container-features directory" ls -l /tmp/dev-container-features
 
 sudo rm -rf /tmp/*
 
-check "gradle" gradle --version
+check "contents of tmp directory" ls -l /tmp
+
 cd /tmp && gradle init --type basic --dsl groovy --incubating --project-name test
 check "GRADLE_USER_HOME exists" grep ".gradle" <(ls -la /home/vscode)
 

--- a/test/java/install_ant_and_gradle_and_maven_and_groovy_for_user_rhel_family.sh
+++ b/test/java/install_ant_and_gradle_and_maven_and_groovy_for_user_rhel_family.sh
@@ -22,8 +22,6 @@ check "contents of tmp directory" ls -l /tmp
 
 current_user=$(whoami)
 
-check "current_user_name" $current_user
-
 # Change ownership of the files
 sudo chown $current_user:$current_user /tmp/build-features-src
 sudo chown $current_user:$current_user /tmp/dev-container-features

--- a/test/java/install_ant_and_gradle_and_maven_and_groovy_for_user_rhel_family.sh
+++ b/test/java/install_ant_and_gradle_and_maven_and_groovy_for_user_rhel_family.sh
@@ -17,28 +17,7 @@ cd /tmp && ant init
 check "ant-src exists" grep "ant-src" <(ls -la /tmp)
 
 check "gradle" gradle --version
-
-check "contents of tmp directory" ls -l /tmp
-
-current_user=$(whoami)
-
-# Change ownership of the files
-sudo chown $current_user:$current_user /tmp/build-features-src
-sudo chown $current_user:$current_user /tmp/dev-container-features
-sudo chown $current_user:$current_user /tmp/dev-container-features/devcontainer-features.builtin.env
-
-sudo chmod 777 /tmp/build-features-src
-sudo chmod 777 /tmp/dev-container-features
-sudo chmod 777 /tmp/dev-container-features/devcontainer-features.builtin.env
-
-check "contents of tmp->build-features-src directory" ls -l /tmp/build-features-src
-check "contents of tmp->dev-container-features directory" ls -l /tmp/dev-container-features
-
-sudo rm -rf /tmp/*
-
-check "contents of tmp directory" ls -l /tmp
-
-cd /tmp && gradle init --type basic --dsl groovy --incubating --project-name test
+cd /tmp && gradle init --type basic --dsl groovy --overwrite --incubating --project-name test
 check "GRADLE_USER_HOME exists" grep ".gradle" <(ls -la /home/vscode)
 
 check "maven" mvn --version

--- a/test/java/install_ant_and_gradle_and_maven_and_groovy_for_user_rhel_family.sh
+++ b/test/java/install_ant_and_gradle_and_maven_and_groovy_for_user_rhel_family.sh
@@ -16,6 +16,19 @@ EOF
 cd /tmp && ant init
 check "ant-src exists" grep "ant-src" <(ls -la /tmp)
 
+current_user=$(whoami)
+
+sudo chown $current_user:$current_user /tmp/build-features-src
+sudo chown $current_user:$current_user /tmp/dev-container-features
+
+sudo chmod 777 /tmp/build-features-src
+sudo chmod 777 /tmp/dev-container-features
+
+check "contents of tmp->build-features-src directory" ls -lrt /tmp/build-features-src
+check "contents of tmp->dev-container-features directory" ls -lrt /tmp/dev-container-features
+
+sudo rm -rf /tmp/*
+
 check "gradle" gradle --version
 cd /tmp && gradle init --type basic --dsl groovy --incubating --project-name test
 check "GRADLE_USER_HOME exists" grep ".gradle" <(ls -la /home/vscode)

--- a/test/java/install_ant_and_gradle_and_maven_and_groovy_rhel_family.sh
+++ b/test/java/install_ant_and_gradle_and_maven_and_groovy_rhel_family.sh
@@ -16,6 +16,24 @@ EOF
 cd /tmp && ant init
 check "ant-src exists" grep "ant-src" <(ls -la /tmp)
 
+check "contents of tmp directory" ls -l /tmp
+
+current_user=$(whoami)
+
+# Change ownership of the files
+sudo chown $current_user:$current_user /tmp/build-features-src
+sudo chown $current_user:$current_user /tmp/dev-container-features
+
+sudo chmod 777 /tmp/build-features-src
+sudo chmod 777 /tmp/dev-container-features
+
+check "contents of tmp->build-features-src directory" ls -lrt /tmp/build-features-src
+check "contents of tmp->dev-container-features directory" ls -lrt /tmp/dev-container-features
+
+sudo rm -rf /tmp/*
+
+check "contents of tmp directory" ls -l /tmp
+
 check "gradle" gradle --version
 cd /tmp && gradle init --type basic --dsl groovy --incubating --project-name test
 check "GRADLE_USER_HOME exists" grep ".gradle" <(ls -la /root)

--- a/test/java/install_ant_and_gradle_and_maven_and_groovy_rhel_family.sh
+++ b/test/java/install_ant_and_gradle_and_maven_and_groovy_rhel_family.sh
@@ -22,8 +22,6 @@ check "contents of tmp directory" ls -l /tmp
 
 current_user=$(whoami)
 
-check "current_user_name" $current_user
-
 # Change ownership of the files
 sudo chown $current_user:$current_user /tmp/build-features-src
 sudo chown $current_user:$current_user /tmp/dev-container-features

--- a/test/java/install_ant_and_gradle_and_maven_and_groovy_rhel_family.sh
+++ b/test/java/install_ant_and_gradle_and_maven_and_groovy_rhel_family.sh
@@ -16,25 +16,30 @@ EOF
 cd /tmp && ant init
 check "ant-src exists" grep "ant-src" <(ls -la /tmp)
 
+check "gradle" gradle --version
+
 check "contents of tmp directory" ls -l /tmp
 
 current_user=$(whoami)
 
+check "current_user_name" $current_user
+
 # Change ownership of the files
 sudo chown $current_user:$current_user /tmp/build-features-src
 sudo chown $current_user:$current_user /tmp/dev-container-features
+sudo chown $current_user:$current_user /tmp/dev-container-features/devcontainer-features.builtin.env
 
 sudo chmod 777 /tmp/build-features-src
 sudo chmod 777 /tmp/dev-container-features
+sudo chmod 777 /tmp/dev-container-features/devcontainer-features.builtin.env
 
-check "contents of tmp->build-features-src directory" ls -lrt /tmp/build-features-src
-check "contents of tmp->dev-container-features directory" ls -lrt /tmp/dev-container-features
+check "contents of tmp->build-features-src directory" ls -l /tmp/build-features-src
+check "contents of tmp->dev-container-features directory" ls -l /tmp/dev-container-features
 
 sudo rm -rf /tmp/*
 
 check "contents of tmp directory" ls -l /tmp
 
-check "gradle" gradle --version
 cd /tmp && gradle init --type basic --dsl groovy --incubating --project-name test
 check "GRADLE_USER_HOME exists" grep ".gradle" <(ls -la /root)
 

--- a/test/java/install_ant_and_gradle_and_maven_and_groovy_rhel_family.sh
+++ b/test/java/install_ant_and_gradle_and_maven_and_groovy_rhel_family.sh
@@ -17,28 +17,7 @@ cd /tmp && ant init
 check "ant-src exists" grep "ant-src" <(ls -la /tmp)
 
 check "gradle" gradle --version
-
-check "contents of tmp directory" ls -l /tmp
-
-current_user=$(whoami)
-
-# Change ownership of the files
-sudo chown $current_user:$current_user /tmp/build-features-src
-sudo chown $current_user:$current_user /tmp/dev-container-features
-sudo chown $current_user:$current_user /tmp/dev-container-features/devcontainer-features.builtin.env
-
-sudo chmod 777 /tmp/build-features-src
-sudo chmod 777 /tmp/dev-container-features
-sudo chmod 777 /tmp/dev-container-features/devcontainer-features.builtin.env
-
-check "contents of tmp->build-features-src directory" ls -l /tmp/build-features-src
-check "contents of tmp->dev-container-features directory" ls -l /tmp/dev-container-features
-
-sudo rm -rf /tmp/*
-
-check "contents of tmp directory" ls -l /tmp
-
-cd /tmp && gradle init --type basic --dsl groovy --incubating --project-name test
+cd /tmp && gradle init --type basic --dsl groovy --overwrite --incubating --project-name test
 check "GRADLE_USER_HOME exists" grep ".gradle" <(ls -la /root)
 
 check "maven" mvn --version

--- a/test/java/install_lts_version.sh
+++ b/test/java/install_lts_version.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "java version LTS installed as default" grep "LTS" <(java --version)
+
+# Report result
+reportResults

--- a/test/java/scenarios.json
+++ b/test/java/scenarios.json
@@ -8,6 +8,14 @@
             }
         }
     },
+    "install_lts_version": {
+        "image": "ubuntu:focal",
+        "features": {
+            "java": {
+                "version": "lts"
+            }
+        }
+    },
     "install_additional_java": {
         "image": "ubuntu:focal",
         "features": {


### PR DESCRIPTION
 **Feature name**:
 
 * Java
 
 **Description**:
 
 This PR is for solution to following issue:
 
 * Features issue [#1011](https://github.com/devcontainers/features/issues/1011) 
     - jdk lts resulted in installation of 21.x-tem instead of 21.x.x-ms, which is not the intended behaviour. 
 
 _Changelog_:
 
 * Updated `install.sh`
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected