### PR TITLE
kubectl version doesn't support vX.Y.Z 

### DIFF
--- a/src/kubectl-helm-minikube/devcontainer-feature.json
+++ b/src/kubectl-helm-minikube/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "kubectl-helm-minikube",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "name": "Kubectl, Helm, and Minikube",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/kubectl-helm-minikube",
     "description": "Installs latest version of kubectl, Helm, and optionally minikube. Auto-detects latest versions and installs needed dependencies.",

--- a/src/kubectl-helm-minikube/install.sh
+++ b/src/kubectl-helm-minikube/install.sh
@@ -59,7 +59,7 @@ find_version_from_git_tags() {
     local repository=$2
     local prefix=${3:-"tags/v"}
     local separator=${4:-"."}
-    local last_part_optional=${5:-"false"} 
+    local last_part_optional=${5:-"false"}
     if [ "$(echo "${requested_version}" | grep -o "." | wc -l)" != "2" ]; then
         local escaped_separator=${separator//./\\.}
         local last_part
@@ -69,7 +69,6 @@ find_version_from_git_tags() {
             last_part="${escaped_separator}[0-9]+"
         fi
         local regex="${prefix}\\K[0-9]+${escaped_separator}[0-9]+${last_part}$"
-        echo "Regex: ${regex}"
         local version_list="$(git ls-remote --tags ${repository} | grep -oP "${regex}" | tr -d ' ' | tr "${separator}" "." | sort -rV)"
         if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "current" ] || [ "${requested_version}" = "lts" ]; then
             declare -g ${variable_name}="$(echo "${version_list}" | head -n 1)"

--- a/src/kubectl-helm-minikube/install.sh
+++ b/src/kubectl-helm-minikube/install.sh
@@ -54,11 +54,12 @@ fi
 find_version_from_git_tags() {
     local variable_name=$1
     local requested_version=${!variable_name}
+    requested_version="${requested_version#v}"
     if [ "${requested_version}" = "none" ]; then return; fi
     local repository=$2
     local prefix=${3:-"tags/v"}
     local separator=${4:-"."}
-    local last_part_optional=${5:-"false"}    
+    local last_part_optional=${5:-"false"} 
     if [ "$(echo "${requested_version}" | grep -o "." | wc -l)" != "2" ]; then
         local escaped_separator=${separator//./\\.}
         local last_part
@@ -68,6 +69,7 @@ find_version_from_git_tags() {
             last_part="${escaped_separator}[0-9]+"
         fi
         local regex="${prefix}\\K[0-9]+${escaped_separator}[0-9]+${last_part}$"
+        echo "Regex: ${regex}"
         local version_list="$(git ls-remote --tags ${repository} | grep -oP "${regex}" | tr -d ' ' | tr "${separator}" "." | sort -rV)"
         if [ "${requested_version}" = "latest" ] || [ "${requested_version}" = "current" ] || [ "${requested_version}" = "lts" ]; then
             declare -g ${variable_name}="$(echo "${version_list}" | head -n 1)"

--- a/test/kubectl-helm-minikube/install_kubectl_with_version.sh
+++ b/test/kubectl-helm-minikube/install_kubectl_with_version.sh
@@ -4,24 +4,29 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
+# Define expected versions
+KUBECTL_EXPECTED_VERSION="v1.33.0"
+HELM_VERSION="v3.17.3"
+MINIKUBE_VERSION="v1.31.1"
+
 set +e
-    kubectl
+    kubectl version --client --output json | jq -r '.clientVersion.gitVersion' | grep "${KUBECTL_VERSION}"
     exit_code=$?
-    check "kubectl-is-installed" bash -c "echo ${exit_code} | grep 0"
+    check "kubectl-version-${KUBECTL_VERSION}-installed" bash -c "echo ${exit_code} | grep 0"
     echo "kubectl version:"
     kubectl version --client 
 
-    helm version
+    helm version --short | grep "${HELM_VERSION}"
     exit_code=$?
-    check "helm-is-installed" bash -c "echo ${exit_code} | grep 0"
+    check "helm-version-${HELM_VERSION}-installed" bash -c "echo ${exit_code} | grep 0"
     echo "helm version:"
-    helm version 
+    helm version --short
 
-    minikube version
+    minikube version --short | grep "${MINIKUBE_VERSION}"  
     exit_code=$?
-    check "minikube-is-installed" bash -c "echo ${exit_code} | grep 0"
+    check "minikube-version-${MINIKUBE_VERSION}-installed" bash -c "echo ${exit_code} | grep 0"
     echo "minikube version:"
-    minikube version
+    minikube version --short
 set -e
 
 # Report result

--- a/test/kubectl-helm-minikube/install_kubectl_with_version.sh
+++ b/test/kubectl-helm-minikube/install_kubectl_with_version.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+set +e
+    kubectl
+    exit_code=$?
+    check "kubectl-is-installed" bash -c "echo ${exit_code} | grep 0"
+    echo "kubectl version:"
+    kubectl version --client 
+
+    helm version
+    exit_code=$?
+    check "helm-is-installed" bash -c "echo ${exit_code} | grep 0"
+    echo "helm version:"
+    helm version 
+
+    minikube version
+    exit_code=$?
+    check "minikube-is-installed" bash -c "echo ${exit_code} | grep 0"
+    echo "minikube version:"
+    minikube version
+set -e
+
+# Report result
+reportResults

--- a/test/kubectl-helm-minikube/install_kubectl_without_version.sh
+++ b/test/kubectl-helm-minikube/install_kubectl_without_version.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+set +e
+    kubectl
+    exit_code=$?
+    check "kubectl-is-installed" bash -c "echo ${exit_code} | grep 0"
+    echo "kubectl version:"
+    kubectl version --client 
+
+    helm version
+    exit_code=$?
+    check "helm-is-installed" bash -c "echo ${exit_code} | grep 0"
+    echo "helm version:"
+    helm version 
+
+    minikube version
+    exit_code=$?
+    check "minikube-is-installed" bash -c "echo ${exit_code} | grep 0"
+    echo "minikube version:"
+    minikube version
+set -e
+
+# Report result
+reportResults

--- a/test/kubectl-helm-minikube/install_kubectl_without_version.sh
+++ b/test/kubectl-helm-minikube/install_kubectl_without_version.sh
@@ -4,24 +4,29 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
+# Define expected versions
+KUBECTL_EXPECTED_VERSION="1.30"
+HELM_VERSION="3.16"
+MINIKUBE_VERSION="1.28"
+
 set +e
-    kubectl
+    kubectl version --client --output json | jq -r '.clientVersion.gitVersion' | grep "${KUBECTL_VERSION}"
     exit_code=$?
-    check "kubectl-is-installed" bash -c "echo ${exit_code} | grep 0"
+    check "kubectl-version-${KUBECTL_VERSION}-installed" bash -c "echo ${exit_code} | grep 0"
     echo "kubectl version:"
     kubectl version --client 
 
-    helm version
+    helm version --short | grep "${HELM_VERSION}"
     exit_code=$?
-    check "helm-is-installed" bash -c "echo ${exit_code} | grep 0"
+    check "helm-version-${HELM_VERSION}-installed" bash -c "echo ${exit_code} | grep 0"
     echo "helm version:"
-    helm version 
+    helm version --short
 
-    minikube version
+    minikube version --short | grep "${MINIKUBE_VERSION}"  
     exit_code=$?
-    check "minikube-is-installed" bash -c "echo ${exit_code} | grep 0"
+    check "minikube-version-${MINIKUBE_VERSION}-installed" bash -c "echo ${exit_code} | grep 0"
     echo "minikube version:"
-    minikube version
+    minikube version --short
 set -e
 
 # Report result

--- a/test/kubectl-helm-minikube/scenarios.json
+++ b/test/kubectl-helm-minikube/scenarios.json
@@ -18,5 +18,25 @@
                 "minikube": "none"
             }
         }
+    },
+    "install_kubectl_without_version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "kubectl-helm-minikube": {
+                "version": "1.30",
+                "helm": "3.16",
+                "minikube": "1.28"
+            }
+        }
+    },
+    "install_kubectl_with_version": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "kubectl-helm-minikube": {
+                "version": "v1.33.0",
+                "helm": "v3.17.3",
+                "minikube": "v1.31.1"
+            }
+        }
     }
 }


### PR DESCRIPTION
**Feature Name**

- kubectl-helm-minikube
  
**Description of Changes**

  - Fixes Issue: https://github.com/devcontainers/features/issues/1369
  - If the version value is provided with a leading v (e.g., v31.0), remove the v prefix to extract the correct version. This ensures the script works for both v31.0 and 31.0.
  
**Changelog**

- Made changes to install.sh file 
- Made changes to test scenarios file
