### PR TITLE
[node] - Node 18 EOL changes

### DIFF
--- a/src/node/devcontainer-feature.json
+++ b/src/node/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "node",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "name": "Node.js (via nvm), yarn and pnpm",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/node",
     "description": "Installs Node.js, nvm, yarn, pnpm, and needed dependencies.",
@@ -11,9 +11,8 @@
                 "lts",
                 "latest",
                 "none",
-                "18",
-                "16",
-                "14"
+                "22",
+                "20"
             ],
             "default": "lts",
             "description": "Select or enter a Node.js version to install"

--- a/test/node/install_node_22_on_jammy.sh
+++ b/test/node/install_node_22_on_jammy.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "version" bash -c "node --version | grep 22"
+check "pnpm" bash -c "pnpm -v | grep 8.8.0"
+check "nvm" bash -c ". /usr/local/share/nvm/nvm.sh && nvm install 10"
+
+# Report result
+reportResults
+

--- a/test/node/scenarios.json
+++ b/test/node/scenarios.json
@@ -77,11 +77,11 @@
             }
         }
     },
-    "install_node_16_on_bionic": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu-18.04",
+    "install_node_22_on_jammy": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
         "features": {
             "node": {
-                "version": "16",
+                "version": "22",
                 "pnpmVersion":"8.8.0"
             }
         }


### PR DESCRIPTION
**Ref:** https://github.com/devcontainers/images/issues/90

**Description:** Node 18 EOL on Apr 30th 2025 for the node devcontainer feature.

**Changelog:**

- Change in devcontainer-feature.json to remove node 18.
- Change in Scenarios.json to correct the node test criteria based on latest versions.
- Change in test scripts

**Checklist:**

- All changes work as expected.