### PR TITLE
Add support for sshd in Fedora

### DIFF
--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -67,7 +67,7 @@ jobs:
       matrix:
         features:
           ["common-utils", "git", "go", "java", "node", "python", "sshd"]
-        baseImage: ["fedora:40", "fedora:41", "alpine:3"]
+        baseImage: ["fedora:40", "fedora:41"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -11,7 +11,8 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        features: [
+        features:
+          [
             "anaconda",
             "aws-cli",
             "azure-cli",
@@ -39,7 +40,7 @@ jobs:
             "sshd",
             "terraform",
             "nix",
-        ]
+          ]
         baseImage:
           [
             "ubuntu:focal",
@@ -48,8 +49,25 @@ jobs:
             "debian:12",
             "mcr.microsoft.com/devcontainers/base:ubuntu",
             "mcr.microsoft.com/devcontainers/base:debian",
-            "mcr.microsoft.com/devcontainers/base:noble"
+            "mcr.microsoft.com/devcontainers/base:noble",
           ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Install latest devcontainer CLI"
+        run: npm install -g @devcontainers/cli
+
+      - name: "Generating tests for '${{ matrix.features }}' against '${{ matrix.baseImage }}'"
+        run: devcontainer features test  --skip-scenarios -f ${{ matrix.features }} -i ${{ matrix.baseImage }} .
+
+  test-non-debian:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        features:
+          ["common-utils", "git", "go", "java", "node", "python", "sshd"]
+        baseImage: ["fedora:40", "fedora:41", "alpine:3"]
     steps:
       - uses: actions/checkout@v4
 
@@ -64,7 +82,8 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        features: [
+        features:
+          [
             "anaconda",
             "aws-cli",
             "azure-cli",
@@ -92,7 +111,7 @@ jobs:
             "sshd",
             "terraform",
             "nix",
-        ]
+          ]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -55,7 +55,7 @@ jobs:
             "debian:12",
             "mcr.microsoft.com/devcontainers/base:ubuntu",
             "mcr.microsoft.com/devcontainers/base:debian",
-            "mcr.microsoft.com/devcontainers/base:noble"
+            "mcr.microsoft.com/devcontainers/base:noble",
           ]
     steps:
       - uses: actions/checkout@v4
@@ -66,6 +66,39 @@ jobs:
       - name: "Generating tests for '${{ matrix.features }}' against '${{ matrix.baseImage }}'"
         run: devcontainer features test  --skip-scenarios -f ${{ matrix.features }} -i ${{ matrix.baseImage }} .
 
+  detect-changes-non-debian:
+    runs-on: ubuntu-latest
+    outputs:
+      features: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            common-utils: ./**/common-utils/**
+            git: ./**/git/**
+            go: ./**/go/**
+            java: ./**/java/**
+            node: ./**/node/**
+            python: ./**/python/**
+            sshd: ./**/sshd/**
+
+  test-non-debian:
+    needs: [detect-changes-non-debian]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        features: ${{ fromJSON(needs.detect-changes-non-debian.outputs.features) }}
+        baseImage: ["fedora:40", "fedora:41", "alpine:3"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Install latest devcontainer CLI"
+        run: npm install -g @devcontainers/cli
+
+      - name: "Generating tests for '${{ matrix.features }}' against '${{ matrix.baseImage }}'"
+        run: devcontainer features test  --skip-scenarios -f ${{ matrix.features }} -i ${{ matrix.baseImage }} .
   test-scenarios:
     needs: [detect-changes]
     runs-on: devcontainer-image-builder-ubuntu

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -90,7 +90,7 @@ jobs:
     strategy:
       matrix:
         features: ${{ fromJSON(needs.detect-changes-non-debian.outputs.features) }}
-        baseImage: ["fedora:40", "fedora:41", "alpine:3"]
+        baseImage: ["fedora:40", "fedora:41"]
     steps:
       - uses: actions/checkout@v4
 

--- a/src/sshd/install.sh
+++ b/src/sshd/install.sh
@@ -156,7 +156,8 @@ case $ADJUSTED_ID in
         check_packages openssh lsof
         ;;
     rhel)
-        check_packages openssh-server openssh-clients lsof
+        check_packages openssh-server passwd openssh-clients lsof procps
+        ssh-keygen -A
         ;;
 esac
 
@@ -215,7 +216,8 @@ tee -a /usr/local/share/ssh-init.sh > /dev/null \
 if [ -f /etc/init.d/ssh ]; then
     sudoIf /etc/init.d/ssh start 2>&1 | sudoIf tee /tmp/sshd.log > /dev/null
 elif [ -f /usr/sbin/sshd ]; then
-    sudoIf /usr/sbin/sshd 2>&1 -E /tmp/sshd.log
+    echo "Starting OpenBSD Secure Shell server" "sshd" | sudoIf tee /tmp/sshd.log > /dev/null
+    sudoIf /usr/sbin/sshd 2>&1 | sudoIf tee -a /tmp/sshd.log > /dev/null
 else
     echo "Unable to find sshd to start"
     exit 1

--- a/src/sshd/install.sh
+++ b/src/sshd/install.sh
@@ -215,7 +215,7 @@ tee -a /usr/local/share/ssh-init.sh > /dev/null \
 if [ -f /etc/init.d/ssh ]; then
     sudoIf /etc/init.d/ssh start 2>&1 | sudoIf tee /tmp/sshd.log > /dev/null
 elif [ -f /usr/sbin/sshd ]; then
-    sudoIf /usr/sbin/sshd 2>&1 | sudoIf tee /tmp/sshd.log > /dev/null
+    sudoIf /usr/sbin/sshd 2>&1 -E /tmp/sshd.log
 else
     echo "Unable to find sshd to start"
     exit 1

--- a/src/sshd/install.sh
+++ b/src/sshd/install.sh
@@ -16,13 +16,65 @@ NEW_PASSWORD="${NEW_PASSWORD:-"skip"}"
 
 set -e
 
-# Clean up
-rm -rf /var/lib/apt/lists/*
-
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
+
+# Bring in ID, ID_LIKE, VERSION_ID, VERSION_CODENAME
+. /etc/os-release
+# Get an adjusted ID independent of distro variants
+if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
+    ADJUSTED_ID="debian"
+elif [ "${ID}" = "alpine" ]; then
+    ADJUSTED_ID="alpine"
+elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"mariner"* ]]; then
+    ADJUSTED_ID="rhel"
+    VERSION_CODENAME="${ID}${VERSION_ID}"
+else
+    echo "Linux distro ${ID} not supported."
+    exit 1
+fi
+
+if [ "${ADJUSTED_ID}" = "rhel" ] && [ "${VERSION_CODENAME-}" = "centos7" ]; then
+    # As of 1 July 2024, mirrorlist.centos.org no longer exists.
+    # Update the repo files to reference vault.centos.org.
+    sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+fi
+
+if type apt-get > /dev/null 2>&1; then
+    INSTALL_CMD=apt-get
+elif type apk > /dev/null 2>&1; then
+    INSTALL_CMD=apk
+elif type microdnf > /dev/null 2>&1; then
+    INSTALL_CMD=microdnf
+elif type dnf > /dev/null 2>&1; then
+    INSTALL_CMD=dnf
+elif type yum > /dev/null 2>&1; then
+    INSTALL_CMD=yum
+else
+    echo "(Error) Unable to find a supported package manager."
+    exit 1
+fi
+
+# Clean up
+clean_up() {
+    case $ADJUSTED_ID in
+        debian)
+            rm -rf /var/lib/apt/lists/*
+            ;;
+        alpine)
+            rm -rf /var/cache/apk/*
+            ;;
+        rhel)
+            rm -rf /var/cache/dnf/*
+            rm -rf /var/cache/yum/*
+            ;;
+    esac
+}
+clean_up
 
 # Determine the appropriate non-root user
 if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
@@ -41,19 +93,54 @@ elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
     USERNAME=root
 fi
 
-apt_get_update()
-{
-    if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
-        echo "Running apt-get update..."
-        apt-get update -y
+pkg_mgr_update() {
+    if [ ${INSTALL_CMD} = "apt-get" ]; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            echo "Running apt-get update..."
+            ${INSTALL_CMD} update -y
+        fi
+    elif [ ${INSTALL_CMD} = "apk" ]; then
+        if [ "$(find /var/cache/apk/* | wc -l)" = "0" ]; then
+            echo "Running apk update..."
+            ${INSTALL_CMD} update
+        fi
+    elif [ ${INSTALL_CMD} = "dnf" ] || [ ${INSTALL_CMD} = "yum" ]; then
+        if [ "$(find /var/cache/${INSTALL_CMD}/* | wc -l)" = "0" ]; then
+            echo "Running ${INSTALL_CMD} check-update ..."
+            ${INSTALL_CMD} check-update
+        fi
     fi
 }
 
 # Checks if packages are installed and installs them if not
 check_packages() {
-    if ! dpkg -s "$@" > /dev/null 2>&1; then
-        apt_get_update
-        apt-get -y install --no-install-recommends "$@"
+    if [ ${INSTALL_CMD} = "apt-get" ]; then
+        if ! dpkg -s "$@" > /dev/null 2>&1; then
+            pkg_mgr_update
+            ${INSTALL_CMD} -y install --no-install-recommends "$@"
+        fi
+    elif [ ${INSTALL_CMD} = "apk" ]; then
+        ${INSTALL_CMD} add \
+            --no-cache \
+            "$@"
+    elif [ ${INSTALL_CMD} = "dnf" ] || [ ${INSTALL_CMD} = "yum" ]; then
+        _num_pkgs=$(echo "$@" | tr ' ' \\012 | wc -l)
+        _num_installed=$(${INSTALL_CMD} -C list installed "$@" | sed '1,/^Installed/d' | wc -l)
+        if [ ${_num_pkgs} != ${_num_installed} ]; then
+            pkg_mgr_update
+            ${INSTALL_CMD} -y install "$@"
+        fi
+    elif [ ${INSTALL_CMD} = "microdnf" ]; then
+        ${INSTALL_CMD} -y install \
+            --refresh \
+            --best \
+            --nodocs \
+            --noplugins \
+            --setopt=install_weak_deps=0 \
+            "$@"
+    else
+        echo "Linux distro ${ID} not supported."
+        exit 1
     fi
 }
 
@@ -61,7 +148,17 @@ check_packages() {
 export DEBIAN_FRONTEND=noninteractive
 
 # Install openssh-server openssh-client
-check_packages openssh-server openssh-client lsof
+case $ADJUSTED_ID in
+    debian)
+        check_packages openssh-server openssh-client lsof
+        ;;
+    alpine)
+        check_packages openssh lsof
+        ;;
+    rhel)
+        check_packages openssh-server openssh-clients lsof
+        ;;
+esac
 
 # Generate password if new password set to the word "random"
 if [ "${NEW_PASSWORD}" = "random" ]; then
@@ -115,7 +212,14 @@ tee -a /usr/local/share/ssh-init.sh > /dev/null \
 << 'EOF'
 
 # ** Start SSH server **
-sudoIf /etc/init.d/ssh start 2>&1 | sudoIf tee /tmp/sshd.log > /dev/null
+if [ -f /etc/init.d/ssh ]; then
+    sudoIf /etc/init.d/ssh start 2>&1 | sudoIf tee /tmp/sshd.log > /dev/null
+elif [ -f /usr/sbin/sshd ]; then
+    sudoIf /usr/sbin/sshd 2>&1 | sudoIf tee /tmp/sshd.log > /dev/null
+else
+    echo "Unable to find sshd to start"
+    exit 1
+fi
 
 set +e
 exec "$@"
@@ -134,6 +238,6 @@ if [ "${EMIT_PASSWORD}" = "true" ]; then
 fi
 
 # Clean up
-rm -rf /var/lib/apt/lists/*
+clean_up
 
 echo -e "\nForward port ${SSHD_PORT} to your local machine and run:\n\n  ssh -p ${SSHD_PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o GlobalKnownHostsFile=/dev/null ${USERNAME}@localhost\n"


### PR DESCRIPTION
This updates the sshd install to be similar to other features that work on RHEL and Fedora.

A few extra steps appear to be needed for Fedora:

- Manually generate host keys `ssh-keygen -A`
- Manually log the ssh service start (expected log messages come from the init.d ssh script which is not used/installed on Fedora)

Attempt at expanding tests to run on fedora:40/41 for packages that appear to support non-debian linux with assumptions tests should pass.