### PR TITLE
Optionally disable GPG check in terraform feature

### DIFF
--- a/src/terraform/README.md
+++ b/src/terraform/README.md
@@ -22,6 +22,7 @@ Installs the Terraform CLI and optionally TFLint and Terragrunt. Auto-detects la
 | installTFsec | Install tfsec, a tool to spot potential misconfigurations for your terraform code | boolean | false |
 | installTerraformDocs | Install terraform-docs, a utility to generate documentation from Terraform modules | boolean | false |
 | httpProxy | Connect to a keyserver using a proxy by configuring this option | string | - |
+| disableGpgCheck | Disable GPG check for Terraform installation | boolean | false |
 
 ## Customizations
 

--- a/src/terraform/devcontainer-feature.json
+++ b/src/terraform/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "terraform",
-    "version": "1.3.9",
+    "version": "1.3.10",
     "name": "Terraform, tflint, and TFGrunt",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/terraform",
     "description": "Installs the Terraform CLI and optionally TFLint and Terragrunt. Auto-detects latest version and installs needed dependencies.",

--- a/src/terraform/devcontainer-feature.json
+++ b/src/terraform/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "terraform",
-    "version": "1.3.8",
+    "version": "1.3.9",
     "name": "Terraform, tflint, and TFGrunt",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/terraform",
     "description": "Installs the Terraform CLI and optionally TFLint and Terragrunt. Auto-detects latest version and installs needed dependencies.",
@@ -54,6 +54,11 @@
             "type": "string",
             "default": "",
             "description": "Connect to a keyserver using a proxy by configuring this option"
+        },
+        "disableGpgCheck": {
+            "type": "boolean",
+            "description": "Optionally disable GPG check for Terraform installation",
+            "default": false
         }
     },
     "customizations": {

--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -379,6 +379,7 @@ if [ "${TERRAFORM_SHA256}" != "dev-mode" ]; then
         gpg --verify terraform_SHA256SUMS.sig terraform_SHA256SUMS
     else
         echo "Skipping GPG check for Terraform."
+        curl -sSL -o terraform_SHA256SUMS https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS
     fi
 else
     echo "${TERRAFORM_SHA256} *${terraform_filename}" > terraform_SHA256SUMS
@@ -431,6 +432,8 @@ if [ "${TFLINT_VERSION}" != "none" ]; then
                 fi
             else
                 echo "Skipping GPG check for TFLint."
+                curl -sSL -o tflint_checksums.txt https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/checksums.txt
+                sha256sum --ignore-missing -c tflint_checksums.txt
             fi
         fi
     fi
@@ -480,6 +483,8 @@ if [ "${INSTALL_SENTINEL}" = "true" ]; then
             shasum -a 256 --ignore-missing -c sentinel_checksums.txt
         else
             echo "Skipping GPG check for Sentinel."
+            curl -sSL -o sentinel_checksums.txt ${sentinel_releases_url}/${SENTINEL_VERSION}/sentinel_${SENTINEL_VERSION}_SHA256SUMS
+            sha256sum --ignore-missing -c sentinel_checksums.txt
         fi
     else
         echo "${SENTINEL_SHA256} *${SENTINEL_FILENAME}" >sentinel_checksums.txt


### PR DESCRIPTION
Allow GPG check in terraform feature to be skipped. This change will mitigate an error where the gpg check can not reach the target key server when Twingate client is running. The existing mitigation feature for setting `httpProxy` cannot be used in this scenario as Twingate does not offer a traditional proxy endpoint