### PR TITLE
feat(desktop-lite): make fluxbox optional

### DIFF
--- a/src/desktop-lite/NOTES.md
+++ b/src/desktop-lite/NOTES.md
@@ -33,6 +33,8 @@ If you add custom content to your base image or a Dockerfile in this location, t
 
 See the [Fluxbox menu documentation](http://www.fluxbox.org/help/man-fluxbox-menu.php) for format details. More information on additional customization can be found in Fluxbox's [help](http://www.fluxbox.org/help/) and [general](http://fluxbox.sourceforge.net/docbook/en/html/book1.html) documentation.
 
+If you do not want to use Fluxbox, then you can set `installFluxbox` to `false` and install your own window manager.
+
 ## Resolving crashes
 
 If you run into applications crashing, you may need to increase the size of the shared memory space allocated to your container. For example, this will bump it up to 1 GB in `devcontainer.json`:

--- a/src/desktop-lite/devcontainer-feature.json
+++ b/src/desktop-lite/devcontainer-feature.json
@@ -47,6 +47,11 @@
             ],
             "default": "5901",
             "description": "Enter a port for the desktop VNC server (TigerVNC)"
+        },
+        "installFluxbox": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether or not to install Fluxbox (set to false if you plan on using a different desktop environment)"
         }
     },
     "init": true,


### PR DESCRIPTION
This PR implements the `installFluxbox` parameter that allows template administrators to install another windows manager or desktop environment if they wish to do so.

#1030