### PR TITLE
[common-utils] Fix group creation if a group with the given id already it exists

### DIFF
--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "common-utils",
-    "version": "2.5.2",
+    "version": "2.5.3",
     "name": "Common Utilities",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/common-utils",
     "description": "Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.",

--- a/test/common-utils/group-already-exists.sh
+++ b/test/common-utils/group-already-exists.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+. /etc/os-release
+check "non-root user" test "$(whoami)" = "devcontainer"
+check "group name is adm" test "$(id -gn)" = "adm"
+
+# Report result
+reportResults

--- a/test/common-utils/scenarios.json
+++ b/test/common-utils/scenarios.json
@@ -152,6 +152,16 @@
             "common-utils": {}
         }
     },
+    "group-already-exists": {
+        "image": "alpine",
+        "remoteUser": "devcontainer",
+        "features": {
+            "common-utils": {
+                "userUid": "1000",
+                "userGid": "4"
+            }
+        }
+    },
     "already-run": {
         "image": "mcr.microsoft.com/devcontainers/base:jammy",
         "features": {


### PR DESCRIPTION
On my computer I have user id 501 and group id 20 which I want to preserve within the container.

However, that group id often already exists in a lot of containers.
Container creation fails when using common-utils and setting the `userGid` to the id of an already existing group, because the current implementation just tries to add the group right away.

This PR adds functionality to detect whether a group with the given id already exists and handles it accordingly.