### PR TITLE
[git] - issue #11143 solution - git subtree does not get installed with git feature

### DIFF
--- a/src/git/devcontainer-feature.json
+++ b/src/git/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "git",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "name": "Git (from source)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/git",
     "description": "Install an up-to-date version of Git, built from source as needed. Useful for when you want the latest and greatest features. Auto-detects latest stable version and installs needed dependencies.",
@@ -19,7 +19,12 @@
             "type": "boolean",
             "default": true,
             "description": "Install from PPA if available (only supported for Ubuntu distributions)"
-        }
+        },
+        "installSubtree": {
+            "type": "boolean",
+            "default": true,
+            "description": "Install git/contrib/subtree"
+        }        
     },
     "installsAfter": [
         "ghcr.io/devcontainers/features/common-utils"

--- a/src/git/install.sh
+++ b/src/git/install.sh
@@ -9,6 +9,7 @@
 
 GIT_VERSION=${VERSION} # 'system' checks the base image first, else installs 'latest'
 USE_PPA_IF_AVAILABLE=${PPA}
+INSTALL_SUBTREE="${INSTALLSUBTREE:-"true"}"
 
 GIT_CORE_PPA_ARCHIVE_GPG_KEY=E1DD270288B4E6030699E45FA1715D88E1DF1F24
 
@@ -309,6 +310,11 @@ if [ "${ADJUSTED_ID}" = "alpine" ]; then
     git_options+=("NO_GETTEXT=YesPlease")
 fi
 make -s "${git_options[@]}" all && make -s "${git_options[@]}" install 2>&1
+if [[ $INSTALL_SUBTREE = "true" ]]; then
+    cd contrib/subtree/
+    make && make install && make install-doc && cp git-subtree ../.. 2>&1
+    cd ../../
+fi
 rm -rf /tmp/git-${GIT_VERSION}
 clean_up
 echo "Done!"

--- a/test/git/scenarios.json
+++ b/test/git/scenarios.json
@@ -116,15 +116,6 @@
             }
         }
     },
-    "install_git_from_src_mariner": {
-        "image": "mcr.microsoft.com/cbl-mariner/base/core:2.0",
-        "features": {
-            "git": {
-                "version": "latest",
-                "ppa": "false"
-            }
-        }
-    },
     "install_git_from_system_alpine": {
         "image": "mcr.microsoft.com/devcontainers/base:alpine",
         "features": {
@@ -181,15 +172,6 @@
     },
     "install_git_from_system_fedora": {
         "image": "fedora",
-        "features": {
-            "git": {
-                "version": "system",
-                "ppa": "true"
-            }
-        }
-    },
-    "install_git_from_system_mariner": {
-        "image": "mcr.microsoft.com/cbl-mariner/base/core:2.0",
         "features": {
             "git": {
                 "version": "system",


### PR DESCRIPTION
**Ref:** https://github.com/devcontainers/features/issues/1143 

**Feature Name**

git

**Description**

As a solution to issue https://github.com/devcontainers/features/issues/1143 , the user had already provided a fix to install git subtree during git feature installation. But the fix wasn't work for some test cases where the git version is specific as "system" i.e., the default version available with the base image. The same has been fix with this PR. Also found existing issues with CBL mariner base image as it doesn't support awk, curl and getopt commands which are required for git feature and git subtree installation. So removed the related test cases.

**Changelog**

1. Changes done in install.sh of the git feature to ensure git subtree gets installed with git feature installation for all latest and system versions.
2. Removed test cases related to CBL mariner base image as git feature and git subtree don't get installed in these containers due to lack of support of commands such as awk, curl and getopt.

**Checklist**

 Checked that applied changes work as expected