### PR TITLE
Revert "Use `secrets.GITHUB_TOKEN` instead of `PAT` for docs generation (#1377)"

### DIFF
--- a/.github/workflows/update-documentation.yml
+++ b/.github/workflows/update-documentation.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Create a PR for Documentation
         id: push_image_info
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
           set -e
           echo "Start."


### PR DESCRIPTION
This reverts commit 1c80e5351ab0e92018b6613edecdb440f46b0d0b.

This is due to the fact that, at an org level, GH Actions are not allowed to open pull requests.