### PR TITLE
[dotnet] - Fixing the dotnet smoke test issue with changes in test script.

### DIFF
--- a/src/dotnet/devcontainer-feature.json
+++ b/src/dotnet/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "dotnet",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "name": "Dotnet CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/dotnet",
     "description": "This Feature installs the latest .NET SDK, which includes the .NET CLI and the shared runtime. Options are provided to choose a different version or additional versions.",

--- a/test/dotnet/dotnet_helpers.sh
+++ b/test/dotnet/dotnet_helpers.sh
@@ -17,6 +17,44 @@ fetch_latest_version_in_channel() {
     fi
 }
 
+# Function to resolve the actual version from an aka.ms URL
+resolve_version_from_aka_ms() {
+    local normalized_channel="${1:-LTS}"  # defaulting to LTS channel
+    local normalized_product="dotnet-sdk"
+    local normalized_os="linux"
+
+    # Dynamically determine the architecture
+    local normalized_architecture
+    normalized_architecture=$(uname -m)
+    case "$normalized_architecture" in
+        x86_64) normalized_architecture="x64" ;;
+        aarch64) normalized_architecture="arm64" ;;
+        arm*) normalized_architecture="arm" ;;
+        *) 
+            echo "Unsupported architecture: $normalized_architecture"
+            return 1
+            ;;
+    esac
+
+    # Construct the aka.ms link
+    local aka_ms_link="https://aka.ms/dotnet/$normalized_channel/$normalized_product-$normalized_os-$normalized_architecture.tar.gz"
+    echo "Constructed aka.ms link: $aka_ms_link"
+
+    # Resolve the redirect URL using curl
+    local resolved_url
+    resolved_url=$(curl -s -L -o /dev/null -w "%{url_effective}" "$aka_ms_link")
+    echo "Resolved URL: $resolved_url"
+
+    # Extract the version from the resolved URL
+    IFS='/'
+    read -ra pathElems <<< "$resolved_url"
+    local count=${#pathElems[@]}
+    local specific_version="${pathElems[count-2]}"
+    unset IFS
+
+    echo "Extracted version: $specific_version"
+}
+
 # Prints the latest dotnet version
 # Usage: fetch_latest_version [<runtime>]
 # Example: fetch_latest_version

--- a/test/dotnet/install_dotnet_lts.sh
+++ b/test/dotnet/install_dotnet_lts.sh
@@ -13,7 +13,8 @@ source dev-container-features-test-lib
 source dotnet_env.sh
 source dotnet_helpers.sh
 
-expected=$(fetch_latest_version_in_channel "LTS")
+# Changing it as the dotnet SDK CDN url is not showing the right version for LTS
+expected=$(resolve_version_from_aka_ms "LTS" | cut -d' ' -f3)
 
 check "Latest LTS version installed" \
 is_dotnet_sdk_version_installed "$expected"


### PR DESCRIPTION
**Ref#** [Issue](https://github.com/devcontainers/internal/issues/260)

**Description:** This change is done to fetch the dotnet sdk `lts` version number in the same manner how the version is picked up while downloading the package in the dotnet_install.sh vendor script. As the current way of getting the version # for dotnet sdk `lts` via specific CDN url is giving incorrect version. See [here](https://github.com/dotnet/sdk/issues/47865)

**Changelog:** Change for this is done only in the following test scripts. & that too for lts scenario alone.
- test/dotnet/dotnet_helpers.sh
- test/dotnet/install_dotnet_lts.sh

**Checklist:**

- All changes work as expected.