### PR TITLE
Update Ubuntu PPA GPG key fingerprint

### DIFF
--- a/src/git/devcontainer-feature.json
+++ b/src/git/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "git",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "name": "Git (from source)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/git",
     "description": "Install an up-to-date version of Git, built from source as needed. Useful for when you want the latest and greatest features. Auto-detects latest stable version and installs needed dependencies.",

--- a/src/git/install.sh
+++ b/src/git/install.sh
@@ -10,7 +10,7 @@
 GIT_VERSION=${VERSION} # 'system' checks the base image first, else installs 'latest'
 USE_PPA_IF_AVAILABLE=${PPA}
 
-GIT_CORE_PPA_ARCHIVE_GPG_KEY=E1DD270288B4E6030699E45FA1715D88E1DF1F24
+GIT_CORE_PPA_ARCHIVE_GPG_KEY=F911AB184317630C59970973E363C90F8F1B6217
 
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'


### PR DESCRIPTION
The old 1024 bit RSA key has been replaced with the new 4096 bit RSA key, or it will trigger a "weak algorithm" warning: https://discourse.ubuntu.com/t/new-requirements-for-apt-repository-signing-in-24-04/42854

The new fingerprint is found on the PPA page: https://launchpad.net/~git-core/+archive/ubuntu/ppa