### PR TITLE
dotnet feature should enable c# devkit not just the basic c# plugin

### DIFF
--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -25,7 +25,7 @@ This Feature installs the latest .NET SDK, which includes the .NET CLI and the s
 
 ### VS Code Extensions
 
-- `ms-dotnettools.csharp`
+- `ms-dotnettools.csdevkit`
 
 ## Configuration examples
 

--- a/src/dotnet/devcontainer-feature.json
+++ b/src/dotnet/devcontainer-feature.json
@@ -48,7 +48,7 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "ms-dotnettools.csharp"
+                "ms-dotnettools.csdevkit"
             ]
         }
     },


### PR DESCRIPTION
@joshspicer is this appropriate?