### PR TITLE
Fixed Unsupported Debian distro

### DIFF
--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -104,7 +104,7 @@ install_debian_packages() {
 
     # Needed for adding manpages-posix and manpages-posix-dev which are non-free packages in Debian
     if [ "${ADD_NON_FREE_PACKAGES}" = "true" ]; then
-        if [[ ! -e "/etc/apt/sources.list" ]] && [[ -e "/etc/apt/sources.list.d/debian.sources" ]]; then 
+        if [[ ! -e "/etc/apt/sources.list" ]] && [[ -e "/etc/apt/sources.list.d/debian.sources" ]]; then
             sed -i '/^URIs: http:\/\/deb.debian.org\/debian$/ { N; N; s/Components: main/Components: main non-free non-free-firmware/ }' /etc/apt/sources.list.d/debian.sources
         else
             # Bring in variables from /etc/os-release like VERSION_CODENAME
@@ -339,7 +339,7 @@ chmod +x /etc/profile.d/00-restore-env.sh
 # Bring in ID, ID_LIKE, VERSION_ID, VERSION_CODENAME
 . /etc/os-release
 # Get an adjusted ID independent of distro variants
-if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
+if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = *"debian"* ]; then
     ADJUSTED_ID="debian"
 elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"mariner"* ]]; then
     ADJUSTED_ID="rhel"

--- a/src/git/install.sh
+++ b/src/git/install.sh
@@ -20,7 +20,7 @@ fi
 # Bring in ID, ID_LIKE, VERSION_ID, VERSION_CODENAME
 . /etc/os-release
 # Get an adjusted ID independent of distro variants
-if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
+if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = *"debian"* ]; then
     ADJUSTED_ID="debian"
 elif [ "${ID}" = "alpine" ]; then
     ADJUSTED_ID="alpine"
@@ -96,7 +96,7 @@ get_gpg_key_servers() {
     fi
 }
 
-# Import the specified key in a variable name passed in as 
+# Import the specified key in a variable name passed in as
 receive_gpg_keys() {
     local keys=${!1}
     local keyring_args=""
@@ -109,7 +109,7 @@ receive_gpg_keys() {
     if ! type curl > /dev/null 2>&1; then
         check_packages curl
     fi
-    
+
     # Use a temporary location for gpg keys to avoid polluting image
     export GNUPGHOME="/tmp/tmp-gnupg"
     mkdir -p ${GNUPGHOME}
@@ -119,7 +119,7 @@ receive_gpg_keys() {
     local retry_count=0
     local gpg_ok="false"
     set +e
-    until [ "${gpg_ok}" = "true" ] || [ "${retry_count}" -eq "5" ]; 
+    until [ "${gpg_ok}" = "true" ] || [ "${retry_count}" -eq "5" ];
     do
         echo "(*) Downloading GPG key..."
         ( echo "${keys}" | xargs -n 1 gpg -q ${keyring_args} --recv-keys) 2>&1 && gpg_ok="true"
@@ -224,7 +224,7 @@ if ([ "${GIT_VERSION}" = "latest" ] || [ "${GIT_VERSION}" = "lts" ] || [ "${GIT_
     receive_gpg_keys GIT_CORE_PPA_ARCHIVE_GPG_KEY /usr/share/keyrings/gitcoreppa-archive-keyring.gpg
     echo -e "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/gitcoreppa-archive-keyring.gpg] http://ppa.launchpad.net/git-core/ppa/ubuntu ${VERSION_CODENAME} main\ndeb-src [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/gitcoreppa-archive-keyring.gpg] http://ppa.launchpad.net/git-core/ppa/ubuntu ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/git-core-ppa.list
     ${INSTALL_CMD} update
-    ${INSTALL_CMD} -y install --no-install-recommends git 
+    ${INSTALL_CMD} -y install --no-install-recommends git
     rm -rf "/tmp/tmp-gnupg"
     rm -rf /var/lib/apt/lists/*
     exit 0
@@ -256,7 +256,7 @@ elif [ "${ADJUSTED_ID}" = "alpine" ]; then
 elif [ "${ADJUSTED_ID}" = "rhel" ]; then
 
     if [ $VERSION_CODENAME = "centos7" ]; then
-        check_packages centos-release-scl 
+        check_packages centos-release-scl
         check_packages devtoolset-11
         source /opt/rh/devtoolset-11/enable
     else

--- a/src/go/install.sh
+++ b/src/go/install.sh
@@ -29,7 +29,7 @@ fi
 . /etc/os-release
 # Get an adjusted ID independent of distro variants
 MAJOR_VERSION_ID=$(echo ${VERSION_ID} | cut -d . -f 1)
-if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
+if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = *"debian"* ]; then
     ADJUSTED_ID="debian"
 elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"mariner"* ]]; then
     ADJUSTED_ID="rhel"
@@ -82,7 +82,7 @@ find_version_from_git_tags() {
     local repository=$2
     local prefix=${3:-"tags/v"}
     local separator=${4:-"."}
-    local last_part_optional=${5:-"false"}    
+    local last_part_optional=${5:-"false"}
     if [ "$(echo "${requested_version}" | grep -o "." | wc -l)" != "2" ]; then
         local escaped_separator=${separator//./\\.}
         local last_part
@@ -256,11 +256,11 @@ if [[ "${TARGET_GO_VERSION}" != "none" ]] && [[ "$(go version 2>/dev/null)" != *
             TARGET_GO_VERSION="${major}.${minor}"
             # Look for latest version from previous minor release
             find_version_from_git_tags TARGET_GO_VERSION "https://go.googlesource.com/go" "tags/go" "." "true"
-        else 
+        else
             ((breakfix=breakfix-1))
             if [ "${breakfix}" = "0" ]; then
                 TARGET_GO_VERSION="${major}.${minor}"
-            else 
+            else
                 TARGET_GO_VERSION="${major}.${minor}.${breakfix}"
             fi
         fi
@@ -287,7 +287,7 @@ GO_TOOLS="\
     github.com/go-delve/delve/cmd/dlv@latest \
     github.com/fatih/gomodifytags@latest \
     github.com/haya14busa/goplay/cmd/goplay@latest \
-    github.com/cweill/gotests/gotests@latest \ 
+    github.com/cweill/gotests/gotests@latest \
     github.com/josharian/impl@latest"
 
 if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
@@ -304,7 +304,7 @@ if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
         export GO111MODULE=on
         go_install_command=get
         echo "Go version < 1.16, using go get."
-    fi 
+    fi
 
     (echo "${GO_TOOLS}" | xargs -n 1 go ${go_install_command} -v )2>&1 | tee -a /usr/local/etc/vscode-dev-containers/go.log
 

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -39,7 +39,7 @@ fi
 . /etc/os-release
 # Get an adjusted ID independent of distro variants
 MAJOR_VERSION_ID=$(echo ${VERSION_ID} | cut -d . -f 1)
-if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
+if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = *"debian"* ]; then
     ADJUSTED_ID="debian"
 elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"mariner"* ]]; then
     ADJUSTED_ID="rhel"

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -31,7 +31,7 @@ fi
 . /etc/os-release
 # Get an adjusted ID independent of distro variants
 MAJOR_VERSION_ID=$(echo ${VERSION_ID} | cut -d . -f 1)
-if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
+if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = *"debian"* ]; then
     ADJUSTED_ID="debian"
 elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"mariner"* ]]; then
     ADJUSTED_ID="rhel"
@@ -218,7 +218,7 @@ install_yarn() {
                 # Yum/DNF want to install nodejs dependencies, we'll use NPM to install yarn
                 su ${USERNAME} -c "umask 0002 && . '${NVM_DIR}/nvm.sh' && nvm use ${_ver} && npm install --global yarn"
             fi
-        else 
+        else
             echo "Yarn already installed."
         fi
     fi

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -46,7 +46,7 @@ fi
 . /etc/os-release
 # Get an adjusted ID independent of distro variants
 MAJOR_VERSION_ID=$(echo ${VERSION_ID} | cut -d . -f 1)
-if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
+if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = *"debian"* ]; then
     ADJUSTED_ID="debian"
 elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"mariner"* ]]; then
     ADJUSTED_ID="rhel"

--- a/test/python/install_cpython_fallback_prev_version_test.sh
+++ b/test/python/install_cpython_fallback_prev_version_test.sh
@@ -17,7 +17,7 @@ fi
 . /etc/os-release
 # Get an adjusted ID independent of distro variants
 MAJOR_VERSION_ID=$(echo ${VERSION_ID} | cut -d . -f 1)
-if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
+if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = *"debian"* ]; then
     ADJUSTED_ID="debian"
 elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"mariner"* ]]; then
     ADJUSTED_ID="rhel"
@@ -125,7 +125,7 @@ get_gpg_key_servers() {
     fi
 }
 
-# Import the specified key in a variable name passed in as 
+# Import the specified key in a variable name passed in as
 receive_gpg_keys() {
     local keys=${!1}
     local keyring_args=""
@@ -152,7 +152,7 @@ receive_gpg_keys() {
     local retry_count=0
     local gpg_ok="false"
     set +e
-    until [ "${gpg_ok}" = "true" ] || [ "${retry_count}" -eq "5" ]; 
+    until [ "${gpg_ok}" = "true" ] || [ "${retry_count}" -eq "5" ];
     do
         echo "(*) Downloading GPG key..."
         ( echo "${keys}" | xargs -n 1 gpg -q ${keyring_args} --recv-keys) 2>&1 && gpg_ok="true"
@@ -228,7 +228,7 @@ find_version_from_git_tags() {
     local repository=$2
     local prefix=${3:-"tags/v"}
     local separator=${4:-"."}
-    local last_part_optional=${5:-"false"}    
+    local last_part_optional=${5:-"false"}
     if [ "$(echo "${requested_version}" | grep -o "." | wc -l)" != "2" ]; then
         local escaped_separator=${separator//./\\.}
         local last_part
@@ -288,7 +288,7 @@ find_prev_version_from_git_tags() {
             ((breakfix=breakfix-1))
             if [ "${breakfix}" = "0" ] && [ "${last_part_optional}" = "true" ]; then
                 declare -g ${variable_name}="${major}.${minor}"
-            else 
+            else
                 declare -g ${variable_name}="${major}.${minor}.${breakfix}"
             fi
         fi
@@ -298,13 +298,13 @@ find_prev_version_from_git_tags() {
 add_symlink() {
     CURRENT_PATH="${PYTHON_INSTALL_PATH}/current"
     if [[ ! -d "${CURRENT_PATH}" ]]; then
-        ln -s -r "${INSTALL_PATH}" "${CURRENT_PATH}" 
+        ln -s -r "${INSTALL_PATH}" "${CURRENT_PATH}"
     fi
 
     if [ "${OVERRIDE_DEFAULT_VERSION}" = "true" ]; then
         if [[ $(ls -l ${CURRENT_PATH}) != *"-> ${INSTALL_PATH}"* ]] ; then
             rm "${CURRENT_PATH}"
-            ln -s -r "${INSTALL_PATH}" "${CURRENT_PATH}" 
+            ln -s -r "${INSTALL_PATH}" "${CURRENT_PATH}"
         fi
     fi
 }
@@ -329,7 +329,7 @@ install_cpython() {
 }
 
 install_from_source() {
-    VERSION=$1  
+    VERSION=$1
     echo "(*) Building Python ${VERSION} from source..."
     echo "(*) Building Python ${VERSION} from source..."
     if ! type git > /dev/null 2>&1; then
@@ -347,7 +347,7 @@ install_from_source() {
             install_prev_vers_cpython "${VERSION}"
         fi
     fi;
-    
+
     # Verify signature
     if [[ ${VERSION_CODENAME} = "centos7" ]] || [[ ${VERSION_CODENAME} = "rhel7" ]]; then
         receive_gpg_keys_centos7 PYTHON_SOURCE_GPG_KEYS
@@ -361,7 +361,7 @@ install_from_source() {
     # Untar and build
     tar -xzf "/tmp/python-src/${cpython_tgz_filename}" -C "/tmp/python-src" --strip-components=1
     local config_args=""
- 
+
     if [ "${OPTIMIZE_BUILD_FROM_SOURCE}" = "true" ]; then
         config_args="${config_args} --enable-optimizations"
     fi


### PR DESCRIPTION
Updated the conditional check to support some other debian based distro as well, which identifies as Debian-like but doesn't match the exact string comparison for "debian". This change allows the script to correctly identify and execute on Linux Mint systems, ensuring compatibility.

**Also trimmed TrailingWhitespace**

**Changes Made**
Modified the conditional statement in the script from:
```
if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
```
to:

```
if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = *"debian"* ]; then
```
**Reason for Change**
While based on Ubuntu and Debian, does not set "ID_LIKE" to "debian" but includes "debian" in its list of like distributions. This change ensures the script recognizes distros as a valid Debian-like distribution and performs necessary actions accordingly.