### PR TITLE
Fix installing latest git from PPA in bionic

### DIFF
--- a/src/git/devcontainer-feature.json
+++ b/src/git/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "git",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "name": "Git (from source)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/git",
     "description": "Install an up-to-date version of Git, built from source as needed. Useful for when you want the latest and greatest features. Auto-detects latest stable version and installs needed dependencies.",

--- a/src/git/devcontainer-feature.json
+++ b/src/git/devcontainer-feature.json
@@ -9,6 +9,7 @@
             "type": "string",
             "proposals": [
                 "latest",
+                "system",
                 "os-provided"
             ],
             "default": "os-provided",

--- a/src/git/install.sh
+++ b/src/git/install.sh
@@ -266,17 +266,7 @@ elif [ "${ADJUSTED_ID}" = "alpine" ]; then
     check_packages asciidoc curl-dev expat-dev g++ gcc openssl-dev pcre2-dev perl-dev perl-error python3-dev tcl tk xmlto
 
 elif [ "${ADJUSTED_ID}" = "rhel" ]; then
-
-    if [ $VERSION_CODENAME = "centos7" ]; then
-        check_packages centos-release-scl
-        check_packages devtoolset-11
-        source /opt/rh/devtoolset-11/enable
-    else
-        check_packages gcc
-    fi
-
-
-    check_packages libcurl-devel expat-devel gettext-devel openssl-devel perl-devel zlib-devel cmake pcre2-devel tar gzip ca-certificates
+    check_packages gcc libcurl-devel expat-devel gettext-devel openssl-devel perl-devel zlib-devel cmake pcre2-devel tar gzip ca-certificates
     if ! type curl > /dev/null 2>&1; then
         check_packages curl
     fi

--- a/src/git/install.sh
+++ b/src/git/install.sh
@@ -26,10 +26,18 @@ elif [ "${ID}" = "alpine" ]; then
     ADJUSTED_ID="alpine"
 elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"mariner"* ]]; then
     ADJUSTED_ID="rhel"
-    VERSION_CODENAME="${ID}{$VERSION_ID}"
+    VERSION_CODENAME="${ID}${VERSION_ID}"
 else
     echo "Linux distro ${ID} not supported."
     exit 1
+fi
+
+if [ "${ADJUSTED_ID}" = "rhel" ] && [ "${VERSION_CODENAME-}" = "centos7" ]; then
+    # As of 1 July 2024, mirrorlist.centos.org no longer exists.
+    # Update the repo files to reference vault.centos.org.
+    sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 fi
 
 if type apt-get > /dev/null 2>&1; then

--- a/test/git/install_git_from_ppa_bionic.sh
+++ b/test/git/install_git_from_ppa_bionic.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "version" git  --version
+check "gettext" dpkg-query -l gettext
+
+cd /tmp && git clone https://github.com/devcontainers/feature-starter.git
+cd feature-starter
+check "perl" bash -c "git -c grep.patternType=perl grep -q 'a.+b'"
+
+# Report result
+reportResults

--- a/test/git/install_git_from_ppa_bionic.sh
+++ b/test/git/install_git_from_ppa_bionic.sh
@@ -7,7 +7,6 @@ source dev-container-features-test-lib
 
 # Definition specific tests
 check "version" git  --version
-check "gettext" dpkg-query -l gettext
 
 cd /tmp && git clone https://github.com/devcontainers/feature-starter.git
 cd feature-starter

--- a/test/git/scenarios.json
+++ b/test/git/scenarios.json
@@ -26,6 +26,15 @@
             }
         }
     },
+    "install_git_from_ppa_bionic": {
+        "image": "ubuntu:bionic",
+        "features": {
+            "git": {
+                "version": "latest",
+                "ppa": "true"
+            }
+        }
+    },
     "install_git_from_src_bionic": {
         "image": "ubuntu:bionic",
         "features": {


### PR DESCRIPTION
`keys.openpgp.org` strips user IDs from keys unless the key owner grants permission to share them. This [leads to](https://superuser.com/a/1485255) gpg rejecting the keys instead of importing them, and failing to install the `git` feature.

This PR enforces an explicit order when testing and importing keys from the keyservers list, ensuring `keys.openpgp.org` is the last keyserver to be tried. Previously, keyservers were selected based on bash's associative array key enumeration order, but this order is different between Bash v4 (in Ubuntu Bionic) and v5 (Ubuntu Focal+).

I believe the issue isn't seen in Bash v5 because the ubuntu keyservers are enumerated first, not because the gpg version in Focal accepts keys without user IDs.

If this is the case, we should either stop attempting to import keys from `keys.openpgp.org`, or encourage the owner of `E1DD270288B4E6030699E45FA1715D88E1DF1F24` to grant `openpgp.org` permission to share their user ID.

Fixes #1055 and adds a new scenario test.

Note: I believe this fix may need to be applied to all features modified in https://github.com/devcontainers/features/pull/1016.