### PR TITLE
[git] Git subtree install option

### DIFF
--- a/src/git/devcontainer-feature.json
+++ b/src/git/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "git",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "name": "Git (from source)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/git",
     "description": "Install an up-to-date version of Git, built from source as needed. Useful for when you want the latest and greatest features. Auto-detects latest stable version and installs needed dependencies.",

--- a/src/git/devcontainer-feature.json
+++ b/src/git/devcontainer-feature.json
@@ -19,6 +19,11 @@
             "type": "boolean",
             "default": true,
             "description": "Install from PPA if available (only supported for Ubuntu distributions)"
+        },
+        "installSubtree": {
+            "type": "boolean",
+            "default": false,
+            "description": "Install git/contrib/subtree"
         }
     },
     "installsAfter": [

--- a/src/git/install.sh
+++ b/src/git/install.sh
@@ -9,6 +9,7 @@
 
 GIT_VERSION=${VERSION} # 'system' checks the base image first, else installs 'latest'
 USE_PPA_IF_AVAILABLE=${PPA}
+INSTALL_SUBTREE="${INSTALLSUBTREE:-"true"}"
 
 GIT_CORE_PPA_ARCHIVE_GPG_KEY=E1DD270288B4E6030699E45FA1715D88E1DF1F24
 
@@ -309,6 +310,11 @@ if [ "${ADJUSTED_ID}" = "alpine" ]; then
     git_options+=("NO_GETTEXT=YesPlease")
 fi
 make -s "${git_options[@]}" all && make -s "${git_options[@]}" install 2>&1
+if [[ $INSTALL_SUBTREE = "true" ]]; then
+    cd contrib/subtree/
+    make && make install && make install-doc && cp git-subtree ../.. 2>&1
+    cd ../../
+fi
 rm -rf /tmp/git-${GIT_VERSION}
 clean_up
 echo "Done!"


### PR DESCRIPTION
This PR enhances the existing git feature to install git/contrib/subtree by specifying to do so in the options.
```
    "options": {
        "version": {
            "type": "string",
            "proposals": [
                "latest",
                "system",
                "os-provided"
            ],
            "default": "os-provided",
            "description": "Select or enter a Git version."
        },
        "ppa": {
            "type": "boolean",
            "default": true,
            "description": "Install from PPA if available (only supported for Ubuntu distributions)"
        },
        "installSubtree": {
            "type": "boolean",
            "default": false,
            "description": "Install git/contrib/subtree"
        }
    },
```