### PR TITLE
[Ruby] - 3.1 EOL and 3.4 addition

### DIFF
--- a/src/ruby/devcontainer-feature.json
+++ b/src/ruby/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "1.2.3",
+    "version": "1.3.0",
     "name": "Ruby (via rvm)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/ruby",
     "description": "Installs Ruby, rvm, rbenv, common Ruby utilities, and needed dependencies.",
@@ -10,9 +10,8 @@
             "proposals": [
                 "latest",
                 "none",
-                "3.1",
-                "3.0",
-                "2.7"
+                "3.4",
+                "3.2"
             ],
             "default": "latest",
             "description": "Select or enter a Ruby version to install"

--- a/test/ruby/install_additional_ruby.sh
+++ b/test/ruby/install_additional_ruby.sh
@@ -5,9 +5,9 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
-check "ruby version 3.1.2 installed as default" ruby -v | grep 3.1.2
-check "ruby version 2.5.9 installed"  rvm list | grep 2.5.9
-check "ruby version 3.0.4 installed"  rvm list | grep 3.0.4
+check "ruby version 3.4.2 installed as default" ruby -v | grep 3.4.2
+check "ruby version 3.2.8 installed"  rvm list | grep 3.2.8
+check "ruby version 3.3.2 installed"  rvm list | grep 3.3.2
 
 check "rbenv" bash -c 'eval "$(rbenv init -)" && rbenv --version'
 check "rake" bash -c "gem list | grep rake"

--- a/test/ruby/ruby_fallback_test.sh
+++ b/test/ruby/ruby_fallback_test.sh
@@ -248,7 +248,7 @@ get_github_api_repo_url() {
 # Figure out correct version of a three part version number is not passed
 ruby_url="https://github.com/ruby/ruby"
 
-RUBY_VERSION="3.1.xyz"
+RUBY_VERSION="3.4.xyz"
 
 set_rvm_install_args() {
     RUBY_VERSION=$1

--- a/test/ruby/scenarios.json
+++ b/test/ruby/scenarios.json
@@ -3,8 +3,8 @@
         "image": "ubuntu:focal",
         "features": {
             "ruby": {
-                "version": "3.1.2",
-                "additionalVersions": "2.5,3.0.4"
+                "version": "3.4.2",
+                "additionalVersions": "3.2,3.3.2"
             }
         }
     },


### PR DESCRIPTION
**Ref:** [Issue](https://github.com/devcontainers/images/issues/90)

**Description:** Ruby 3.1 EOL on March 31st 2025 & Adding Ruby 3.4 available since Dec 2024 to the ruby devcontainer feature.

**Changelog:** 

- Change in devcontainer-feature.json to remove ruby 3.1 & add ruby 3.4
- Change in Scenarios.json to correct the Ruby test criteria based on latest versions.
- Change in install_additonal_ruby.sh & ruby_fallback_test.sh test scripts correct the expected ruby versions.

**Checklist:**

- All changes work as expected.