### PR TITLE
[nvidia-cuda] - Ubuntu focal EOL change for nvidia-cuda

### DIFF
--- a/src/nvidia-cuda/devcontainer-feature.json
+++ b/src/nvidia-cuda/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "nvidia-cuda",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "name": "NVIDIA CUDA",
   "description": "Installs shared libraries for NVIDIA CUDA.",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/nvidia-cuda",

--- a/src/nvidia-cuda/install.sh
+++ b/src/nvidia-cuda/install.sh
@@ -46,7 +46,8 @@ check_packages wget ca-certificates
 
 # Add NVIDIA's package repository to apt so that we can download packages
 # Always use the ubuntu2004 repo because the other repos (e.g., debian11) are missing packages
-NVIDIA_REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64"
+# Updating the repo to ubuntu2204 as ubuntu 20.04 is going out of support 
+NVIDIA_REPO_URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64"
 KEYRING_PACKAGE="cuda-keyring_1.0-1_all.deb"
 KEYRING_PACKAGE_URL="$NVIDIA_REPO_URL/$KEYRING_PACKAGE"
 KEYRING_PACKAGE_PATH="$(mktemp -d)"


### PR DESCRIPTION
**Ref:** [#90](https://github.com/devcontainers/images/issues/90) , [#261](https://github.com/devcontainers/internal/issues/261)

**Description:** The ubuntu focal is going out of support from May 31, 2025. So changing the nvidia-cuda repo url to the ubuntu jammy (22.04) version url from the focal one. Also not moving to the ubuntu noble repo as it appears to have only limiteds versions `cuda` & `libcudnn` available.

**Changlog:** The following changes are done.

- Changed the repo url in install.sh
- Version bump in devcontainer-feature.json

**Checklist:**
- [x] All checks are passed.
