### PR TITLE
Use `secrets.GITHUB_TOKEN` instead of `PAT` for docs generation

### DIFF
--- a/.github/workflows/update-documentation.yml
+++ b/.github/workflows/update-documentation.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - arausell/gh-token
   workflow_dispatch:
 
 jobs:
@@ -13,7 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    # if: "github.ref == 'refs/heads/main'"
+    if: "github.ref == 'refs/heads/main'"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/update-documentation.yml
+++ b/.github/workflows/update-documentation.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - arausell/gh-token
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/update-documentation.yml
+++ b/.github/workflows/update-documentation.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Create a PR for Documentation
         id: push_image_info
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
           echo "Start."

--- a/.github/workflows/update-documentation.yml
+++ b/.github/workflows/update-documentation.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    if: "github.ref == 'refs/heads/main'"
+    # if: "github.ref == 'refs/heads/main'"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The [Update Documentation](https://github.com/devcontainers/features/actions/runs/15469927821) action has been failing because the Personal Access Token used has expired. I updated the action to use [GITHUB_TOKEN](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#about-the-github_token-secret) instead.