### PR TITLE
[desktop-lite] - add tests for running xtigervnc and novnc

### DIFF
--- a/src/desktop-lite/devcontainer-feature.json
+++ b/src/desktop-lite/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "desktop-lite",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "name": "Light-weight Desktop",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/desktop-lite",
     "description": "Adds a lightweight Fluxbox based desktop to the container that can be accessed using a VNC viewer or the web. GUI-based commands executed from the built-in VS code terminal will open on the desktop automatically.",

--- a/src/desktop-lite/install.sh
+++ b/src/desktop-lite/install.sh
@@ -394,8 +394,12 @@ else
 fi
 
 # Run whatever was passed in
-log "Executing \"\$@\"."
-exec "$@"
+if [ -n "$1" ]; then
+    log "Executing \"\$@\"."
+    exec "$@"
+else
+    log "No command provided to execute."
+fi
 log "** SCRIPT EXIT **"
 EOF
 

--- a/test/desktop-lite/scenarios.json
+++ b/test/desktop-lite/scenarios.json
@@ -1,0 +1,8 @@
+{
+    "test_xtigervnc_novnc_started": {
+        "image": "ubuntu:noble",
+        "features": {
+            "desktop-lite": {}
+        }
+    }
+}

--- a/test/desktop-lite/test_xtigervnc_novnc_started.sh
+++ b/test/desktop-lite/test_xtigervnc_novnc_started.sh
@@ -23,5 +23,9 @@ check "Whether xtigervnc is Running" check_process_running 5901
 sleep 1
 check "Whether no_vnc is Running" check_process_running 6080
 
+check "desktop-init-exists" bash -c "ls /usr/local/share/desktop-init.sh"
+check "log-exists" bash -c "ls /tmp/container-init.log"
+check "log file contents" bash -c "cat /tmp/container-init.log"
+
 # Report result
 reportResults

--- a/test/desktop-lite/test_xtigervnc_novnc_started.sh
+++ b/test/desktop-lite/test_xtigervnc_novnc_started.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Check if xtigervnc & noVnc processes are running after successful installation and initialization
+check_process_running() {
+    port=$1
+    # Get process id of process running on specific port
+    PID=$(lsof -i :$port | awk 'NR==2 {print $2}')
+    if [ -n "$PID" ]; then
+        CMD=$(ps -p $PID -o cmd --no-headers)
+        GREEN='\033[0;32m'; NC='\033[0m'; RED='\033[0;31m'; YELLOW='\033[0;33m';
+        echo -e "${GREEN}Command running on port $port: ${YELLOW}$CMD${NC}"
+    else
+        echo -e "${RED}No process found listening on port $port.${NC}"
+    fi
+}
+
+check "Whether xtigervnc is Running" check_process_running 5901
+sleep 1
+check "Whether no_vnc is Running" check_process_running 6080
+
+# Report result
+reportResults


### PR DESCRIPTION
**Feature Name**

* Desktop-lite

**Description**

This PR is raised to write test cases for checking the running processes on default ports `5901` & `6080` i.e.  for `xtigervnc` and `novnc` running on `desktop-lite` successfully launched desktop

**_changelog_**

Added a test scenario and a test file corresponding to this scenario


**Checklist** 

* [x] Checked that applied changes work as expected
