### PR TITLE
proposed feature for .net aspire

### DIFF
--- a/src/dotnetaspire/README.md
+++ b/src/dotnetaspire/README.md
@@ -1,0 +1,64 @@
+
+# .NET Aspire (dotnetaspire)
+
+This Feature installs .NET Aspire and if necessary the .NET (dotnet) that it depends on. Options are provided to choose a different version or additional versions.
+
+## OS Support
+
+This Feature should work on recent versions of Debian/Ubuntu-based distributions that support .NET and have the `apt` package manager installed
+
+`bash` is required to execute the `install.sh` script.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/devcontainers/features/dotnetaspire:1": {}
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| version | .NET Aspire version. Use 'latest' for the latest supported version, '9.0' for the 9.0 version, 'X.Y' or 'X.Y.Z' for a specific version, or 'latest-daily' for the latest unsupported build. | string | latest |
+
+## Customizations
+
+### VS Code Extensions
+
+- `ms-dotnettools.csharp`
+
+## Configuration examples
+
+Installing only the latest .NET Aspire version (the default).
+
+``` jsonc
+"features": {
+    "ghcr.io/devcontainers/features/dotnetaspire:1": "latest" // or "" or {}
+}
+```
+
+Installing .NET Aspire version 9.0.
+
+``` jsonc
+"features": {
+    "ghcr.io/devcontainers/features/dotnetaspire:1": "9.0" // or "" or {}
+}
+```
+
+Installing the latest .NET Aspire unsupported build.
+
+``` jsonc
+"features": {
+    "ghcr.io/devcontainers/features/dotnetaspire:1": "latest-daily" // or "" or {}
+}
+```
+
+
+## OS Support
+
+This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
+
+`bash` is required to execute the `install.sh` script.
+

--- a/src/dotnetaspire/README.md
+++ b/src/dotnetaspire/README.md
@@ -27,7 +27,7 @@ This Feature should work on recent versions of Debian/Ubuntu-based distributions
 
 ### VS Code Extensions
 
-- `ms-dotnettools.csharp`
+- `ms-dotnettools.csdevkit`
 
 ## Configuration examples
 

--- a/src/dotnetaspire/devcontainer-feature.json
+++ b/src/dotnetaspire/devcontainer-feature.json
@@ -16,6 +16,23 @@
             "description": "Select or enter a .NET Aspire version. Use 'latest' for the latest supported version, '9.0' for the 9.0 version, 'X.Y' or 'X.Y.Z' for a specific version, or 'latest-daily' for the latest unsupported build."
         },
     },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-dotnettools.csdevkit",
+                "ms-azuretools.vscode-bicep",
+                "GitHub.copilot-chat",
+                "GitHub.copilot"
+            ],
+            "settings": {
+                "remote.autoForwardPorts": true,
+                "remote.autoForwardPortsSource": "hybrid",
+                "remote.otherPortsAttributes": {
+                    "onAutoForward": "ignore"
+                }
+            }
+        }
+    },
     "dependsOn": {
         "ghcr.io/devcontainers/features/dotnet": {
             "version": "8.0",

--- a/src/dotnetaspire/devcontainer-feature.json
+++ b/src/dotnetaspire/devcontainer-feature.json
@@ -17,8 +17,9 @@
         },
     },
     "dependsOn": {
-        // how to ensure the correct .NET version is installed? seems it would require using onCreateCommand
-        // to write out a temporary devcontainer.json. For now, it's fixed at 9.0
-        "ghcr.io/devcontainers/features/dotnet": "9.0"
+        "ghcr.io/devcontainers/features/dotnet": {
+            "version": "8.0",
+            "additionalVersions": "9.0"
+        }
     }
 }

--- a/src/dotnetaspire/devcontainer-feature.json
+++ b/src/dotnetaspire/devcontainer-feature.json
@@ -9,7 +9,7 @@
             "type": "string",
             "proposals": [
                 "latest daily",
-                "latest", // currently 9.0, when 9.1 ships, implement both "9.1" and "latest". 
+                "latest",
                 "9.0",
             ],
             "default": "9.0",

--- a/src/dotnetaspire/devcontainer-feature.json
+++ b/src/dotnetaspire/devcontainer-feature.json
@@ -1,0 +1,24 @@
+{
+    "id": "dotnetaspire",
+    "version": "1.0.0",
+    "name": ".NET Aspire",
+    "documentationURL": "https://github.com/devcontainers/features/tree/main/src/dotnetaspire",
+    "description": "Installs .NET Aspire. See https://aka.ms/dotnetaspire",
+    "options": {
+        "version": {
+            "type": "string",
+            "proposals": [
+                "latest daily",
+                "latest", // currently 9.0, when 9.1 ships, implement both "9.1" and "latest". 
+                "9.0",
+            ],
+            "default": "9.0",
+            "description": "Select or enter a .NET Aspire version. Use 'latest' for the latest supported version, '9.0' for the 9.0 version, 'X.Y' or 'X.Y.Z' for a specific version, or 'latest-daily' for the latest unsupported build."
+        },
+    },
+    "dependsOn": {
+        // how to ensure the correct .NET version is installed? seems it would require using onCreateCommand
+        // to write out a temporary devcontainer.json. For now, it's fixed at 9.0
+        "ghcr.io/devcontainers/features/dotnet": "9.0"
+    }
+}

--- a/src/dotnetaspire/install.sh
+++ b/src/dotnetaspire/install.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/devcontainers/features/tree/main/src/dotnet
+# Maintainer: The .NET Aspire team at https://github.com/dotnet/aspire
+
+set -e
+
+# default to latest if not specified
+VERSION="${VERSION:-"latest"}"
+
+if [[ ! $VERSION =~ ^(9\.0|latest|latest-daily)$ ]]; then
+    echo "Error: VERSION must be either '9.0', '9.0.0, 'latest', or 'latest-daily' not: '$VERSION'."
+    exit 1
+fi
+
+if [[ $VERSION =~ ^(9\.0|9\.0\.0|latest)$ ]]; then
+    VERSION="9.0.0"
+fi
+
+echo "Activating feature '.NET Aspire' version: $VERSION"
+
+# Before .NET Aspire 9.0 install required `dotnet workload`: this is no longer necessary, as Aspire is 
+# installed when restoring an Aspireprojects. It's only necessary to install the appropriate version of the templates.
+
+
+if [[ $VERSION =~ ^(9\.0\.0)$ ]]; then
+    dotnet new install Aspire.ProjectTemplates::$VERSION
+else
+    # https://github.com/dotnet/aspire/blob/main/docs/using-latest-daily.md
+    dotnet nuget add source --name dotnet9 https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json
+
+    # If you use Package Source Mapping, you'll also need to add the following mappings to your NuGet.config
+    # <packageSourceMapping>
+    #   <packageSource key="dotnet9">
+    #     <package pattern="Aspire.*" />
+    #     <package pattern="Microsoft.Extensions.ServiceDiscovery*" />
+    #     <package pattern="Microsoft.Extensions.Http.Resilience" />
+    #   </packageSource>
+    # </packageSourceMapping>
+
+    dotnet new install Aspire.ProjectTemplates::*-* --force
+fi
+
+echo "... done activating feature '.NET Aspire' version: $VERSION"

--- a/src/dotnetaspire/install.sh
+++ b/src/dotnetaspire/install.sh
@@ -14,7 +14,7 @@ set -e
 VERSION="${VERSION:-"latest"}"
 
 if [[ ! $VERSION =~ ^(9\.0|latest|latest-daily)$ ]]; then
-    echo "Error: VERSION must be either '9.0', '9.0.0, 'latest', or 'latest-daily' not: '$VERSION'."
+    echo "Error: VERSION must be either '9.0', '9.0.0', 'latest', or 'latest-daily' not: '$VERSION'."
     exit 1
 fi
 

--- a/src/dotnetaspire/install.sh
+++ b/src/dotnetaspire/install.sh
@@ -25,7 +25,7 @@ fi
 echo "Activating feature '.NET Aspire' version: $VERSION"
 
 # Before .NET Aspire 9.0 install required `dotnet workload`: this is no longer necessary, as Aspire is 
-# installed when restoring an Aspireprojects. It's only necessary to install the appropriate version of the templates.
+# installed when restoring Aspire projects. It's only necessary to install the appropriate version of the templates.
 
 
 if [[ $VERSION =~ ^(9\.0\.0)$ ]]; then

--- a/test/dotnetaspire/dotnet_env.sh
+++ b/test/dotnetaspire/dotnet_env.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export DOTNET_NOLOGO=true
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+export DOTNET_GENERATE_ASPNET_CERTIFICATE=false

--- a/test/dotnetaspire/install_dotnetaspire_exact_version.sh
+++ b/test/dotnetaspire/install_dotnetaspire_exact_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -11,13 +11,7 @@ source dev-container-features-test-lib
 # The 'check' command comes from the dev-container-features-test-lib. Syntax is...
 # check <LABEL> <cmd> [args...]
 source dotnet_env.sh
-source dotnet_helpers.sh
 
-check ".NET SDK 8.0.100-preview.6.23330.14 installed" \
-is_dotnet_sdk_version_installed "8.0.100-preview.6.23330.14"
-
-check "Build and run example project" \
-dotnet run --project projects/net8.0 
 
 # Report results
 # If any of the checks above exited with a non-zero exit code, the test will fail.

--- a/test/dotnetaspire/install_dotnetaspire_exact_version.sh
+++ b/test/dotnetaspire/install_dotnetaspire_exact_version.sh
@@ -1,18 +1,1 @@
 #!/usr/bin/env bash
-
-set -e
-
-# Optional: Import test library bundled with the devcontainer CLI
-# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
-# Provides the 'check' and 'reportResults' commands.
-source dev-container-features-test-lib
-
-# Feature-specific tests
-# The 'check' command comes from the dev-container-features-test-lib. Syntax is...
-# check <LABEL> <cmd> [args...]
-source dotnet_env.sh
-
-
-# Report results
-# If any of the checks above exited with a non-zero exit code, the test will fail.
-reportResults

--- a/test/dotnetaspire/install_dotnetaspire_exact_version.sh
+++ b/test/dotnetaspire/install_dotnetaspire_exact_version.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
+# Provides the 'check' and 'reportResults' commands.
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib. Syntax is...
+# check <LABEL> <cmd> [args...]
+source dotnet_env.sh
+source dotnet_helpers.sh
+
+check ".NET SDK 8.0.100-preview.6.23330.14 installed" \
+is_dotnet_sdk_version_installed "8.0.100-preview.6.23330.14"
+
+check "Build and run example project" \
+dotnet run --project projects/net8.0 
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/dotnetaspire/install_dotnetaspire_latest_daily_version.sh
+++ b/test/dotnetaspire/install_dotnetaspire_latest_daily_version.sh
@@ -1,18 +1,1 @@
 #!/usr/bin/env bash
-
-set -e
-
-# Optional: Import test library bundled with the devcontainer CLI
-# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
-# Provides the 'check' and 'reportResults' commands.
-source dev-container-features-test-lib
-
-# Feature-specific tests
-# The 'check' command comes from the dev-container-features-test-lib. Syntax is...
-# check <LABEL> <cmd> [args...]
-source dotnet_env.sh
-
-
-# Report results
-# If any of the checks above exited with a non-zero exit code, the test will fail.
-reportResults

--- a/test/dotnetaspire/install_dotnetaspire_latest_daily_version.sh
+++ b/test/dotnetaspire/install_dotnetaspire_latest_daily_version.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-# Run tests with `devcontainer features test -f dotnetaspire` in the parent of the src and test folders.
-
 # Optional: Import test library bundled with the devcontainer CLI
 # See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
 # Provides the 'check' and 'reportResults' commands.
@@ -14,13 +12,6 @@ source dev-container-features-test-lib
 # check <LABEL> <cmd> [args...]
 source dotnet_env.sh
 
-check "dotnet is installed in DOTNET_ROOT and execute permission is granted" \
-test -x "$DOTNET_ROOT/dotnet" 
-
-check "dotnetaspire templates are installed" \
-test "$DOTNET_ROOT/dotnet new aspire"
-
-# There isn't currently a good way to check what version of the templates was installed.
 
 # Report results
 # If any of the checks above exited with a non-zero exit code, the test will fail.

--- a/test/dotnetaspire/install_dotnetaspire_latest_version.sh
+++ b/test/dotnetaspire/install_dotnetaspire_latest_version.sh
@@ -1,18 +1,1 @@
 #!/usr/bin/env bash
-
-set -e
-
-# Optional: Import test library bundled with the devcontainer CLI
-# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
-# Provides the 'check' and 'reportResults' commands.
-source dev-container-features-test-lib
-
-# Feature-specific tests
-# The 'check' command comes from the dev-container-features-test-lib. Syntax is...
-# check <LABEL> <cmd> [args...]
-source dotnet_env.sh
-
-
-# Report results
-# If any of the checks above exited with a non-zero exit code, the test will fail.
-reportResults

--- a/test/dotnetaspire/install_dotnetaspire_latest_version.sh
+++ b/test/dotnetaspire/install_dotnetaspire_latest_version.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-# Run tests with `devcontainer features test -f dotnetaspire` in the parent of the src and test folders.
-
 # Optional: Import test library bundled with the devcontainer CLI
 # See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
 # Provides the 'check' and 'reportResults' commands.
@@ -14,13 +12,6 @@ source dev-container-features-test-lib
 # check <LABEL> <cmd> [args...]
 source dotnet_env.sh
 
-check "dotnet is installed in DOTNET_ROOT and execute permission is granted" \
-test -x "$DOTNET_ROOT/dotnet" 
-
-check "dotnetaspire templates are installed" \
-test "$DOTNET_ROOT/dotnet new aspire"
-
-# There isn't currently a good way to check what version of the templates was installed.
 
 # Report results
 # If any of the checks above exited with a non-zero exit code, the test will fail.

--- a/test/dotnetaspire/scenarios.json
+++ b/test/dotnetaspire/scenarios.json
@@ -6,5 +6,21 @@
                 "version": "9.0"
             }
         }
+    },
+    "install_dotnetaspire_latest_version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "dotnetaspire": {
+                "version": "latest"
+            }
+        }
+    },
+    "install_dotnetaspire_latest_daily_version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "dotnetaspire": {
+                "version": "latest-daily"
+            }
+        }
     }
 }

--- a/test/dotnetaspire/scenarios.json
+++ b/test/dotnetaspire/scenarios.json
@@ -1,0 +1,10 @@
+{
+    "install_dotnetaspire_exact_version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "dotnetaspire": {
+                "version": "9.0"
+            }
+        }
+    }
+}

--- a/test/dotnetaspire/test.sh
+++ b/test/dotnetaspire/test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+# Run tests with `devcontainer features test -f dotnetaspire` in the parent of the src and test folders.
+
+# Optional: Import test library bundled with the devcontainer CLI
+# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
+# Provides the 'check' and 'reportResults' commands.
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib. Syntax is...
+# check <LABEL> <cmd> [args...]
+source dotnet_env.sh
+source dotnet_helpers.sh
+
+check "dotnet is installed in DOTNET_ROOT and execute permission is granted" \
+test -x "$DOTNET_ROOT/dotnet" 
+
+check "dotnetaspire templates are installed" \
+test "$DOTNET_ROOT/dotnet new aspire"
+
+# Report results
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/dotnetaspire/test.sh
+++ b/test/dotnetaspire/test.sh
@@ -17,6 +17,12 @@ source dotnet_env.sh
 check "dotnet is installed in DOTNET_ROOT and execute permission is granted" \
 test -x "$DOTNET_ROOT/dotnet" 
 
+check "dotnet 8.0 is installed" \
+test "$($DOTNET_ROOT/dotnet --info | grep '8.0.')"
+
+check "dotnet 9.0 is installed" \
+test "$($DOTNET_ROOT/dotnet --info | grep '9.0.')"
+
 check "dotnetaspire templates are installed" \
 test "$DOTNET_ROOT/dotnet new aspire"
 

--- a/test/dotnetaspire/test.sh
+++ b/test/dotnetaspire/test.sh
@@ -4,14 +4,7 @@ set -e
 
 # Run tests with `devcontainer features test -f dotnetaspire` in the parent of the src and test folders.
 
-# Optional: Import test library bundled with the devcontainer CLI
-# See https://github.com/devcontainers/cli/blob/HEAD/docs/features/test.md#dev-container-features-test-lib
-# Provides the 'check' and 'reportResults' commands.
 source dev-container-features-test-lib
-
-# Feature-specific tests
-# The 'check' command comes from the dev-container-features-test-lib. Syntax is...
-# check <LABEL> <cmd> [args...]
 source dotnet_env.sh
 
 check "dotnet is installed in DOTNET_ROOT and execute permission is granted" \
@@ -28,6 +21,4 @@ test "$DOTNET_ROOT/dotnet new aspire"
 
 # There isn't currently a good way to check what version of the templates was installed.
 
-# Report results
-# If any of the checks above exited with a non-zero exit code, the test will fail.
 reportResults

--- a/test/dotnetaspire/test.sh
+++ b/test/dotnetaspire/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -13,7 +13,6 @@ source dev-container-features-test-lib
 # The 'check' command comes from the dev-container-features-test-lib. Syntax is...
 # check <LABEL> <cmd> [args...]
 source dotnet_env.sh
-source dotnet_helpers.sh
 
 check "dotnet is installed in DOTNET_ROOT and execute permission is granted" \
 test -x "$DOTNET_ROOT/dotnet" 


### PR DESCRIPTION
Prior art published from their own repos -- 
".NET Aspire" https://github.com/NikiforovAll/devcontainer-features 
".NET Aspire Daily Builds" https://github.com/ElanHasson/devcontainer-features
Thank you @NikiforovAll and @ElanHasson for publishing these!

These happen to be at the top of the list:
![image](https://github.com/user-attachments/assets/44ca5177-52de-42be-83ac-31eb59a39146)

Both of these use the old way to install .NET Aspire, based on "dotnet workload". This only works with Aspire 8.0. From Aspire 9.0 onwards, this is no longer relevant. Anyone using Aspire today will likely want 9.0 or later.

I considered offering PR's to update each of them, but it seems to me that it would be better to have a single devcontainer feature for .NET Aspire which handled both scenarios plus arbitrary versions (>=9.0). This is that.

Merging this would require that the existing features be unpublished when this was merged, or this uses a different name. @NikiforovAll and @ElanHasson what would you think of replacing yours with a combined one?

cc @joperezr @davidfowl

When merged it could replace [this line](https://github.com/dotnet/aspire/blob/main/.devcontainer/dogfooding-nightly/devcontainer.json#L30) in the Aspire repo