### PR TITLE
`[powershell]`: Fix manual PowerShell installation binary execution permissions

### DIFF
--- a/src/powershell/devcontainer-feature.json
+++ b/src/powershell/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "powershell",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "name": "PowerShell",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/powershell",
     "description": "Installs PowerShell along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",
@@ -10,7 +10,9 @@
             "proposals": [
                 "latest",
                 "none",
-                "7.1"
+                "7.4",
+                "7.3",
+                "7.2"
             ],
             "default": "latest",
             "description": "Select or enter a version of PowerShell."

--- a/src/powershell/install.sh
+++ b/src/powershell/install.sh
@@ -224,6 +224,7 @@ install_using_github() {
     chmod 755 "${powershell_target_path}/pwsh"
     ln -sf "${powershell_target_path}/pwsh" /usr/bin/pwsh
     add-shell "/usr/bin/pwsh"
+    cd /tmp
     rm -rf /tmp/pwsh
 }
 

--- a/src/powershell/install.sh
+++ b/src/powershell/install.sh
@@ -221,7 +221,9 @@ install_using_github() {
         echo "${powershell_archive_sha256} *${powershell_filename}" | sha256sum -c -
     fi
     tar xf "${powershell_filename}" -C "${powershell_target_path}"
-    ln -s "${powershell_target_path}/pwsh" /usr/local/bin/pwsh
+    chmod 755 "${powershell_target_path}/pwsh"
+    ln -s "${powershell_target_path}/pwsh" /usr/bin/pwsh
+    add-shell "/usr/bin/pwsh"
     rm -rf /tmp/pwsh
 }
 

--- a/src/powershell/install.sh
+++ b/src/powershell/install.sh
@@ -222,26 +222,30 @@ install_using_github() {
     fi
     tar xf "${powershell_filename}" -C "${powershell_target_path}"
     chmod 755 "${powershell_target_path}/pwsh"
-    ln -s "${powershell_target_path}/pwsh" /usr/bin/pwsh
+    ln -sf "${powershell_target_path}/pwsh" /usr/bin/pwsh
     add-shell "/usr/bin/pwsh"
     rm -rf /tmp/pwsh
 }
 
-export DEBIAN_FRONTEND=noninteractive
+if ! type pwsh >/dev/null 2>&1; then
+    export DEBIAN_FRONTEND=noninteractive
+    
+    # Source /etc/os-release to get OS info
+    . /etc/os-release
+    architecture="$(dpkg --print-architecture)"
 
-# Source /etc/os-release to get OS info
-. /etc/os-release
-architecture="$(dpkg --print-architecture)"
-
-if [[ "${POWERSHELL_ARCHIVE_ARCHITECTURES}" = *"${architecture}"* ]] && [[  "${POWERSHELL_ARCHIVE_VERSION_CODENAMES}" = *"${VERSION_CODENAME}"* ]]; then
-    install_using_apt || use_github="true"
+    if [[ "${POWERSHELL_ARCHIVE_ARCHITECTURES}" = *"${architecture}"* ]] && [[  "${POWERSHELL_ARCHIVE_VERSION_CODENAMES}" = *"${VERSION_CODENAME}"* ]]; then
+        install_using_apt || use_github="true"
+    else
+        use_github="true"
+    fi
+    
+    if [ "${use_github}" = "true" ]; then
+        echo "Attempting install from GitHub release..."
+        install_using_github
+    fi
 else
-    use_github="true"
-fi
-
-if [ "${use_github}" = "true" ]; then
-    echo "Attempting install from GitHub release..."
-    install_using_github
+    echo "PowerShell is already installed."
 fi
 
 # If PowerShell modules are requested, loop through and install

--- a/src/powershell/install.sh
+++ b/src/powershell/install.sh
@@ -18,7 +18,7 @@ POWERSHELL_PROFILE_URL="${POWERSHELLPROFILEURL}"
 
 MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
 POWERSHELL_ARCHIVE_ARCHITECTURES="amd64"
-POWERSHELL_ARCHIVE_VERSION_CODENAMES="stretch buster bionic focal bullseye jammy"
+POWERSHELL_ARCHIVE_VERSION_CODENAMES="stretch buster bionic focal bullseye jammy bookworm noble"
 GPG_KEY_SERVERS="keyserver hkp://keyserver.ubuntu.com
 keyserver hkp://keyserver.ubuntu.com:80
 keyserver hkps://keys.openpgp.org

--- a/test/powershell/install_powershell_fallback_test.sh
+++ b/test/powershell/install_powershell_fallback_test.sh
@@ -168,9 +168,10 @@ install_using_github() {
         echo "${powershell_archive_sha256} *${powershell_filename}" | sha256sum -c -
     fi
     sudo tar xf "${powershell_filename}" -C "${powershell_target_path}"
-    sudo ln -s "${powershell_target_path}/pwsh" /usr/local/bin/pwsh
-    sudo rm -rf /tmp/pwsh /usr/local/bin/pwsh
-
+    sudo chmod 755 "${powershell_target_path}/pwsh"
+    sudo ln -sf "${powershell_target_path}/pwsh" /usr/bin/pwsh
+    sudo add-shell "/usr/bin/pwsh"
+    sudo rm -rf /tmp/pwsh
 }
 
 echo -e "\nInstalling Powershell with find_prev_version_from_git_tags() fn 👈🏻"

--- a/test/powershell/install_powershell_fallback_test.sh
+++ b/test/powershell/install_powershell_fallback_test.sh
@@ -8,7 +8,7 @@ source dev-container-features-test-lib
 # Extension-specific tests
 check "az.resources" pwsh -Command "(Get-Module -ListAvailable -Name Az.Resources).Version.ToString()"
 check "az.storage" pwsh -Command "(Get-Module -ListAvailable -Name Az.Storage).Version.ToString()"
-check "profile" pwsh -Command "(Get-Variable $env:ProfileLoaded).Value"
+check "profile" pwsh -Command "if (\$null -eq \$env:ProfileLoaded) { echo 'Not set!'; exit 1 } else { if ( [bool]\$env:ProfileLoaded ) { echo 'Profile loaded.'; exit 0 } else { echo 'False value!'; exit 1 } }"
 
 check "Powershell version as installed by feature" bash -c "pwsh --version"
 

--- a/test/powershell/install_powershell_fallback_test.sh
+++ b/test/powershell/install_powershell_fallback_test.sh
@@ -171,6 +171,7 @@ install_using_github() {
     sudo chmod 755 "${powershell_target_path}/pwsh"
     sudo ln -sf "${powershell_target_path}/pwsh" /usr/bin/pwsh
     sudo add-shell "/usr/bin/pwsh"
+    cd /tmp
     sudo rm -rf /tmp/pwsh
 }
 

--- a/test/powershell/scenarios.json
+++ b/test/powershell/scenarios.json
@@ -1,6 +1,6 @@
 {
   "install_modules": {
-    "image": "mcr.microsoft.com/devcontainers/base:jammy",
+    "image": "mcr.microsoft.com/devcontainers/base:noble",
     "features": {
       "powershell": {
         "modules": "az.resources, az.storage",
@@ -9,7 +9,7 @@
     }
   },
   "install_powershell_fallback_test": {
-    "image": "mcr.microsoft.com/devcontainers/base:jammy",
+    "image": "mcr.microsoft.com/devcontainers/base:noble",
     "features": {
       "powershell": {
         "modules": "az.resources, az.storage",
@@ -18,7 +18,7 @@
     }
   },
   "install_modules_version": {
-    "image": "mcr.microsoft.com/devcontainers/base:jammy",
+    "image": "mcr.microsoft.com/devcontainers/base:noble",
     "features": {
       "powershell": {
         "modules": "az.resources==2.5.0, az.storage==4.3.0"
@@ -26,7 +26,7 @@
     }
   },
   "validate_powershell_installation": {
-    "image": "mcr.microsoft.com/devcontainers/base:jammy",
+    "image": "mcr.microsoft.com/devcontainers/base:noble",
     "features": {
       "powershell": {}
     }

--- a/test/powershell/scenarios.json
+++ b/test/powershell/scenarios.json
@@ -24,5 +24,11 @@
         "modules": "az.resources==2.5.0, az.storage==4.3.0"
       }
     }
+  },
+  "validate_powershell_installation": {
+    "image": "mcr.microsoft.com/devcontainers/base:jammy",
+    "features": {
+      "powershell": {}
+    }
   }
 }

--- a/test/powershell/validate_powershell_installation.sh
+++ b/test/powershell/validate_powershell_installation.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# Import test library for `check` command
+source dev-container-features-test-lib
+
+# Extension-specific tests
+check "pwsh file is symlink" bash -c "[ -L /usr/bin/pwsh ]"
+check "pwsh symlink is registered as shell" bash -c "[ $(grep -c '/usr/bin/pwsh' /etc/shells) -eq 1 ]"
+check "pwsh target is correct" bash -c "[ $(readlink /usr/bin/pwsh) = /opt/microsoft/powershell/7/pwsh ]"
+check "pwsh target is registered as shell" bash -c "[ $(grep -c '/opt/microsoft/powershell/7/pwsh' /etc/shells) -eq 1 ]"
+check "pwsh owner is root" bash -c "[ $(stat -c %U /opt/microsoft/powershell/7/pwsh) = root ]"
+check "pwsh group is root" bash -c "[ $(stat -c %G /opt/microsoft/powershell/7/pwsh) = root ]"
+check "pwsh file mode is -rwxr-xr-x" bash -c "[ $(stat -c '%A' /opt/microsoft/powershell/7/pwsh) = '-rwxr-xr-x' ]"
+check "pwsh is in PATH" bash -c "command -v pwsh"
+
+# Report result
+reportResults


### PR DESCRIPTION
This patch aligns the manual setup of `pwsh` with the settings the official Debian module uses:

- symlink to `/usr/bin/pwsh` instead of `/usr/bin/local/pwsh`
- register as shell in `/etc/shells` (using `add-shell`)

Also, because of #1041, this will also enforce execution permissions of the `/opt/microsoft/powershell/7/pwsh` binary.

The package version minor version number is increased to `1.5.0`. Also, version suggestions for PowerShell installation were updated to remove deprecated version `7.1` and add version `7.2`, `7.3` and `7.4` to the selection (they can still be installed as this is only the suggestions presented to the user).

Some other maintenance work:

- Add Debian Bookworm and Ubuntu Noble archive names to allow install of packaged versions from them
- Make the feature idempotent to improve when the feature is installed multiple times
- Repaired broken profile test
- Added a new `validate_powershell_installation` test to validate general `pwsh` binary installation
