### PR TITLE
[oryx] - Pinning to a previous commit in repository

### DIFF
--- a/src/oryx/devcontainer-feature.json
+++ b/src/oryx/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "oryx",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "name": "Oryx",
     "description": "Installs the oryx CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/oryx",

--- a/src/oryx/install.sh
+++ b/src/oryx/install.sh
@@ -177,7 +177,11 @@ GIT_ORYX=/opt/tmp/oryx-repo
 mkdir -p ${BUILD_SCRIPT_GENERATOR}
 mkdir -p ${ORYX}
 
-git clone --depth=1 https://github.com/microsoft/Oryx $GIT_ORYX
+# https://github.com/microsoft/Oryx/commit/aa205b50896b2174c0d0d8be1c9e94684aab1e9a is breaking the `oryx` tool
+# Pinning to a previous working commit until the upstream issue is fixed.
+git clone https://github.com/microsoft/Oryx $GIT_ORYX
+cd $GIT_ORYX
+git reset --hard cada9e85564f034d18420f8b5b38b3cf2259f321
 
 if [[ "${PINNED_SDK_VERSION}" != "" ]]; then
     cd $GIT_ORYX

--- a/test/oryx/scenarios.json
+++ b/test/oryx/scenarios.json
@@ -1,6 +1,6 @@
 {
     "install_dotnet_and_oryx": {
-        "image": "ubuntu:focal",
+        "image": "ubuntu:noble",
         "features": {
             "dotnet": {
                 "version": "8.0",
@@ -11,7 +11,7 @@
         }
     },
     "install_older_dotnet_and_oryx": {
-        "image": "ubuntu:focal",
+        "image": "ubuntu:noble",
         "features": {
             "dotnet": {
                 "version": "7.0"
@@ -20,7 +20,7 @@
         }
     },
     "install_prev_dotnet_and_oryx": {
-        "image": "ubuntu:focal",
+        "image": "ubuntu:noble",
         "features": {
             "dotnet": {
                 "version": "6.0"
@@ -29,7 +29,7 @@
         }
     },
     "test_python_project": {
-        "image": "ubuntu:focal",
+        "image": "ubuntu:noble",
         "features": {
             "python": {
                 "version": "3.10.4",


### PR DESCRIPTION
**Ref:** [#2594](https://github.com/microsoft/Oryx/issues/2594) 

**Description:** Ever since this [PR](https://github.com/microsoft/Oryx/pull/2580) has been merged on 26th May, 2025, Oryx build from source has been failing with the `MSBUILD : error MSB1009: Project file does not exist.` error.

**Changlog:** The following changes are done.

- src/oryx/install-sh : Pinning to the previous commit as the [latest](https://github.com/microsoft/Oryx/commit/aa205b50896b2174c0d0d8be1c9e94684aab1e9a) commit is breaking the oryx installation.
- test/oryx/scenarios.json : Updated test images to `ubuntu:noble` from `ubuntu:focal`.

**Checklist:**
- [x] All checks are passed.