### PR TITLE
[docker-outside-of-docker] - Correction in fetching previous version from github api url

### DIFF
--- a/src/docker-outside-of-docker/devcontainer-feature.json
+++ b/src/docker-outside-of-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-outside-of-docker",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "name": "Docker (docker-outside-of-docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker",
     "description": "Re-use the host docker socket, adding the Docker CLI to a container. Feature invokes a script to enable using a forwarded Docker socket within a container to run Docker commands.",

--- a/src/docker-outside-of-docker/install.sh
+++ b/src/docker-outside-of-docker/install.sh
@@ -363,9 +363,6 @@ if [ "${DOCKER_DASH_COMPOSE_VERSION}" != "none" ]; then
         echo "(*) Installing docker-compose ${compose_version}..."
         curl -fsSL "https://github.com/docker/compose/releases/download/v${compose_version}/docker-compose-linux-${target_compose_arch}" -o ${docker_compose_path} || {
             install_compose_fallback "$docker_compose_url" "$compose_version" "$target_compose_arch" "$docker_compose_path"
-            if [ $? -ne 0 ]; then
-                 echo -e "Error: Failed to install docker-compose v${compose_version}"
-            fi
         }
         chmod +x ${docker_compose_path}
 

--- a/src/docker-outside-of-docker/install.sh
+++ b/src/docker-outside-of-docker/install.sh
@@ -170,7 +170,7 @@ get_previous_version() {
         version=$(echo "$output" | jq -r '.[1].tag_name')
         declare -g ${variable_name}="${version#v}"
     fi  
-    echo "${variable_name}=${!variable_name}"
+    echo "${variable_name}=${!variable_name}" 
 }
 
 get_github_api_repo_url() {

--- a/src/docker-outside-of-docker/install.sh
+++ b/src/docker-outside-of-docker/install.sh
@@ -156,16 +156,17 @@ get_previous_version() {
     output=$(curl -s "$repo_url");
 
     check_packages jq
-
-    message=$(echo "$output" | jq -r '.message')
     
-    if [[ $message == "API rate limit exceeded"* ]]; then
-        echo -e "\nAn attempt to find latest version using GitHub Api Failed... \nReason: ${message}"
-        echo -e "\nAttempting to find latest version using GitHub tags."
-        find_prev_version_from_git_tags prev_version "$url" "tags/v"
-        declare -g ${variable_name}="${prev_version}"
-    else 
-        echo -e "\nAttempting to find latest version using GitHub Api."
+    if echo "$output" | jq -e 'type == "object"' > /dev/null; then
+        message=$(echo "$output" | jq -r '.message')
+        if [[ $message == "API rate limit exceeded"* ]]; then
+            echo -e "\nAn attempt to find previous to latest version using GitHub Api Failed... \nReason: ${message}"
+            echo -e "\nAttempting to find previous to latest version using GitHub tags."
+            find_prev_version_from_git_tags prev_version "$url" "tags/v"
+            declare -g ${variable_name}="${prev_version}"
+        fi
+    elif echo "$output" | jq -e 'type == "array"' > /dev/null; then
+        echo -e "\nAttempting to find previous version using GitHub Api."
         version=$(echo "$output" | jq -r '.[1].tag_name')
         declare -g ${variable_name}="${version#v}"
     fi  

--- a/src/docker-outside-of-docker/install.sh
+++ b/src/docker-outside-of-docker/install.sh
@@ -362,10 +362,9 @@ if [ "${DOCKER_DASH_COMPOSE_VERSION}" != "none" ]; then
         find_version_from_git_tags compose_version "$docker_compose_url" "tags/v"
         echo "(*) Installing docker-compose ${compose_version}..."
         curl -fsSL "https://github.com/docker/compose/releases/download/v${compose_version}/docker-compose-linux-${target_compose_arch}" -o ${docker_compose_path} || {
-            if [[ $DOCKER_DASH_COMPOSE_VERSION == "latest" ]]; then 
-                install_compose_fallback "$docker_compose_url" "$compose_version" "$target_compose_arch" "$docker_compose_path"
-            else
-                echo -e "Error: Failed to install docker-compose v${compose_version}" 
+            install_compose_fallback "$docker_compose_url" "$compose_version" "$target_compose_arch" "$docker_compose_path"
+            if [ $? -ne 0 ]; then
+                 echo -e "Error: "Failed to install docker-compose v${compose_version}"
             fi
         }
         chmod +x ${docker_compose_path}

--- a/src/docker-outside-of-docker/install.sh
+++ b/src/docker-outside-of-docker/install.sh
@@ -364,7 +364,7 @@ if [ "${DOCKER_DASH_COMPOSE_VERSION}" != "none" ]; then
         curl -fsSL "https://github.com/docker/compose/releases/download/v${compose_version}/docker-compose-linux-${target_compose_arch}" -o ${docker_compose_path} || {
             install_compose_fallback "$docker_compose_url" "$compose_version" "$target_compose_arch" "$docker_compose_path"
             if [ $? -ne 0 ]; then
-                 echo -e "Error: "Failed to install docker-compose v${compose_version}"
+                 echo -e "Error: Failed to install docker-compose v${compose_version}"
             fi
         }
         chmod +x ${docker_compose_path}

--- a/src/docker-outside-of-docker/install.sh
+++ b/src/docker-outside-of-docker/install.sh
@@ -174,7 +174,7 @@ get_previous_version() {
 
 get_github_api_repo_url() {
     local url=$1
-    echo "${url/https:\/\/github.com/https:\/\/api.github.com\/repos}/releases/latest"
+    echo "${url/https:\/\/github.com/https:\/\/api.github.com\/repos}/releases"
 }
 
 install_compose_switch_fallback() {

--- a/src/docker-outside-of-docker/install.sh
+++ b/src/docker-outside-of-docker/install.sh
@@ -166,7 +166,7 @@ get_previous_version() {
         declare -g ${variable_name}="${prev_version}"
     else 
         echo -e "\nAttempting to find latest version using GitHub Api."
-        version=$(echo "$output" | jq -r '.tag_name')
+        version=$(echo "$output" | jq -r '.[1].tag_name')
         declare -g ${variable_name}="${version#v}"
     fi  
     echo "${variable_name}=${!variable_name}"

--- a/test/docker-outside-of-docker/docker_build_compose_fallback.sh
+++ b/test/docker-outside-of-docker/docker_build_compose_fallback.sh
@@ -126,7 +126,7 @@ get_previous_version() {
         declare -g ${variable_name}="${prev_version}"
     else 
         echo -e "\nAttempting to find latest version using GitHub Api."
-        version=$(echo "$output" | jq -r '.tag_name')
+        version=$(echo "$output" | jq -r '.[1].tag_name')
         declare -g ${variable_name}="${version#v}"
     fi  
     echo "${variable_name}=${!variable_name}"

--- a/test/docker-outside-of-docker/docker_build_compose_fallback.sh
+++ b/test/docker-outside-of-docker/docker_build_compose_fallback.sh
@@ -156,9 +156,9 @@ install_compose-switch_as_docker-compose() {
 echo -e "\n👉 Trying to install compose-switch as docker-compose using mode 1 ( find_prev_version_from_git_tags method )";
 install_compose-switch_as_docker-compose "mode1"
 check "installs compose-switch as docker-compose mode 1" bash -c "[[ -f /usr/local/bin/docker-compose ]]"
-check "docker-compose switch version" bash -c "docker compose-switch --version | awk '{print $NF}'"
+check "docker-compose version" bash -c "docker-compose version"
 
 echo -e "\n👉 Trying to install compose-switch as docker-compose using mode 2 ( GitHub Api )";
 install_compose-switch_as_docker-compose "mode2"
 check "installs compose-switch as docker-compose mode 2" bash -c "[[ -f /usr/local/bin/docker-compose ]]"
-check "docker-compose switch version" bash -c "docker compose-switch --version | awk '{print $NF}'"
+check "docker-compose version" bash -c "docker-compose version"

--- a/test/docker-outside-of-docker/docker_build_compose_fallback.sh
+++ b/test/docker-outside-of-docker/docker_build_compose_fallback.sh
@@ -156,7 +156,9 @@ install_compose-switch_as_docker-compose() {
 echo -e "\n👉 Trying to install compose-switch as docker-compose using mode 1 ( find_prev_version_from_git_tags method )";
 install_compose-switch_as_docker-compose "mode1"
 check "installs compose-switch as docker-compose mode 1" bash -c "[[ -f /usr/local/bin/docker-compose ]]"
+check "docker-compose switch version" bash -c "docker compose version"
 
 echo -e "\n👉 Trying to install compose-switch as docker-compose using mode 2 ( GitHub Api )";
 install_compose-switch_as_docker-compose "mode2"
 check "installs compose-switch as docker-compose mode 2" bash -c "[[ -f /usr/local/bin/docker-compose ]]"
+check "docker-compose switch version" bash -c "docker compose version"

--- a/test/docker-outside-of-docker/docker_build_compose_fallback.sh
+++ b/test/docker-outside-of-docker/docker_build_compose_fallback.sh
@@ -156,9 +156,9 @@ install_compose-switch_as_docker-compose() {
 echo -e "\n👉 Trying to install compose-switch as docker-compose using mode 1 ( find_prev_version_from_git_tags method )";
 install_compose-switch_as_docker-compose "mode1"
 check "installs compose-switch as docker-compose mode 1" bash -c "[[ -f /usr/local/bin/docker-compose ]]"
-check "docker-compose switch version" bash -c "docker compose version"
+check "docker-compose switch version" bash -c "docker-compose --version"
 
 echo -e "\n👉 Trying to install compose-switch as docker-compose using mode 2 ( GitHub Api )";
 install_compose-switch_as_docker-compose "mode2"
 check "installs compose-switch as docker-compose mode 2" bash -c "[[ -f /usr/local/bin/docker-compose ]]"
-check "docker-compose switch version" bash -c "docker compose version"
+check "docker-compose switch version" bash -c "docker-compose --version"

--- a/test/docker-outside-of-docker/docker_build_compose_fallback.sh
+++ b/test/docker-outside-of-docker/docker_build_compose_fallback.sh
@@ -156,9 +156,9 @@ install_compose-switch_as_docker-compose() {
 echo -e "\n👉 Trying to install compose-switch as docker-compose using mode 1 ( find_prev_version_from_git_tags method )";
 install_compose-switch_as_docker-compose "mode1"
 check "installs compose-switch as docker-compose mode 1" bash -c "[[ -f /usr/local/bin/docker-compose ]]"
-check "docker-compose switch version" bash -c "docker compose-switch --version"
+check "docker-compose switch version" bash -c "docker compose-switch --version | awk '{print $NF}'"
 
 echo -e "\n👉 Trying to install compose-switch as docker-compose using mode 2 ( GitHub Api )";
 install_compose-switch_as_docker-compose "mode2"
 check "installs compose-switch as docker-compose mode 2" bash -c "[[ -f /usr/local/bin/docker-compose ]]"
-check "docker-compose switch version" bash -c "docker compose-switch --version"
+check "docker-compose switch version" bash -c "docker compose-switch --version | awk '{print $NF}'"

--- a/test/docker-outside-of-docker/docker_build_compose_fallback.sh
+++ b/test/docker-outside-of-docker/docker_build_compose_fallback.sh
@@ -134,7 +134,7 @@ get_previous_version() {
 
 get_github_api_repo_url() {
     local url=$1
-    echo "${url/https:\/\/github.com/https:\/\/api.github.com\/repos}/releases/latest"
+    echo "${url/https:\/\/github.com/https:\/\/api.github.com\/repos}/releases"
 }
 
 install_compose_switch_fallback() {

--- a/test/docker-outside-of-docker/docker_build_compose_fallback.sh
+++ b/test/docker-outside-of-docker/docker_build_compose_fallback.sh
@@ -156,9 +156,9 @@ install_compose-switch_as_docker-compose() {
 echo -e "\n👉 Trying to install compose-switch as docker-compose using mode 1 ( find_prev_version_from_git_tags method )";
 install_compose-switch_as_docker-compose "mode1"
 check "installs compose-switch as docker-compose mode 1" bash -c "[[ -f /usr/local/bin/docker-compose ]]"
-check "docker-compose switch version" bash -c "docker-compose --version"
+check "docker-compose switch version" bash -c "docker compose-switch --version"
 
 echo -e "\n👉 Trying to install compose-switch as docker-compose using mode 2 ( GitHub Api )";
 install_compose-switch_as_docker-compose "mode2"
 check "installs compose-switch as docker-compose mode 2" bash -c "[[ -f /usr/local/bin/docker-compose ]]"
-check "docker-compose switch version" bash -c "docker-compose --version"
+check "docker-compose switch version" bash -c "docker compose-switch --version"


### PR DESCRIPTION
**Feature Name**
* `Docker-Outside-Of-Docker`

**Description of Changes**
* Correcting the fallback method for `Docker-outside-of-Docker` Feature as previously it was fetching the `latest` version in a plight to fetch the `previous` version from the `GitHub API URL`, which was misleading and therefore now fetching the second element's `tag_name` property's value in `releases` array json for correcting the above

**_Changelog_**
* Made changes to `install.sh` file
* Made changes to `docker_build_compose_fallback.sh` file in test case scenarios implementations of docker-outside-of-docker

**Checklist**
* [x] Checked that applied changes work as expected