### PR TITLE
[Go] Add Go 1.24

### DIFF
--- a/src/go/devcontainer-feature.json
+++ b/src/go/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "go",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "name": "Go",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/go",
     "description": "Installs Go and common Go utilities. Auto-detects latest version and installs needed dependencies.",
@@ -10,8 +10,8 @@
             "proposals": [
                 "latest",
                 "none",
-                "1.23",
-                "1.22"
+                "1.24",
+                "1.23"
             ],
             "default": "latest",
             "description": "Select or enter a Go version to install"


### PR DESCRIPTION
Similar to: https://github.com/devcontainers/features/pull/1104

Go 1.24 has been released: https://go.dev/doc/devel/release#go1.24.0