### PR TITLE
[nvidia-cuda] - Cudnn install script issue, unable to fetch latest version of libcudnn9 library

### DIFF
--- a/src/nvidia-cuda/install.sh
+++ b/src/nvidia-cuda/install.sh
@@ -74,7 +74,7 @@ if [ "$CUDNN_VERSION" = "automatic" ]; then
     if [[ "$CUDA_VERSION" < "12.3" ]]; then
         CUDNN_VERSION=$(apt-cache policy libcudnn8 | grep "$CUDA_VERSION" | grep -Eo '^[^-1+]*' | sort -V | tail -n1 | xargs)
     else
-        CUDNN_VERSION=$(apt-cache policy libcudnn9-cuda-$major_cuda_version | grep "Candidate" | awk '{print $2}' | grep -Eo '^[^-1+]*')
+        CUDNN_VERSION=$(apt-cache policy libcudnn9-cuda-$major_cuda_version | grep "Candidate" | awk '{print $2}' | grep -Eo '^[^-+]*')
     fi
 fi
 major_cudnn_version=$(echo "${CUDNN_VERSION}" | cut -d '.' -f 1)

--- a/test/nvidia-cuda/install_cuda_12_3_version.sh
+++ b/test/nvidia-cuda/install_cuda_12_3_version.sh
@@ -5,8 +5,8 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
-# # Check installation of libcudnn9-cuda-12 (9.4.0)
-check "libcudnn.so.9.5.0" test 1 -eq "$(find /usr -name 'libcudnn.so.9.5.0' | wc -l)"
+# Check installation of libcudnn9
+check "libcudnn.so.9" test 1 -eq "$(find /usr -name 'libcudnn.so.9' | wc -l)"
 
 # Check installation of cuda-nvtx-12-3 (12.3)
 check "cuda-12-3+nvtx" test -e '/usr/local/cuda-12.3/targets/x86_64-linux/include/nvtx3/'

--- a/test/nvidia-cuda/install_cuda_12_4_version.sh
+++ b/test/nvidia-cuda/install_cuda_12_4_version.sh
@@ -5,8 +5,8 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
-# # Check installation of libcudnn9-cuda-12 (9.4.0)
-check "libcudnn.so.9.5.0" test 1 -eq "$(find /usr -name 'libcudnn.so.9.5.0' | wc -l)"
+# Check installation of libcudnn9
+check "libcudnn.so.9" test 1 -eq "$(find /usr -name 'libcudnn.so.9' | wc -l)"
 
 # Check installation of cuda-nvtx-12-4 (12.4)
 check "cuda-12-4+nvtx" test -e '/usr/local/cuda-12.4/targets/x86_64-linux/include/nvtx3/'


### PR DESCRIPTION
**Ref#** https://github.com/devcontainers/features/issues/1270 

**Description:** Unable to fetch the latest libcudnn9 library version for cuda 12.3 or greater versions.

**Root Cause:** The regular expression used for fetching latest libcudnn9 library version was incorrect as it wasn't expecting digit 1 to be present in the version number.

**Changelog:** Changes done in install.sh script of nvidia-cuda to correct the regular expression & also changes done in the test scripts to test the presence of latest libcudnn9 library instead of specific version when the libcudnn version isn't specified.   

**Checklist:**

- Checked that applied changes work as expected.