### PR TITLE
Codespace unable to start in Jupyter using python feature with option "installJupyterLab": true 

### DIFF
--- a/src/python/devcontainer-feature.json
+++ b/src/python/devcontainer-feature.json
@@ -67,7 +67,7 @@
     "PYTHON_PATH": "/usr/local/python/current",
     "PIPX_HOME": "/usr/local/py-utils",
     "PIPX_BIN_DIR": "/usr/local/py-utils/bin",
-    "PATH": "/usr/local/python/current/bin:/usr/local/py-utils/bin:${PATH}"
+    "PATH": "/usr/local/python/current/bin:/usr/local/py-utils/bin:/usr/local/jupyter:${PATH}"
   },
   "customizations": {
     "vscode": {

--- a/src/python/devcontainer-feature.json
+++ b/src/python/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "python",
-  "version": "1.6.5",
+  "version": "1.7.0",
   "name": "Python",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/python",
   "description": "Installs the provided version of Python, as well as PIPX, and other common Python utilities.  JupyterLab is conditionally installed with the python feature. Note: May require source code compilation.",
@@ -78,9 +78,9 @@
       ],
       "settings": {
         "python.defaultInterpreterPath": "/usr/local/python/current/bin/python",
-	      "[python]": {
-	        "editor.defaultFormatter": "ms-python.autopep8"
-	      }
+        "[python]": {
+          "editor.defaultFormatter": "ms-python.autopep8"
+        }
       }
     }
   },

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -926,6 +926,13 @@ if [ "${INSTALL_JUPYTERLAB}" = "true" ]; then
             # either string is not found, or file is not present
             # In either case take same action, note >> places at end of file
             echo "${REPLACE_STR}:${PATH}" >> ${SUDOERS_FILE}
+            JUPYTER_INPATH=/home/${USERNAME}/.local/bin
+            if [ ! -d "$JUPYTER_INPATH" ]; then
+                echo "Error: $JUPYTER_INPATH does not exist."
+                exit 1
+            fi
+            JUPYTER_PATH=/usr/local/jupyter
+            ln -s "$JUPYTER_INPATH" "$JUPYTER_PATH"
         fi
     fi
 

--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -912,28 +912,15 @@ if [ "${INSTALL_JUPYTERLAB}" = "true" ]; then
     install_user_package $INSTALL_UNDER_ROOT jupyterlab
     install_user_package $INSTALL_UNDER_ROOT jupyterlab-git
 
+    # Create a symlink to the JupyterLab binary for non root users
     if [ "$INSTALL_UNDER_ROOT" = false ]; then
-        # JupyterLab would have installed into /home/${USERNAME}/.local/bin
-        # Adding it to default path for Codespaces which use non-login shells
-        SUDOERS_FILE="/etc/sudoers.d/$USERNAME"
-        SEARCH_STR="Defaults secure_path="
-        REPLACE_STR="Defaults secure_path=/home/${USERNAME}/.local/bin"
-
-        if grep -qs ${SEARCH_STR} ${SUDOERS_FILE}; then
-            # string found and file is present
-            sed -i "s|${SEARCH_STR}|${REPLACE_STR}:|g" "${SUDOERS_FILE}"
-        else
-            # either string is not found, or file is not present
-            # In either case take same action, note >> places at end of file
-            echo "${REPLACE_STR}:${PATH}" >> ${SUDOERS_FILE}
-            JUPYTER_INPATH=/home/${USERNAME}/.local/bin
-            if [ ! -d "$JUPYTER_INPATH" ]; then
-                echo "Error: $JUPYTER_INPATH does not exist."
-                exit 1
-            fi
-            JUPYTER_PATH=/usr/local/jupyter
-            ln -s "$JUPYTER_INPATH" "$JUPYTER_PATH"
+        JUPYTER_INPATH=/home/${USERNAME}/.local/bin
+        if [ ! -d "$JUPYTER_INPATH" ]; then
+            echo "Error: $JUPYTER_INPATH does not exist."
+            exit 1
         fi
+        JUPYTER_PATH=/usr/local/jupyter
+        ln -s "$JUPYTER_INPATH" "$JUPYTER_PATH"
     fi
 
     # Configure JupyterLab if needed

--- a/test/python/install_jupyterlab.sh
+++ b/test/python/install_jupyterlab.sh
@@ -22,8 +22,8 @@ check "jupyterlab_git" grep jupyterlab_git <<< "$packages"
 # Check for correct JupyterLab configuration
 check "config" grep ".*.allow_origin = '*'" /home/vscode/.jupyter/jupyter_server_config.py
 
-# Check for PATH modification
-check "default path has jupyterlab" sudo grep "/home/${user}/.local/bin" /etc/sudoers.d/$user
+#check "default path has jupyterlab symlink"
+check "default path has jupyterlab" test -L "/usr/local/jupyter"
 
 # Report result
 reportResults

--- a/test/python/install_jupyterlab_existing_sudoers_file/Dockerfile
+++ b/test/python/install_jupyterlab_existing_sudoers_file/Dockerfile
@@ -1,5 +1,0 @@
-# Builds an image with a preconfigured SUDOERS file
-# Used to test the install script for JupyterLab which modifies this file
-FROM mcr.microsoft.com/devcontainers/base:focal
-
-COPY --chown=root sudoers.test /etc/sudoers.d/vscode

--- a/test/python/install_jupyterlab_existing_sudoers_file/sudoers.test
+++ b/test/python/install_jupyterlab_existing_sudoers_file/sudoers.test
@@ -1,2 +1,0 @@
-# Sudoers File for testing, after install script runs the Defaults secure_path should be appended to
-Defaults secure_path=/original_content_of_sudoers_file

--- a/test/python/scenarios.json
+++ b/test/python/scenarios.json
@@ -68,19 +68,6 @@
             }
         }
     },
-    "install_jupyterlab_existing_sudoers_file": {
-        "build": {
-            "dockerfile": "Dockerfile"
-        },
-        "remoteUser": "vscode",
-        "features": {
-            "python": {
-                "version": "latest",
-                "installJupyterlab": true,
-                "configureJupyterlabAllowOrigin": "*"
-            }
-        }
-    },
     "install_jupyterlab_rhel_family": {
         "image": "almalinux:8",
         "remoteUser": "vscode",


### PR DESCRIPTION
Issue https://github.com/devcontainers/features/issues/870
- For image mcr.microsoft.com/devcontainers/base:ubuntu

Issue https://github.com/github/codespaces/issues/19082 
- For image mcr.microsoft.com/devcontainers/go:1-1.23-bullseye

JupyterLab is not opening from codespace due to PATH variable difference for non interactive shell when jupyterlab is installed for non root user

**Feature Name**
 - Python

**Changelog**
- Created a symlink for installed path of jupyter and added it to devcontainer-features.json containerEnv PATH variable.
- Remove changes added in [PR - 887](https://github.com/devcontainers/features/pull/887) which earlier aimed to fixed the issue


**Checklist**
- [x] Check if jupyter command  is recognised from non interactive shell