### PR TITLE
common-utils Azure linux 3 support 

### DIFF
--- a/src/common-utils/install.sh
+++ b/src/common-utils/install.sh
@@ -31,6 +31,8 @@ fi
 if [ "${ID}" = "alpine" ]; then
     apk add --no-cache bash
 fi
-
+if [ "${ID}" = "azurelinux" ]; then
+    tdnf install -y curl git 
+fi
 exec /bin/bash "$(dirname $0)/main.sh" "$@"
 exit $?

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -166,7 +166,7 @@ install_redhat_packages() {
     elif type tdnf > /dev/null 2>&1; then
        install_cmd=tdnf
     elif type dnf > /dev/null 2>&1; then
-       install_cmd=dnf
+       install_cmd=tdnf
     elif type yum > /dev/null 2>&1; then
        install_cmd=yum
     else

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -162,11 +162,11 @@ install_redhat_packages() {
     local remove_epel="false"
     local install_cmd=microdnf
     if type microdnf > /dev/null 2>&1; then
-       install_cmd=dnf
+       install_cmd=microdnf
     elif type tdnf > /dev/null 2>&1; then
        install_cmd=tdnf
     elif type dnf > /dev/null 2>&1; then
-       install_cmd=tdnf
+       install_cmd=dnf
     elif type yum > /dev/null 2>&1; then
        install_cmd=yum
     else

--- a/src/common-utils/main.sh
+++ b/src/common-utils/main.sh
@@ -161,12 +161,18 @@ install_redhat_packages() {
     local package_list=""
     local remove_epel="false"
     local install_cmd=microdnf
-    if ! type microdnf > /dev/null 2>&1; then
-        install_cmd=dnf
-        if ! type dnf > /dev/null 2>&1; then
-            install_cmd=yum
-        fi
-    fi
+    if type microdnf > /dev/null 2>&1; then
+       install_cmd=dnf
+    elif type tdnf > /dev/null 2>&1; then
+       install_cmd=tdnf
+    elif type dnf > /dev/null 2>&1; then
+       install_cmd=dnf
+    elif type yum > /dev/null 2>&1; then
+       install_cmd=yum
+    else
+       echo "Unable to find 'tdnf', 'dnf', or 'yum' package manager. Exiting."
+       exit 1
+fi
 
     if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
         package_list="${package_list} \
@@ -344,7 +350,7 @@ chmod +x /etc/profile.d/00-restore-env.sh
 # Get an adjusted ID independent of distro variants
 if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
     ADJUSTED_ID="debian"
-elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"mariner"* ]]; then
+elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "azurelinux" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"mariner"* ]]; then
     ADJUSTED_ID="rhel"
     VERSION_CODENAME="${ID}${VERSION_ID}"
 elif [ "${ID}" = "alpine" ]; then

--- a/test/common-utils/Azure-linux-CU.sh
+++ b/test/common-utils/Azure-linux-CU.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Load Linux distribution info
+. /etc/os-release
+
+# Check if the current user is root
+check "root user" test "$(whoami)" = "root"
+
+# Check if the Linux distro is Azure Linux
+check "azurelinux distro" test "$ID" = "azurelinux"
+
+# Definition specific tests
+check "curl" curl --version
+check "jq" jq  --version
+
+# Report result
+reportResults

--- a/test/common-utils/scenarios.json
+++ b/test/common-utils/scenarios.json
@@ -292,5 +292,13 @@
         "features": {
             "common-utils": {}
         }
+    },
+    "Azure-linux-CU": {
+        "image": "mcr.microsoft.com/dotnet/sdk:8.0-azurelinux3.0",
+        "features": {
+            "common-utils": {
+                "remoteUser": "vscode"
+            }
+        }
     }
 }

--- a/test/common-utils/scenarios.json
+++ b/test/common-utils/scenarios.json
@@ -296,9 +296,7 @@
     "Azure-linux-CU": {
         "image": "mcr.microsoft.com/dotnet/sdk:8.0-azurelinux3.0",
         "features": {
-            "common-utils": {
-                "remoteUser": "vscode"
-            }
+            "common-utils": {}
         }
     }
 }


### PR DESCRIPTION
Feature Name

- Common-utils

Description of Changes

- common-utils Azure linux 3 support 

- As per the  [issue](https://github.com/devcontainers/features/issues/1283) 
User facing issue while using  Azure linux image with the common-utils feature as Linux distro azurelinux not supported. 

Changelog

- Modified the install.sh and main.sh to work the expected installation for AzureLinux

- Modified the test cases scenarios to meet the required checks for the common-utils with the image mcr.microsoft.com/dotnet/sdk:8.0-azurelinux3.0

Checklist

- [ ☑️ ]  Checked that applied changes work as expected