### PR TITLE
Add 'contents: write' permission to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
I suspect this will fix the git tagging issue reported in https://github.com/devcontainers/features/issues/1122