### PR TITLE
[common-utils] - append shell history functionality - #1026

### DIFF
--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -64,6 +64,18 @@
             "type": "boolean",
             "default": false,
             "description": "Add packages from non-free Debian repository? (Debian only)"
+        },
+        "allowShellHistory": {
+            "type": "boolean",
+            "default": false,
+            "description": "Preserve shell history across dev container instances? (Currently supports bash, zsh, and fish)"
         }
-    }
+    },
+    "mounts": [
+        {
+            "source": "${devcontainerId}-shellhistory",
+            "target": "/dc/shellhistory",
+            "type": "volume"
+        }
+    ]
 }

--- a/test/common-utils/allow_shell_history.sh
+++ b/test/common-utils/allow_shell_history.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "default-shell-is-zsh" bash -c "getent passwd $(whoami) | awk -F: '{ print $7 }' | grep '/bin/zsh'"
+# check it overrides the ~/.zshrc with default dev containers template
+check "default-zshrc-is-dev-container-template" bash -c "cat ~/.zshrc | grep ZSH_THEME | grep devcontainers"
+check "zsh-path-contains-local-bin" zsh -l -c "echo $PATH | grep '/home/devcontainer/.local/bin'"
+
+check "Ensure .zprofile is owned by remoteUser" bash -c "stat -c '%U' /home/devcontainer/.zprofile | grep devcontainer"
+
+# Report result
+reportResults

--- a/test/common-utils/scenarios.json
+++ b/test/common-utils/scenarios.json
@@ -292,5 +292,15 @@
         "features": {
             "common-utils": {}
         }
+    },
+    "allow_shell_history": {
+        "image": "debian:bookworm",
+        "features": {
+            "common-utils": {
+                "installZsh": true,
+                "configureZshAsDefaultShell": true,
+                "allowShellHistory": true
+            }
+        }
     }
 }


### PR DESCRIPTION
Ref: #1026 

**Feature**
* Common-Utils

**Description**
* In response to #1026 have appended shell history functionality to `common-utils` feature as a configurable option

**_changelog_**
* Have added changes to `devcontainer-feature.json` file, added boolean option `allowShellHistory` and mounts as a configurable option
* Have added changes to `main.sh` in `common-utils` features src 
* Have added to `scenarios` to test this new feature
* Have added test cases in `allow_shell_history.sh` file

**Checklist**
- [x] checked that applied changes work as expected 