### PR TITLE
Install Jupyterlab for root user

### DIFF
--- a/src/python/install.sh
+++ b/src/python/install.sh
@@ -941,6 +941,9 @@ if [ "${INSTALL_JUPYTERLAB}" = "true" ]; then
 
         add_user_jupyter_config $CONFIG_DIR $CONFIG_FILE "c.ServerApp.allow_origin = '${CONFIGURE_JUPYTERLAB_ALLOW_ORIGIN}'"
         add_user_jupyter_config $CONFIG_DIR $CONFIG_FILE "c.NotebookApp.allow_origin = '${CONFIGURE_JUPYTERLAB_ALLOW_ORIGIN}'"
+        if [ "$INSTALL_UNDER_ROOT" = true ]; then
+            add_user_jupyter_config $CONFIG_DIR $CONFIG_FILE "c.ServerApp.allow_root = True"
+        fi
     fi
 fi
 


### PR DESCRIPTION
JupyterLab is not opening from codespace when jupyterlab is installed for root user as it requires --allow-root. 
Error as Running as root is not recommended. Use --allow-root to bypass in interactive shell

**Feature Name**

- Python

**Changelog**

- Setting the jupyter configuration with ServerApp.allow_root = True