### PR TITLE
[desktop-lite] Suggested usage of appPort instead of forwardPorts for devcontainer-cli

### DIFF
--- a/src/desktop-lite/NOTES.md
+++ b/src/desktop-lite/NOTES.md
@@ -19,7 +19,7 @@ To set up the `6080` port from your `devcontainer.json` file, include the follow
 You can also connect to the desktop using a [VNC viewer](https://www.realvnc.com/en/connect/download/viewer/). To do so:
 
 1. Connect to the environment from a desktop tool that supports the dev container spec (e.g., VS Code client).
-1. Forward the VNC server port (`5901` by default) to your local machine using either the `forwardPorts` property in `devcontainer.json` or the user interface in your tool (e.g., you can press <kbd>F1</kbd> or <kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> and select **Ports: Focus on Ports View** in VS Code to bring it into focus).
+1. Forward the VNC server port (`5901` by default) to your local machine using either the `forwardPorts` property in `devcontainer.json` or the user interface in your tool (e.g., you can press <kbd>F1</kbd> or <kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> and select **Ports: Focus on Ports View** in VS Code to bring it into focus). If using the [Dev Conatiner Cli](https://github.com/devcontainers/cli), you should use the `appPort` property in `devcontainer.json` instead.
 1. Start your VNC Viewer and connect to localhost:5901. Note that you may need to bump up the color depth to 24 bits to see full color.
 1. Enter the desktop password (`vscode` by default).
 

--- a/src/desktop-lite/NOTES.md
+++ b/src/desktop-lite/NOTES.md
@@ -19,7 +19,7 @@ To set up the `6080` port from your `devcontainer.json` file, include the follow
 You can also connect to the desktop using a [VNC viewer](https://www.realvnc.com/en/connect/download/viewer/). To do so:
 
 1. Connect to the environment from a desktop tool that supports the dev container spec (e.g., VS Code client).
-1. Forward the VNC server port (`5901` by default) to your local machine using either the `forwardPorts` property in `devcontainer.json` or the user interface in your tool (e.g., you can press <kbd>F1</kbd> or <kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> and select **Ports: Focus on Ports View** in VS Code to bring it into focus). If using the [Dev Conatiner Cli](https://github.com/devcontainers/cli), you should use the `appPort` property in `devcontainer.json` instead.
+1. Forward the VNC server port (`5901` by default) to your local machine using either the `forwardPorts` property in `devcontainer.json` or the user interface in your tool (e.g., you can press <kbd>F1</kbd> or <kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> and select **Ports: Focus on Ports View** in VS Code to bring it into focus). If you are using the [Dev Container CLI](https://github.com/devcontainers/cli), you should instead use the `appPort` property in `devcontainer.json`.
 1. Start your VNC Viewer and connect to localhost:5901. Note that you may need to bump up the color depth to 24 bits to see full color.
 1. Enter the desktop password (`vscode` by default).
 


### PR DESCRIPTION
Update to the desktop-lite usage documentation:
The devcontainer-cli does not yet support the usage of forwardPorts, as indicated https://github.com/devcontainers/cli/issues/186. Conveniently, we can still use appPort in a similar manner.

This PR simply adds a line of documentation to `NOTES.md` to make users aware of this difference.