### PR TITLE
[rust] - remove crates deprecated ext. - install dependi ext. instead

### DIFF
--- a/src/rust/devcontainer-feature.json
+++ b/src/rust/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "rust",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "name": "Rust",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/rust",
     "description": "Installs Rust, common Rust utilities, and their required dependencies",

--- a/src/rust/devcontainer-feature.json
+++ b/src/rust/devcontainer-feature.json
@@ -56,8 +56,7 @@
             "extensions": [
                 "vadimcn.vscode-lldb",
                 "rust-lang.rust-analyzer",
-                "tamasfe.even-better-toml",
-                "fill-labs.dependi"
+                "tamasfe.even-better-toml"
             ],
             "settings": {
                 "files.watcherExclude": {

--- a/src/rust/devcontainer-feature.json
+++ b/src/rust/devcontainer-feature.json
@@ -47,7 +47,7 @@
                 "vadimcn.vscode-lldb",
                 "rust-lang.rust-analyzer",
                 "tamasfe.even-better-toml",
-                "serayuzgur.crates"
+                "fill-labs.dependi"
             ],
             "settings": {
                 "files.watcherExclude": {

--- a/src/rust/devcontainer-feature.json
+++ b/src/rust/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "rust",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "name": "Rust",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/rust",
     "description": "Installs Rust, common Rust utilities, and their required dependencies",


### PR DESCRIPTION
**Feature Name**

* Rust

**Changes**

This PR brings in the following changes to the features repo / rust feature :  

* Crates extension is deprecated now, as given in issue [#1131](https://github.com/devcontainers/images/issues/1131), so instead of that installing dependi extension (fill-labs.dependi).


**Checklist**

* [x] Checked that applied changes work as expected