### PR TITLE
[Desktop-lite] - VNC_RESOLUTION unreadable fix - issue #945 fix

### DIFF
--- a/src/desktop-lite/devcontainer-feature.json
+++ b/src/desktop-lite/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "desktop-lite",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "name": "Light-weight Desktop",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/desktop-lite",
     "description": "Adds a lightweight Fluxbox based desktop to the container that can be accessed using a VNC viewer or the web. GUI-based commands executed from the built-in VS code terminal will open on the desktop automatically.",

--- a/src/desktop-lite/install.sh
+++ b/src/desktop-lite/install.sh
@@ -309,24 +309,24 @@ export LANGUAGE="${LANGUAGE:-"en_US.UTF-8"}"
 # Execute the command it not already running
 startInBackgroundIfNotRunning()
 {
-    log "Starting \$1."
-    echo -e "\n** \$(date) **" | sudoIf tee -a /tmp/\$1.log > /dev/null
-    if ! pgrep -x \$1 > /dev/null; then
-        keepRunningInBackground "\$@"
-        while ! pgrep -x \$1 > /dev/null; do
+    log "Starting $1."
+    echo -e "\n** $(date) **" | sudoIf tee -a /tmp/\$1.log > /dev/null
+    if ! pgrep -x $1 > /dev/null; then
+        keepRunningInBackground "$@"
+        while ! pgrep -x $1 > /dev/null; do
             sleep 1
         done
-        log "\$1 started."
+        log "$1 started."
     else
-        echo "\$1 is already running." | sudoIf tee -a /tmp/\$1.log > /dev/null
-        log "\$1 is already running."
+        echo "$1 is already running." | sudoIf tee -a /tmp/\$1.log > /dev/null
+        log "$1 is already running."
     fi
 }
 
 # Keep command running in background
 keepRunningInBackground()
 {
-    ($2 bash -c "while :; do echo [\\\$(date)] Process started.; \$3; echo [\\\$(date)] Process exited!; sleep 5; done 2>&1" | sudoIf tee -a /tmp/\$1.log > /dev/null & echo "\$!" | sudoIf tee /tmp/\$1.pid > /dev/null)
+    ($2 bash -c "while :; do echo [\\$(date)] Process started.; $3; echo [\\$(date)] Process exited!; sleep 5; done 2>&1" | sudoIf tee -a /tmp/\$1.log > /dev/null & echo "\$!" | sudoIf tee /tmp/\$1.pid > /dev/null)
 }
 
 # Use sudo to run as root when required
@@ -352,7 +352,7 @@ sudoUserIf()
 # Log messages
 log()
 {
-    echo -e "[\$(date)] \$@" | sudoIf tee -a \$LOG > /dev/null
+    echo -e "[$(date)] $@" | sudoIf tee -a $LOG > /dev/null
 }
 
 log "** SCRIPT START **"
@@ -372,21 +372,21 @@ sudoIf rm -rf /tmp/.X11-unix /tmp/.X*-lock
 mkdir -p /tmp/.X11-unix
 sudoIf chmod 1777 /tmp/.X11-unix
 sudoIf chown root:${group_name} /tmp/.X11-unix
-if [ "\$(echo "\${VNC_RESOLUTION}" | tr -cd 'x' | wc -c)" = "1" ]; then VNC_RESOLUTION=\${VNC_RESOLUTION}x16; fi
-screen_geometry="\${VNC_RESOLUTION%*x*}"
-screen_depth="\${VNC_RESOLUTION##*x}"
+if [ "$(echo "${VNC_RESOLUTION}" | tr -cd 'x' | wc -c)" = "1" ]; then VNC_RESOLUTION=${VNC_RESOLUTION}x16; fi
+screen_geometry="${VNC_RESOLUTION%*x*}"
+screen_depth="${VNC_RESOLUTION##*x}"
 
 # Check if VNC_PASSWORD is set and use the appropriate command
-common_options="tigervncserver \${DISPLAY} -geometry \${screen_geometry} -depth \${screen_depth} -rfbport ${VNC_PORT} -dpi \${VNC_DPI:-96} -localhost -desktop fluxbox -fg"
+common_options="tigervncserver \${DISPLAY} -geometry ${screen_geometry} -depth ${screen_depth} -rfbport ${VNC_PORT} -dpi ${VNC_DPI:-96} -localhost -desktop fluxbox -fg"
 
-if [ -n "\${VNC_PASSWORD+x}" ]; then
-    startInBackgroundIfNotRunning "Xtigervnc" sudoUserIf "\${common_options} -passwd /usr/local/etc/vscode-dev-containers/vnc-passwd"
+if [ -n "${VNC_PASSWORD+x}" ]; then
+    startInBackgroundIfNotRunning "Xtigervnc" sudoUserIf "${common_options} -passwd /usr/local/etc/vscode-dev-containers/vnc-passwd"
 else
-    startInBackgroundIfNotRunning "Xtigervnc" sudoUserIf "\${common_options} -SecurityTypes None"
+    startInBackgroundIfNotRunning "Xtigervnc" sudoUserIf "${common_options} -SecurityTypes None"
 fi
 
 # Spin up noVNC if installed and not running.
-if [ -d "/usr/local/novnc" ] && [ "\$(ps -ef | grep /usr/local/novnc/noVNC*/utils/launch.sh | grep -v grep)" = "" ]; then
+if [ -d "/usr/local/novnc" ] && [ "$(ps -ef | grep /usr/local/novnc/noVNC*/utils/launch.sh | grep -v grep)" = "" ]; then
     keepRunningInBackground "noVNC" sudoIf "/usr/local/novnc/noVNC*/utils/launch.sh --listen ${NOVNC_PORT} --vnc localhost:${VNC_PORT}"
     log "noVNC started."
 else
@@ -395,7 +395,7 @@ fi
 
 # Run whatever was passed in
 log "Executing \"\$@\"."
-exec "\$@"
+exec "$@"
 log "** SCRIPT EXIT **"
 EOF
 

--- a/src/desktop-lite/install.sh
+++ b/src/desktop-lite/install.sh
@@ -371,7 +371,7 @@ done
 sudoIf rm -rf /tmp/.X11-unix /tmp/.X*-lock
 mkdir -p /tmp/.X11-unix
 sudoIf chmod 1777 /tmp/.X11-unix
-sudoIf chown root:\${group_name} /tmp/.X11-unix
+sudoIf chown root:${group_name} /tmp/.X11-unix
 if [ "\$(echo "\${VNC_RESOLUTION}" | tr -cd 'x' | wc -c)" = "1" ]; then VNC_RESOLUTION=\${VNC_RESOLUTION}x16; fi
 screen_geometry="\${VNC_RESOLUTION%*x*}"
 screen_depth="\${VNC_RESOLUTION##*x}"

--- a/src/desktop-lite/install.sh
+++ b/src/desktop-lite/install.sh
@@ -377,7 +377,7 @@ screen_geometry="${VNC_RESOLUTION%*x*}"
 screen_depth="${VNC_RESOLUTION##*x}"
 
 # Check if VNC_PASSWORD is set and use the appropriate command
-common_options="tigervncserver \${DISPLAY} -geometry ${screen_geometry} -depth ${screen_depth} -rfbport ${VNC_PORT} -dpi ${VNC_DPI:-96} -localhost -desktop fluxbox -fg"
+common_options="tigervncserver ${DISPLAY} -geometry ${screen_geometry} -depth ${screen_depth} -rfbport ${VNC_PORT} -dpi ${VNC_DPI:-96} -localhost -desktop fluxbox -fg"
 
 if [ -n "${VNC_PASSWORD+x}" ]; then
     startInBackgroundIfNotRunning "Xtigervnc" sudoUserIf "${common_options} -passwd /usr/local/etc/vscode-dev-containers/vnc-passwd"
@@ -394,7 +394,7 @@ else
 fi
 
 # Run whatever was passed in
-log "Executing \"\$@\"."
+log "Executing "\$@\"."
 exec "$@"
 log "** SCRIPT EXIT **"
 EOF

--- a/src/desktop-lite/install.sh
+++ b/src/desktop-lite/install.sh
@@ -332,20 +332,20 @@ keepRunningInBackground()
 # Use sudo to run as root when required
 sudoIf()
 {
-    if [ "\$(id -u)" -ne 0 ]; then
-        sudo "\$@"
+    if [ "$(id -u)" -ne 0 ]; then
+        sudo "$@"
     else
-        "\$@"
+        "$@"
     fi
 }
 
 # Use sudo to run as non-root user if not already running
 sudoUserIf()
 {
-    if [ "\$(id -u)" -eq 0 ] && [ "\${user_name}" != "root" ]; then
-        sudo -u \${user_name} "\$@"
+    if [ "$(id -u)" -eq 0 ] && [ "${user_name}" != "root" ]; then
+        sudo -u "${user_name}" "$@"
     else
-        "\$@"
+        "$@"
     fi
 }
 

--- a/src/desktop-lite/install.sh
+++ b/src/desktop-lite/install.sh
@@ -326,7 +326,7 @@ startInBackgroundIfNotRunning()
 # Keep command running in background
 keepRunningInBackground()
 {
-    (\$2 bash -c "while :; do echo [\\\$(date)] Process started.; \$3; echo [\\\$(date)] Process exited!; sleep 5; done 2>&1" | sudoIf tee -a /tmp/\$1.log > /dev/null & echo "\$!" | sudoIf tee /tmp/\$1.pid > /dev/null)
+    ($2 bash -c "while :; do echo [\\\$(date)] Process started.; \$3; echo [\\\$(date)] Process exited!; sleep 5; done 2>&1" | sudoIf tee -a /tmp/\$1.log > /dev/null & echo "\$!" | sudoIf tee /tmp/\$1.pid > /dev/null)
 }
 
 # Use sudo to run as root when required

--- a/src/desktop-lite/install.sh
+++ b/src/desktop-lite/install.sh
@@ -293,7 +293,7 @@ echo -e "\nSuccess!\n"
 EOF
 
 # Container ENTRYPOINT script
-cat << EOF > /usr/local/share/desktop-init.sh
+cat << 'EOF' > /usr/local/share/desktop-init.sh
 #!/bin/bash
 
 user_name="${USERNAME}"


### PR DESCRIPTION
 **Feature name**:
 
 * Desktop-lite
 
 **Description**:
 
 This PR introduces the following functionality :
 
 * This PR is as a solution to Features issue #945 
 * VNC_RESOLUTION's value was not able to be read when set inside `containerEnv` as a configured option, appearing to be available as an Environment variable during build time, but it can only be read at runtime of container.
  
 
 _Changelog_:
 
 * Updated `install.sh`
 * Added a single quotes wrapper around EOF so as to disable variable expansion during build time, and such that the variable's values can be read when they are needed i.e. during runtime of container.
 
 **Checklist**:
 
 * [x]   Checked that applied changes work as expected