### PR TITLE
Add `plucky` to the `docker-outside-of-docker` distro allow lists

### DIFF
--- a/src/docker-outside-of-docker/devcontainer-feature.json
+++ b/src/docker-outside-of-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-outside-of-docker",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "name": "Docker (docker-outside-of-docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker",
     "description": "Re-use the host docker socket, adding the Docker CLI to a container. Feature invokes a script to enable using a forwarded Docker socket within a container to run Docker commands.",

--- a/src/docker-outside-of-docker/install.sh
+++ b/src/docker-outside-of-docker/install.sh
@@ -20,8 +20,8 @@ INSTALL_DOCKER_BUILDX="${INSTALLDOCKERBUILDX:-"true"}"
 INSTALL_DOCKER_COMPOSE_SWITCH="${INSTALLDOCKERCOMPOSESWITCH:-"true"}"
 
 MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
-DOCKER_MOBY_ARCHIVE_VERSION_CODENAMES="bookworm buster bullseye bionic focal jammy noble"
-DOCKER_LICENSED_ARCHIVE_VERSION_CODENAMES="bookworm buster bullseye bionic focal hirsute impish jammy noble"
+DOCKER_MOBY_ARCHIVE_VERSION_CODENAMES="bookworm buster bullseye bionic focal jammy noble plucky"
+DOCKER_LICENSED_ARCHIVE_VERSION_CODENAMES="bookworm buster bullseye bionic focal hirsute impish jammy noble plucky"
 
 set -e
 


### PR DESCRIPTION
Adds `plucky` to the `docker-outside-of-docker` distro allow lists.

I'm curious why these lists are necessary. This seems like extra work for every new Ubuntu release?