### PR TITLE
feat(nix): Enable persistent volume for shared nix-store

### DIFF
--- a/src/nix/devcontainer-feature.json
+++ b/src/nix/devcontainer-feature.json
@@ -46,7 +46,7 @@
     "mounts": [
         { 
             "source": "devcontainer-nix-store", 
-            "target": "/nix/store", 
+            "target": "/nix", 
             "type": "volume" 
         }
     ],

--- a/src/nix/devcontainer-feature.json
+++ b/src/nix/devcontainer-feature.json
@@ -43,5 +43,12 @@
     "containerEnv": {
         "PATH": "/nix/var/nix/profiles/default/bin:/nix/var/nix/profiles/default/sbin:${PATH}"
     },
+    "mounts": [
+        { 
+            "source": "devcontainer-nix-store", 
+            "target": "/nix/store", 
+            "type": "volume" 
+        }
+    ],
     "entrypoint": "/usr/local/share/nix-entrypoint.sh"
 }

--- a/src/nix/devcontainer-feature.json
+++ b/src/nix/devcontainer-feature.json
@@ -7,7 +7,10 @@
     "options": {
         "version": {
             "type": "string",
-            "proposals": ["latest", "2.11"],
+            "proposals": [
+                "latest",
+                "2.11"
+            ],
             "default": "latest",
             "description": "Version of Nix to install."
         },
@@ -44,10 +47,10 @@
         "PATH": "/nix/var/nix/profiles/default/bin:/nix/var/nix/profiles/default/sbin:${PATH}"
     },
     "mounts": [
-        { 
-            "source": "devcontainer-nix-store", 
-            "target": "/nix", 
-            "type": "volume" 
+        {
+            "source": "${devcontainerId}-nix-store",
+            "target": "/nix",
+            "type": "volume"
         }
     ],
     "entrypoint": "/usr/local/share/nix-entrypoint.sh"

--- a/src/nix/devcontainer-feature.json
+++ b/src/nix/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "nix",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "name": "Nix Package Manager",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/nix",
     "description": "Installs the Nix package manager and optionally a set of packages.",

--- a/src/nix/devcontainer-feature.json
+++ b/src/nix/devcontainer-feature.json
@@ -48,7 +48,7 @@
     },
     "mounts": [
         {
-            "source": "${devcontainerId}-nix-store",
+            "source": "nix-store-${devcontainerId}",
             "target": "/nix",
             "type": "volume"
         }

--- a/test/nix/scenarios.json
+++ b/test/nix/scenarios.json
@@ -91,7 +91,6 @@
             }
         }
     },
-
     "flake": {
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "remoteUser": "vscode",


### PR DESCRIPTION
Closes #284

Enables a shared, persistent docker volume for /nix/store. 
Garbage collection is no issue since nix simply refetches everything that's missing. On the other hand this volume will probably save a lot of storage and bandwidth due to deduplication.

My use case: I enabled the nix feature per default for every devcontainer, to be used with my dotfiles-repo (and home-manager). 

Alternative: Duplicate feature to have both options, one with cache, one without.

-----

**Update**

The nix-store volumes are no longer shared with all containers using this feature. Nix (or it's store) does not seem to be ready for shared access. Instead, every devcontainer using this feature gets its own persistent store volume. This reduces the rebuild-times and data transfer, but not as much as a the shared store. Imo, still a useful change.

The diff looks bad, but it's just because I removed one if-else-condition spanning 55 lines. 

(Wrong statement about renamed package removed)