### PR TITLE
[aws-cli] Change dependency from gnupg2 to gpg

### DIFF
--- a/src/aws-cli/devcontainer-feature.json
+++ b/src/aws-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "aws-cli",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "name": "AWS CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/aws-cli",
     "description": "Installs the AWS CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",

--- a/src/aws-cli/install.sh
+++ b/src/aws-cli/install.sh
@@ -68,7 +68,7 @@ check_packages() {
 
 export DEBIAN_FRONTEND=noninteractive
 
-check_packages curl ca-certificates gnupg2 dirmngr unzip bash-completion less
+check_packages curl ca-certificates gpg dirmngr unzip bash-completion less
 
 verify_aws_cli_gpg_signature() {
     local filePath=$1


### PR DESCRIPTION
Currently the aws-cli feature installs `gnupg2` for verifying aws-cli signature
However, `gnupg2` package install a few other utilities besides`gpg`. Only `gpg` package is required for signature verification, the other components are reductant.

Using `gpg` as the dependency improves install speed, save disk space for automated workflow, and more importantly reduces the attack surface of minimal systems.