### PR TITLE
Exclude unsupported image scenarios for Oryx

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -1,6 +1,6 @@
 name: "PR - Test Updated Features"
 on:
-  workflow_dispatch:
+  pull_request:
 
 jobs:
   detect-changes:


### PR DESCRIPTION
Oryx do not support Jammy
Images ubuntu:jammy and mcr.microsoft.com/devcontainers/base:ubuntu are of Jammy versions and Oryx will always fail for these images.

Pipeline configured to run on PR included these images by default.

Removed these images for oryx feature test. 