### PR TITLE
Desktop lite: Fix quote error

### DIFF
--- a/src/desktop-lite/devcontainer-feature.json
+++ b/src/desktop-lite/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "desktop-lite",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "name": "Light-weight Desktop",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/desktop-lite",
     "description": "Adds a lightweight Fluxbox based desktop to the container that can be accessed using a VNC viewer or the web. GUI-based commands executed from the built-in VS code terminal will open on the desktop automatically.",

--- a/src/desktop-lite/install.sh
+++ b/src/desktop-lite/install.sh
@@ -411,7 +411,7 @@ else
 fi
 
 # Run whatever was passed in
-log "Executing "\$@\"."
+log "Executing \"$@\"."
 exec "$@"
 log "** SCRIPT EXIT **"
 EOF


### PR DESCRIPTION
Corrected a syntax error in line 414 

log "Executing "\$@\"."

was corrected to

log "Executing \"$@\"."