### PR TITLE
Use postStartCommand to avoid creating a .gitconfig

### DIFF
--- a/src/common-utils/README.md
+++ b/src/common-utils/README.md
@@ -38,7 +38,7 @@ these images have already allocated UID & GID 1000. Attempting to add this Featu
 
 By default, this script provides a custom command prompt that includes information about the git repository for the current folder. However, with certain large repositories, this can result in a slow command prompt due to the performance of needed git operations.
 
-For performance reasons, a "dirty" indicator that tells you whether or not there are uncommitted changes is disabled by default. You can opt to turn this on for smaller repositories by entering the following in a terminal or adding it to your `postCreateCommand`:
+For performance reasons, a "dirty" indicator that tells you whether or not there are uncommitted changes is disabled by default. You can opt to turn this on for smaller repositories by entering the following in a terminal or adding it to your `postStartCommand`:
 
 ```bash
 git config devcontainers-theme.show-dirty 1


### PR DESCRIPTION
https://github.com/microsoft/vscode-remote-release/issues/6989

An existing .gitconfig after postCreateCommand prevents local Dev Containers from copying over the local .gitconfig. Using postStartCommand avoids that because the .gitconfig is copied over before that.