### PR TITLE
Remove hardcoded fallback to tem from ms JDK

### DIFF
--- a/src/java/devcontainer-feature.json
+++ b/src/java/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "java",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "name": "Java (via SDKMAN!)",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/java",
   "description": "Installs Java, SDKMAN! (if not installed), and needed dependencies.",
@@ -10,6 +10,7 @@
       "proposals": [
         "latest",
         "none",
+        "21",
         "17",
         "11",
         "8"

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -213,14 +213,8 @@ find_version_list() {
         major_version=$(echo "$java_ver" | cut -d '.' -f 1)
     fi
     
-    # Remove this hardcoded fallback as this fails for latest version released ex: 24
+    # Remove the hardcoded fallback as this fails for new jdk latest version released ex: 24
     # Related Issue: https://github.com/devcontainers/features/issues/1308
-    # if [ "${JDK_DISTRO}" = "ms" ]; then
-    #     if [ "${major_version}" = "8" ] || [ "${major_version}" = "18" ] || [ "${major_version}" = "22" ] || [ "${major_version}" = "23" ] || [ "${major_version}" = "24" ];then
-    #         JDK_DISTRO="tem"
-    #     fi
-    # fi
-
     if [ "${JDK_DISTRO}" = "ms" ]; then
         # Check if the requested version is available in the 'ms' distribution
         echo "Check if OpenJDK is available for version ${major_version} for ${JDK_DISTRO} Distro"

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -213,11 +213,26 @@ find_version_list() {
         major_version=$(echo "$java_ver" | cut -d '.' -f 1)
     fi
     
+    # Remove this hardcoded fallback as this fails for latest version released ex: 24
+    # Related Issue: https://github.com/devcontainers/features/issues/1308
+    # if [ "${JDK_DISTRO}" = "ms" ]; then
+    #     if [ "${major_version}" = "8" ] || [ "${major_version}" = "18" ] || [ "${major_version}" = "22" ] || [ "${major_version}" = "23" ] || [ "${major_version}" = "24" ];then
+    #         JDK_DISTRO="tem"
+    #     fi
+    # fi
+
     if [ "${JDK_DISTRO}" = "ms" ]; then
-        if [ "${major_version}" = "8" ] || [ "${major_version}" = "18" ] || [ "${major_version}" = "22" ] || [ "${major_version}" = "23" ]; then
+        # Check if the requested version is available in the 'ms' distribution
+        echo "Check if OpenJDK is available for version ${major_version} for ${JDK_DISTRO} Distro"
+        available_versions=$(su ${USERNAME} -c ". ${SDKMAN_DIR}/bin/sdkman-init.sh && sdk list ${install_type} | grep ${JDK_DISTRO} | grep -oE '[0-9]+(\.[0-9]+(\.[0-9]+)?)?' | sort -u")
+        if echo "${available_versions}" | grep -q "^${major_version}"; then
+            echo "JDK version ${major_version} is available in ${JDK_DISTRO}..."
+        else
+            echo "JDK version ${major_version} not available in  ${JDK_DISTRO}.... Switching to (tem)."
             JDK_DISTRO="tem"
         fi
     fi
+    echo "JDK_DISTRO: ${JDK_DISTRO}"
     if [ "${install_type}" != "java" ]; then
         regex="${prefix}\\K[0-9]+\\.?[0-9]*\\.?[0-9]*${suffix}"
     else

--- a/test/java/install_latest_version.sh
+++ b/test/java/install_latest_version.sh
@@ -9,7 +9,7 @@ echo 'public class HelloWorld { public static void main(String[] args) { System.
 javac HelloWorld.java
 
 check "hello world" /bin/bash -c "java HelloWorld | grep "Hello, World!""
-check "java version latest installed" grep "23" <(java --version)
+check "java version latest installed" grep "24" <(java --version)
 
 # Report result
 reportResults


### PR DESCRIPTION
**Feature Name**

  - Java
  
**Description of Changes**

  - Fixes Issue: https://github.com/devcontainers/features/issues/1308
  - Latest JDK Distro version 24 is released.
  - Fallback mechanism from ms to tem have hardcoded JDK versions(8,18,22,23)
  - This causes issue as the latest version 24 is not among them

**Changelog**

- Made changes to install.sh file 
- Made changes to test scenarios file