### PR TITLE
common-utils: add bash-completion

### DIFF
--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "common-utils",
-    "version": "2.4.4",
+    "version": "2.4.5",
     "name": "Common Utilities",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/common-utils",
     "description": "Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.",

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -346,11 +346,20 @@ if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
     ADJUSTED_ID="debian"
 elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"mariner"* ]]; then
     ADJUSTED_ID="rhel"
+    VERSION_CODENAME="${ID}${VERSION_ID}"
 elif [ "${ID}" = "alpine" ]; then
     ADJUSTED_ID="alpine"
 else
     echo "Linux distro ${ID} not supported."
     exit 1
+fi
+
+if [ "${ADJUSTED_ID}" = "rhel" ] && [ "${VERSION_CODENAME-}" = "centos7" ]; then
+    # As of 1 July 2024, mirrorlist.centos.org no longer exists.
+    # Update the repo files to reference vault.centos.org.
+    sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 fi
 
 # Install packages for appropriate OS

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -32,6 +32,7 @@ install_debian_packages() {
     if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
         package_list="${package_list} \
         apt-utils \
+        bash-completion \
         openssh-client \
         gnupg2 \
         dirmngr \
@@ -170,6 +171,7 @@ install_redhat_packages() {
     if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
         package_list="${package_list} \
             gawk \
+            bash-completion \
             openssh-clients \
             gnupg2 \
             iproute \
@@ -254,6 +256,7 @@ install_alpine_packages() {
     if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
         apk add --no-cache \
             openssh-client \
+            bash-completion \
             gnupg \
             procps \
             lsof \


### PR DESCRIPTION
This change increases the size of the base images by about 1MB. Below is the size comparison of the `base-alpine` image with and without the `bash-completion` package:

```
$ docker images --format "{{.Repository}}:{{.Tag}}\t{{.Size}}"
without-bash-completion:latest  664MB
with-bash-completion:latest     665MB
```

Resolve #1043