### PR TITLE
[common-utils] Fixes issue installing libssl3 on debian unstable

### DIFF
--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -81,8 +81,13 @@ install_debian_packages() {
         fi
 
         # Include libssl3 if available
-        if [[ ! -z $(apt-cache --names-only search ^libssl3$) ]]; then
-            package_list="${package_list} libssl3"
+        if [[ ! -z $(apt-cache --names-only search ^libssl3) ]]; then
+            # Test if the t64 package is available, prefer that to the non-64 bit package
+            if [[ ! -z $(apt-cache --names-only search ^libssl3t64$) ]]; then
+                package_list="${package_list} libssl3t64"
+            elif [[ ! -z $(apt-cache --names-only search ^libssl3$) ]]; then
+                package_list="${package_list} libssl3"
+            fi
         fi
 
         # Include appropriate version of libssl1.0.x if available


### PR DESCRIPTION
Debian unstable has `libssl3t64` installed, which conflicts with `libssl3` and causes image creation to fail.

Added a test to pick libssl3t64 if available, falls back to libssl3 if not.

Some thoughts:

- Nesting `if`s inside of the `^libssl3` test is unnecessary, but felt good for grouping the selection logic together.
- The `elif` fallback to `libssl3` is likewise overly verbose, but I included it for readability. Changing to `else` should have the same outcome.