### PR TITLE
EOL Dotnet 6.0

### DIFF
--- a/src/dotnet/devcontainer-feature.json
+++ b/src/dotnet/devcontainer-feature.json
@@ -12,8 +12,7 @@
                 "lts",
                 "none",
                 "8.0",
-                "7.0",
-                "6.0"
+                "7.0"
             ],
             "default": "latest",
             "description": "Select or enter a .NET SDK version. Use 'latest' for the latest version, 'lts' for the latest LTS version, 'X.Y' or 'X.Y.Z' for a specific version."

--- a/test/dotnet/scenarios.json
+++ b/test/dotnet/scenarios.json
@@ -13,7 +13,7 @@
         "remoteUser": "vscode",
         "features": {
             "dotnet": {
-                "version": "3.1"
+                "version": "8.0"
             }
         }
     },
@@ -22,7 +22,7 @@
         "remoteUser": "vscode",
         "features": {
             "dotnet": {
-                "version": "5.0.3xx"
+                "version": "8.0.0xx"
             }
         }
     },
@@ -42,8 +42,7 @@
             "dotnet": {
                 "version": "8.0.100-preview.6.23330.14",
                 "additionalVersions": [
-                    "7.0",
-                    "6.0"
+                    "7.0"
                 ]
             }
         }


### PR DESCRIPTION
**Ref:** https://github.com/devcontainers/images/issues/90

**Feature Name**

dotnet

**Description**

Dotnet 6.0 has reached EOL and is no longer supported.

**Changelog**

1. Changes done in devcontainer-feature.json to remove dotnet 6.0 references.
2. Changes done in scnearios.json to remove dotnet 6.0 and older versions references.

**Checklist**

Checked that applied changes work as expected