### PR TITLE
Extend OS support for sshd feature to RHEL-like and Alpine

### DIFF
--- a/src/sshd/install.sh
+++ b/src/sshd/install.sh
@@ -16,12 +16,75 @@ NEW_PASSWORD="${NEW_PASSWORD:-"skip"}"
 
 set -e
 
-# Clean up
-rm -rf /var/lib/apt/lists/*
-
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
+fi
+
+# Bring in ID, ID_LIKE, VERSION_ID, VERSION_CODENAME
+. /etc/os-release
+# Get an adjusted ID independent of distro variants
+MAJOR_VERSION_ID=$(echo ${VERSION_ID} | cut -d . -f 1)
+if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
+    ADJUSTED_ID="debian"
+elif [ "${ID}" = "alpine" ]; then
+    ADJUSTED_ID="alpine"
+elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"mariner"* ]]; then
+    ADJUSTED_ID="rhel"
+    if [[ "${ID}" = "rhel" ]] || [[ "${ID}" = *"alma"* ]] || [[ "${ID}" = *"rocky"* ]]; then
+        VERSION_CODENAME="rhel${MAJOR_VERSION_ID}"
+    else
+        VERSION_CODENAME="${ID}${MAJOR_VERSION_ID}"
+    fi
+else
+    echo "Linux distro ${ID} not supported."
+    exit 1
+fi
+
+# Setup INSTALL_CMD & PKG_MGR_CMD
+if type apt-get > /dev/null 2>&1; then
+    PKG_MGR_CMD=apt-get
+    INSTALL_CMD="${PKG_MGR_CMD} -y install --no-install-recommends"
+elif type apk > /dev/null 2>&1; then
+    PKG_MGR_CMD=apk
+    INSTALL_CMD="${PKG_MGR_CMD}"
+elif type microdnf > /dev/null 2>&1; then
+    PKG_MGR_CMD=microdnf
+    INSTALL_CMD="${PKG_MGR_CMD} ${INSTALL_CMD_ADDL_REPOS} -y install --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0"
+elif type dnf > /dev/null 2>&1; then
+    PKG_MGR_CMD=dnf
+    INSTALL_CMD="${PKG_MGR_CMD} ${INSTALL_CMD_ADDL_REPOS} -y install --refresh --best --nodocs --noplugins --setopt=install_weak_deps=0"
+else
+    PKG_MGR_CMD=yum
+    INSTALL_CMD="${PKG_MGR_CMD} ${INSTALL_CMD_ADDL_REPOS} -y install --noplugins --setopt=install_weak_deps=0"
+fi
+
+# Clean up
+clean_up() {
+    case ${ADJUSTED_ID} in
+        debian)
+            rm -rf /var/lib/apt/lists/*
+            ;;
+        alpine)
+            rm -rf /var/cache/apk/*
+            ;;
+        rhel)
+            rm -rf /var/cache/dnf/* /var/cache/yum/*
+            rm -rf /tmp/yum.log
+            rm -rf ${GPG_INSTALL_PATH}
+            ;;
+    esac
+}
+clean_up
+
+# Ensure that login shells get the correct path if the user updated the PATH using ENV.
+rm -f /etc/profile.d/00-restore-env.sh
+echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
+chmod +x /etc/profile.d/00-restore-env.sh
+
+# Some distributions do not install awk by default (e.g. Mariner)
+if ! type awk >/dev/null 2>&1; then
+    check_packages awk
 fi
 
 # Determine the appropriate non-root user
@@ -41,27 +104,81 @@ elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
     USERNAME=root
 fi
 
-apt_get_update()
-{
-    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
-        echo "Running apt-get update..."
-        apt-get update -y
-    fi
+pkg_mgr_update() {
+    case $ADJUSTED_ID in
+        debian)
+            if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+                echo "Running apt-get update..."
+                ${PKG_MGR_CMD} update -y
+            fi
+            ;;
+        alpine)
+            if [ "$(find /var/cache/apk/* | wc -l)" = "0" ]; then
+                echo "Running apk update..."
+                ${PKG_MGR_CMD} update
+            fi
+            ;;
+        rhel)
+            if [ ${PKG_MGR_CMD} = "microdnf" ]; then
+                if [ "$(ls /var/cache/yum/* 2>/dev/null | wc -l)" = 0 ]; then
+                    echo "Running ${PKG_MGR_CMD} makecache ..."
+                    ${PKG_MGR_CMD} makecache
+                fi
+            else
+                if [ "$(ls /var/cache/${PKG_MGR_CMD}/* 2>/dev/null | wc -l)" = 0 ]; then
+                    echo "Running ${PKG_MGR_CMD} check-update ..."
+                    set +e
+                    ${PKG_MGR_CMD} check-update
+                    rc=$?
+                    if [ $rc != 0 ] && [ $rc != 100 ]; then
+                        exit 1
+                    fi
+                    set -e
+                fi
+            fi
+            ;;
+    esac
 }
 
 # Checks if packages are installed and installs them if not
 check_packages() {
-    if ! dpkg -s "$@" > /dev/null 2>&1; then
-        apt_get_update
-        apt-get -y install --no-install-recommends "$@"
-    fi
+    case ${ADJUSTED_ID} in
+        debian)
+            if ! dpkg -s "$@" > /dev/null 2>&1; then
+                pkg_mgr_update
+                ${INSTALL_CMD} "$@"
+            fi
+            ;;
+        alpine)
+            if ! apk -e "$@" > /dev/null 2>&1; then
+                pkg_mgr_update
+                ${INSTALL_CMD} "$@"
+            fi
+            ;;
+        rhel)
+            if ! rpm -q "$@" > /dev/null 2>&1; then
+                pkg_mgr_update
+                ${INSTALL_CMD} "$@"
+            fi
+            ;;
+    esac
 }
 
 # Ensure apt is in non-interactive to avoid prompts
 export DEBIAN_FRONTEND=noninteractive
 
-# Install openssh-server openssh-client
-check_packages openssh-server openssh-client lsof
+# Install openssh-server openssh-client lsof openssl
+case ${ADJUSTED_ID} in
+    debian)
+        check_packages openssh-server openssh-client lsof openssl
+        ;;
+    alpine)
+        check_packages openssh-server openssh-client lsof openssl
+        ;;
+    rhel)
+        check_packages openssh-server openssh-clients lsof openssl
+        ;;
+esac
 
 # Generate password if new password set to the word "random"
 if [ "${NEW_PASSWORD}" = "random" ]; then
@@ -73,15 +190,29 @@ elif [ "${NEW_PASSWORD}" != "skip" ]; then
 fi
 
 if [ $(getent group ssh) ]; then
-  echo "'ssh' group already exists."
+    echo "'ssh' group already exists."
 else
-  echo "adding 'ssh' group, as it does not already exist."
-  groupadd ssh
+    echo "adding 'ssh' group, as it does not already exist."
+    case ${ADJUSTED_ID} in
+        debian|rhel)
+            groupadd ssh
+            ;;
+        alpine)
+            addgroup ssh
+            ;;
+    esac
 fi
 
 # Add user to ssh group
 if [ "${USERNAME}" != "root" ]; then
-    usermod -aG ssh ${USERNAME}
+    case ${ADJUSTED_ID} in
+        debian|rhel)
+            usermod -aG ssh ${USERNAME}
+            ;;
+        alpine)
+            adduser ${USERNAME} ssh
+            ;;
+    esac
 fi
 
 # Setup sshd
@@ -91,7 +222,10 @@ sed -i 's/#*PermitRootLogin prohibit-password/PermitRootLogin yes/g' /etc/ssh/ss
 sed -i -E "s/#*\s*Port\s+.+/Port ${SSHD_PORT}/g" /etc/ssh/sshd_config
 # Need to UsePAM so /etc/environment is processed
 sed -i -E "s/#?\s*UsePAM\s+.+/UsePAM yes/g" /etc/ssh/sshd_config
+# Enable X11 forwarding
+sed -i -E "s/#?\s*X11Forwarding\s+.+/X11Forwarding yes/g" /etc/ssh/sshd_config
 
+# TODO: Update for non-Debian distros
 # Write out a scripts that can be referenced as an ENTRYPOINT to auto-start sshd and fix login environments
 tee /usr/local/share/ssh-init.sh > /dev/null \
 << 'EOF'
@@ -134,6 +268,6 @@ if [ "${EMIT_PASSWORD}" = "true" ]; then
 fi
 
 # Clean up
-rm -rf /var/lib/apt/lists/*
+clean_up
 
 echo -e "\nForward port ${SSHD_PORT} to your local machine and run:\n\n  ssh -p ${SSHD_PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o GlobalKnownHostsFile=/dev/null ${USERNAME}@localhost\n"

--- a/test/sshd/test.sh
+++ b/test/sshd/test.sh
@@ -7,7 +7,7 @@ source dev-container-features-test-lib
 
 check "sshd-init-exists" bash -c "ls /usr/local/share/ssh-init.sh"
 check "sshd-log-exists" bash -c "ls /tmp/sshd.log"
-check "sshd-log-contents" bash -c "cat /tmp/sshd.log | grep 'Starting OpenBSD Secure Shell server'"
+check "sshd-log-contents" bash -c "cat /tmp/sshd.log | grep -e 'Starting OpenBSD Secure Shell server' -e 'INFO:systemctl:notify start done' -e 'Detaching to start `/usr/sbin/sshd.pam\' ... [ ok ]`'"
 check "sshd-log-has-sshd" bash -c "cat /tmp/sshd.log | grep 'sshd'"
 check "sshd" bash -c "ps -aux | grep -v grep | grep sshd"
 


### PR DESCRIPTION
The sshd feature is written specifically for Debian-based distributions. This PR extends support for RHEL-like and Alpine distributions, accounting for differences in:
* Default shell availability
* Package managers
* User privilege tools (`sudo`, `doas`)
* Init systems

Bash-specific shell syntax is converted to POSIX standard shell syntax. Package management is done in the style of supported, multi-OS features like [common-utils](https://github.com/devcontainers/features/tree/main/src/common-utils).