### PR TITLE
Align how http proxies are handled when fetching gpg keys for download verification

### DIFF
--- a/src/git-lfs/install.sh
+++ b/src/git-lfs/install.sh
@@ -70,16 +70,11 @@ get_gpg_key_servers() {
         ["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
     )
 
-    local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
-
-    if [ ! -z "${KEYSERVER_PROXY}" ]; then
-        curl_args="--proxy ${KEYSERVER_PROXY}"
-    fi
 
     for keyserver in "${!keyservers_curl_map[@]}"; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
-        if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
+        if curl -s --max-time 5 ${keyserver_curl_url} > /dev/null; then
             echo "keyserver ${keyserver}"
             keyserver_reachable=true
         else

--- a/src/git/install.sh
+++ b/src/git/install.sh
@@ -75,17 +75,12 @@ clean_up
 
 # Get the list of GPG key servers that are reachable
 get_gpg_key_servers() {
-    local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
-
-    if [ ! -z "${KEYSERVER_PROXY}" ]; then
-        curl_args="--proxy ${KEYSERVER_PROXY}"
-    fi
 
     test_keyserver() {
         local keyserver="$1"
         local keyserver_curl_url="$2"
-        if curl -s ${curl_args} --max-time 5 "${keyserver_curl_url}" > /dev/null; then
+        if curl -s --max-time 5 "${keyserver_curl_url}" > /dev/null; then
             echo "keyserver ${keyserver}"
             keyserver_reachable=true
         else

--- a/src/github-cli/install.sh
+++ b/src/github-cli/install.sh
@@ -32,16 +32,11 @@ get_gpg_key_servers() {
         ["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
     )
 
-    local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
-
-    if [ ! -z "${KEYSERVER_PROXY}" ]; then
-        curl_args="--proxy ${KEYSERVER_PROXY}"
-    fi
 
     for keyserver in "${!keyservers_curl_map[@]}"; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
-        if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
+        if curl -s --max-time 5 ${keyserver_curl_url} > /dev/null; then
             echo "keyserver ${keyserver}"
             keyserver_reachable=true
         else

--- a/src/github-cli/install.sh
+++ b/src/github-cli/install.sh
@@ -11,6 +11,7 @@ CLI_VERSION=${VERSION:-"latest"}
 INSTALL_DIRECTLY_FROM_GITHUB_RELEASE=${INSTALLDIRECTLYFROMGITHUBRELEASE:-"true"}
 
 GITHUB_CLI_ARCHIVE_GPG_KEY=23F3D4EA75716059
+KEYSERVER_PROXY="${HTTP_PROXY:-""}"
 
 set -e
 
@@ -58,8 +59,14 @@ get_gpg_key_servers() {
 receive_gpg_keys() {
     local keys=${!1}
     local keyring_args=""
+    local gpg_cmd="gpg"
+
     if [ ! -z "$2" ]; then
+        mkdir -p "$(dirname \"$2\")"
         keyring_args="--no-default-keyring --keyring $2"
+    fi
+    if [ ! -z "${KEYSERVER_PROXY}" ]; then
+        keyring_args="${keyring_args} --keyserver-options http-proxy=${KEYSERVER_PROXY}"
     fi
 
     # Install curl
@@ -76,16 +83,15 @@ receive_gpg_keys() {
     local retry_count=0
     local gpg_ok="false"
     set +e
-    until [ "${gpg_ok}" = "true" ] || [ "${retry_count}" -eq "5" ]; 
-    do
-        echo "(*) Downloading GPG key..."
-        ( echo "${keys}" | xargs -n 1 gpg -q ${keyring_args} --recv-keys) 2>&1 && gpg_ok="true"
-        if [ "${gpg_ok}" != "true" ]; then
-            echo "(*) Failed getting key, retrying in 10s..."
-            (( retry_count++ ))
-            sleep 10s
-        fi
-    done
+        until [ "${gpg_ok}" = "true" ] || [ "${retry_count}" -eq "5" ]; do
+            echo "(*) Downloading GPG key..."
+            (echo "${keys}" | xargs -n 1 gpg -q ${keyring_args} --recv-keys) 2>&1 && gpg_ok="true"
+            if [ "${gpg_ok}" != "true" ]; then
+                echo "(*) Failed getting key, retrying in 10s..."
+                (( retry_count++ ))
+                sleep 10s
+            fi
+        done
     set -e
     if [ "${gpg_ok}" = "false" ]; then
         echo "(!) Failed to get gpg key."

--- a/src/kubectl-helm-minikube/install.sh
+++ b/src/kubectl-helm-minikube/install.sh
@@ -240,16 +240,11 @@ get_gpg_key_servers() {
         ["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
     )
 
-    local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
-
-    if [ ! -z "${KEYSERVER_PROXY}" ]; then
-        curl_args="--proxy ${KEYSERVER_PROXY}"
-    fi
 
     for keyserver in "${!keyservers_curl_map[@]}"; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
-        if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
+        if curl -s --max-time 5 ${keyserver_curl_url} > /dev/null; then
             echo "keyserver ${keyserver}"
             keyserver_reachable=true
         else

--- a/src/kubectl-helm-minikube/install.sh
+++ b/src/kubectl-helm-minikube/install.sh
@@ -22,6 +22,7 @@ MINIKUBE_SHA256="${MINIKUBE_SHA256:-"automatic"}"
 USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
 
 HELM_GPG_KEYS_URI="https://raw.githubusercontent.com/helm/helm/main/KEYS"
+KEYSERVER_PROXY="${HTTP_PROXY:-""}"
 
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -13,17 +13,16 @@ Installs the provided version of Python, as well as PIPX, and other common Pytho
 
 ## Options
 
-| Options Id | Description | Type | Default Value |
-|-----|-----|-----|-----|
-| version | Select a Python version to install. | string | os-provided |
-| installTools | Flag indicating whether or not to install the tools specified via the 'toolsToInstall' option. Default is 'true'. | boolean | true |
-| toolsToInstall | Comma-separated list of tools to install when 'installTools' is true. Defaults to a set of common Python tools like pylint. | string | flake8,autopep8,black,yapf,mypy,pydocstyle,pycodestyle,bandit,pipenv,virtualenv,pytest,pylint |
-| optimize | Optimize Python for performance when compiled (slow) | boolean | false |
-| enableShared | Enable building a shared Python library | boolean | false |
-| installPath | The path where python will be installed. | string | /usr/local/python |
-| installJupyterlab | Install JupyterLab, a web-based interactive development environment for notebooks | boolean | false |
-| configureJupyterlabAllowOrigin | Configure JupyterLab to accept HTTP requests from the specified origin | string | - |
-| httpProxy | Connect to GPG keyservers using a proxy for fetching source code signatures by configuring this option | string | - |
+| Options Id                     | Description                                                                                                                 | Type    | Default Value                                                                                 |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------- | ------- | --------------------------------------------------------------------------------------------- |
+| version                        | Select a Python version to install.                                                                                         | string  | os-provided                                                                                   |
+| installTools                   | Flag indicating whether or not to install the tools specified via the 'toolsToInstall' option. Default is 'true'.           | boolean | true                                                                                          |
+| toolsToInstall                 | Comma-separated list of tools to install when 'installTools' is true. Defaults to a set of common Python tools like pylint. | string  | flake8,autopep8,black,yapf,mypy,pydocstyle,pycodestyle,bandit,pipenv,virtualenv,pytest,pylint |
+| optimize                       | Optimize Python for performance when compiled (slow)                                                                        | boolean | false                                                                                         |
+| enableShared                   | Enable building a shared Python library                                                                                     | boolean | false                                                                                         |
+| installPath                    | The path where python will be installed.                                                                                    | string  | /usr/local/python                                                                             |
+| installJupyterlab              | Install JupyterLab, a web-based interactive development environment for notebooks                                           | boolean | false                                                                                         |
+| configureJupyterlabAllowOrigin | Configure JupyterLab to accept HTTP requests from the specified origin                                                      | string  | -                                                                                             |
 
 ## Customizations
 

--- a/src/python/devcontainer-feature.json
+++ b/src/python/devcontainer-feature.json
@@ -56,11 +56,6 @@
       "type": "string",
       "default": "",
       "description": "Configure JupyterLab to accept HTTP requests from the specified origin"
-    },
-    "httpProxy": {
-      "type": "string",
-      "default": "",
-      "description": "Connect to GPG keyservers using a proxy for fetching source code signatures by configuring this option"
     }
   },
   "containerEnv": {
@@ -78,9 +73,9 @@
       ],
       "settings": {
         "python.defaultInterpreterPath": "/usr/local/python/current/bin/python",
-	      "[python]": {
-	        "editor.defaultFormatter": "ms-python.autopep8"
-	      }
+        "[python]": {
+          "editor.defaultFormatter": "ms-python.autopep8"
+        }
       }
     }
   },

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -141,16 +141,11 @@ get_gpg_key_servers() {
         ["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
     )
 
-    local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
-
-    if [ ! -z "${KEYSERVER_PROXY}" ]; then
-        curl_args="--proxy ${KEYSERVER_PROXY}"
-    fi
 
     for keyserver in "${!keyservers_curl_map[@]}"; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
-        if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
+        if curl -s --max-time 5 ${keyserver_curl_url} > /dev/null; then
             echo "keyserver ${keyserver}"
             keyserver_reachable=true
         else

--- a/src/ruby/install.sh
+++ b/src/ruby/install.sh
@@ -78,16 +78,11 @@ get_gpg_key_servers() {
         ["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
     )
 
-    local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
-
-    if [ ! -z "${KEYSERVER_PROXY}" ]; then
-        curl_args="--proxy ${KEYSERVER_PROXY}"
-    fi
 
     for keyserver in "${!keyservers_curl_map[@]}"; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
-        if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
+        if curl -s --max-time 5 ${keyserver_curl_url} > /dev/null; then
             echo "keyserver ${keyserver}"
             keyserver_reachable=true
         else

--- a/src/terraform/README.md
+++ b/src/terraform/README.md
@@ -13,15 +13,14 @@ Installs the Terraform CLI and optionally TFLint and Terragrunt. Auto-detects la
 
 ## Options
 
-| Options Id | Description | Type | Default Value |
-|-----|-----|-----|-----|
-| version | Terraform version | string | latest |
-| tflint | Tflint version (https://github.com/terraform-linters/tflint/releases) | string | latest |
-| terragrunt | Terragrunt version | string | latest |
-| installSentinel | Install sentinel, a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions | boolean | false |
-| installTFsec | Install tfsec, a tool to spot potential misconfigurations for your terraform code | boolean | false |
-| installTerraformDocs | Install terraform-docs, a utility to generate documentation from Terraform modules | boolean | false |
-| httpProxy | Connect to a keyserver using a proxy by configuring this option | string | - |
+| Options Id           | Description                                                                                                                                          | Type    | Default Value |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------- |
+| version              | Terraform version                                                                                                                                    | string  | latest        |
+| tflint               | Tflint version (https://github.com/terraform-linters/tflint/releases)                                                                                | string  | latest        |
+| terragrunt           | Terragrunt version                                                                                                                                   | string  | latest        |
+| installSentinel      | Install sentinel, a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions | boolean | false         |
+| installTFsec         | Install tfsec, a tool to spot potential misconfigurations for your terraform code                                                                    | boolean | false         |
+| installTerraformDocs | Install terraform-docs, a utility to generate documentation from Terraform modules                                                                   | boolean | false         |
 
 ## Customizations
 

--- a/src/terraform/devcontainer-feature.json
+++ b/src/terraform/devcontainer-feature.json
@@ -49,11 +49,6 @@
             "type": "boolean",
             "default": false,
             "description": "Install terraform-docs, a utility to generate documentation from Terraform modules"
-        },
-        "httpProxy": {
-            "type": "string",
-            "default": "",
-            "description": "Connect to a keyserver using a proxy by configuring this option"
         }
     },
     "customizations": {

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -52,16 +52,11 @@ get_gpg_key_servers() {
         ["hkps://keyserver.pgp.com"]="https://keyserver.pgp.com"
     )
 
-    local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
-
-    if [ ! -z "${KEYSERVER_PROXY}" ]; then
-        curl_args="--proxy ${KEYSERVER_PROXY}"
-    fi
 
     for keyserver in "${!keyservers_curl_map[@]}"; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
-        if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
+        if curl -s --max-time 5 ${keyserver_curl_url} > /dev/null; then
             echo "keyserver ${keyserver}"
             keyserver_reachable=true
         else

--- a/test/python/install_cpython_fallback_prev_version_test.sh
+++ b/test/python/install_cpython_fallback_prev_version_test.sh
@@ -105,16 +105,11 @@ get_gpg_key_servers() {
         ["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
     )
 
-    local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
-
-    if [ ! -z "${KEYSERVER_PROXY}" ]; then
-        curl_args="--proxy ${KEYSERVER_PROXY}"
-    fi
 
     for keyserver in "${!keyservers_curl_map[@]}"; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
-        if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
+        if curl -s --max-time 5 ${keyserver_curl_url} > /dev/null; then
             echo "keyserver ${keyserver}"
             keyserver_reachable=true
         else

--- a/test/ruby/ruby_fallback_test.sh
+++ b/test/ruby/ruby_fallback_test.sh
@@ -69,16 +69,11 @@ get_gpg_key_servers() {
         ["hkp://keyserver.pgp.com"]="http://keyserver.pgp.com:11371"
     )
 
-    local curl_args=""
     local keyserver_reachable=false  # Flag to indicate if any keyserver is reachable
-
-    if [ ! -z "${KEYSERVER_PROXY}" ]; then
-        curl_args="--proxy ${KEYSERVER_PROXY}"
-    fi
 
     for keyserver in "${!keyservers_curl_map[@]}"; do
         local keyserver_curl_url="${keyservers_curl_map[${keyserver}]}"
-        if curl -s ${curl_args} --max-time 5 ${keyserver_curl_url} > /dev/null; then
+        if curl -s --max-time 5 ${keyserver_curl_url} > /dev/null; then
             echo "keyserver ${keyserver}"
             keyserver_reachable=true
         else

--- a/test/ruby/ruby_fallback_test.sh
+++ b/test/ruby/ruby_fallback_test.sh
@@ -13,6 +13,7 @@ check "ruby" ruby -v
 trap 'echo "Last executed command failed at line ${LINENO}"' ERR
 
 RVM_GPG_KEYS="409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"
+KEYSERVER_PROXY="${HTTP_PROXY:-""}"
 
 # Clean up
 rm -rf /var/lib/apt/lists/*
@@ -95,8 +96,14 @@ get_gpg_key_servers() {
 receive_gpg_keys() {
     local keys=${!1}
     local keyring_args=""
+    local gpg_cmd="gpg"
+
     if [ ! -z "$2" ]; then
-        keyring_args="--no-default-keyring --keyring \"$2\""
+        mkdir -p "$(dirname \"$2\")"
+        keyring_args="--no-default-keyring --keyring $2"
+    fi
+    if [ ! -z "${KEYSERVER_PROXY}" ]; then
+        keyring_args="${keyring_args} --keyserver-options http-proxy=${KEYSERVER_PROXY}"
     fi
 
     # Install curl
@@ -108,21 +115,20 @@ receive_gpg_keys() {
     export GNUPGHOME="/tmp/tmp-gnupg"
     mkdir -p ${GNUPGHOME}
     chmod 700 ${GNUPGHOME}
-    echo -e "disable-ipv6\n$(get_gpg_key_servers)" | tee ${GNUPGHOME}/dirmngr.conf > /dev/null
+    echo -e "disable-ipv6\n$(get_gpg_key_servers)" > ${GNUPGHOME}/dirmngr.conf
     # GPG key download sometimes fails for some reason and retrying fixes it.
     local retry_count=0
     local gpg_ok="false"
     set +e
-    until [ "${gpg_ok}" = "true" ] || [ "${retry_count}" -eq "5" ]; 
-    do
-        echo "(*) Downloading GPG key..."
-        ( echo "${keys}" | xargs -n 1 gpg -q ${keyring_args} --recv-keys) 2>&1 && gpg_ok="true"
-        if [ "${gpg_ok}" != "true" ]; then
-            echo "(*) Failed getting key, retrying in 10s..."
-            (( retry_count++ ))
-            sleep 10s
-        fi
-    done
+        until [ "${gpg_ok}" = "true" ] || [ "${retry_count}" -eq "5" ]; do
+            echo "(*) Downloading GPG key..."
+            (echo "${keys}" | xargs -n 1 gpg -q ${keyring_args} --recv-keys) 2>&1 && gpg_ok="true"
+            if [ "${gpg_ok}" != "true" ]; then
+                echo "(*) Failed getting key, retrying in 10s..."
+                (( retry_count++ ))
+                sleep 10s
+            fi
+        done
     set -e
     if [ "${gpg_ok}" = "false" ]; then
         echo "(!) Failed to get gpg key."


### PR DESCRIPTION
I noticed while trying to run a dev-container setup behind a corporate proxy that git-lfs was getting stuck waiting for gpg keys.

It downloads the collateral file from, mostly, github and then checks to make sure the hashes match up with what is expected. Due to how the proxy was being handled through the install scripts it would either failure to download the collateral (http proxy not correctly setup in container environment) or would fail to verify the collateral (http proxy setup correctly, but gpg not being passed proxy values).

To solve this I went through and aligned all of the features which use gpg checking with how the python feature does it.

I also removed the httpProxy parameter from the features which had it as anyone using it would have already had to have had the proxy correctly setup in order to download the collateral initially. I was one the fence about this change and would remove it if it is deemed no backwards compatible. I didn't see any documentation on how this type of removal should be handled.

Affected features:

git-lfs
git
github-cli
kubectl-helm-minikube
python
ruby
terraform