### PR TITLE
feat(kubectl-helm-minikube): 🧑‍💻 add helm completion

### DIFF
--- a/src/kubectl-helm-minikube/devcontainer-feature.json
+++ b/src/kubectl-helm-minikube/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "kubectl-helm-minikube",
-    "version": "1.1.10",
+    "version": "1.2.0",
     "name": "Kubectl, Helm, and Minikube",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/kubectl-helm-minikube",
     "description": "Installs latest version of kubectl, Helm, and optionally minikube. Auto-detects latest versions and installs needed dependencies.",

--- a/src/kubectl-helm-minikube/install.sh
+++ b/src/kubectl-helm-minikube/install.sh
@@ -311,6 +311,16 @@ if [ ${HELM_VERSION} != "none" ]; then
         echo '(!) Helm installation failed!'
         exit 1
     fi
+
+    # helm bash completion
+    helm completion bash > /etc/bash_completion.d/helm
+
+    # helm zsh completion
+    if [ -e "${USERHOME}/.oh-my-zsh" ]; then
+        mkdir -p "${USERHOME}/.oh-my-zsh/completions"
+        helm completion zsh > "${USERHOME}/.oh-my-zsh/completions/_helm"
+        chown -R "${USERNAME}" "${USERHOME}/.oh-my-zsh"
+    fi
 fi
 
 # Install Minikube, verify checksum

--- a/test/kubectl-helm-minikube/checkBashCompletion.sh
+++ b/test/kubectl-helm-minikube/checkBashCompletion.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+command=$1
+expected=$2
+
+echo -e "Checking completion for command '$command'..."
+
+# Send command as a character stream, followed by two tab characters, into an interactive bash shell.
+# Also note the 'y' which responds to the possible Bash question "Display all xxx possibilities? (y or n)".
+# Bash produces the autocompletion output on stderr, so redirect that to stdout.
+# The sed bit captures the lines between Header and Footer (used as output delimiters).
+# The first grep removes the "Display all" message (that is atomatically answered to "y" by the script).
+# The last grep filters the output to lines containing the expected result.
+COMPLETE_OUTPUT=$(echo if false\; then "Header"\; $command$'\t'$'\t'y\; "Footer" fi | bash -i 2>&1 | sed -n '/Header/{:a;n;/Footer/q;p;ba}' | grep -v ^'Display all ')
+echo -e "\nCompletion output:\n"
+echo -e "$COMPLETE_OUTPUT"
+echo -e "\n"
+
+FILTERED_COMPLETE_OUTPUT=$(echo "$COMPLETE_OUTPUT" | grep "$expected")
+
+if [ -z "$FILTERED_COMPLETE_OUTPUT" ]; then
+  echo -e "Completion output does not contains '$expected'."
+  exit 1
+else
+  echo -e "Completion output contains '$expected'."
+  exit 0
+fi

--- a/test/kubectl-helm-minikube/test.sh
+++ b/test/kubectl-helm-minikube/test.sh
@@ -10,5 +10,15 @@ check "kube" kubectl
 check "helm" helm version
 check "minikune" minikube version
 
+# By default bash complete is disabled for the root user
+# Enable it by replacing current ~/.bashrc with the /etc/skel/.bashrc file
+mv ~/.bashrc ~/.bashrc.bak
+cp /etc/skel/.bashrc ~/
+
+check "helm-bash-completion-contains-version-command" ./checkBashCompletion.sh "helm " "version"
+
+# Restore original ~/.bashrc
+mv ~/.bashrc.bak ~/.bashrc
+
 # Report result
 reportResults


### PR DESCRIPTION
Like **kubectl**, **helm** supports **bash** and **zsh** command completion.