### PR TITLE
[desktop-lite] - Adding support for noVnc latest version in the feature

### DIFF
--- a/src/desktop-lite/devcontainer-feature.json
+++ b/src/desktop-lite/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "desktop-lite",
-    "version": "1.2.6",
+    "version": "1.2.7",
     "name": "Light-weight Desktop",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/desktop-lite",
     "description": "Adds a lightweight Fluxbox based desktop to the container that can be accessed using a VNC viewer or the web. GUI-based commands executed from the built-in VS code terminal will open on the desktop automatically.",
@@ -16,9 +16,9 @@
         "noVncVersion": {
             "type": "string",
             "proposals": [
-                "1.2.0"
+                "1.6.0"
             ],
-            "default": "1.2.0",
+            "default": "1.6.0",
             "description": "The noVNC version to use"
         },
         "password": {

--- a/src/desktop-lite/install.sh
+++ b/src/desktop-lite/install.sh
@@ -394,9 +394,8 @@ fi
 
 # Spin up noVNC if installed and not running.
 if [ -d "/usr/local/novnc" ]; then
-    NOVNC_VERSION_INSTALLED=\$(ls /usr/local/novnc | grep -oP 'noVNC-\K[0-9.]+' | head -n1)
     if [ "\$(ps -ef | grep /usr/local/novnc/noVNC*/utils/launch.sh | grep -v grep)" = "" ] && [ "\$(ps -ef | grep /usr/local/novnc/noVNC*/utils/novnc_proxy | grep -v grep)" = "" ]; then
-        if version_gt "\$NOVNC_VERSION_INSTALLED" "1.2.0"; then
+        if version_gt "${NOVNC_VERSION}" "1.2.0"; then
             keepRunningInBackground "noVNC" sudoIf "/usr/local/novnc/noVNC*/utils/novnc_proxy --listen ${NOVNC_PORT} --vnc localhost:${VNC_PORT}"
             log "noVNC started with novnc_proxy."
         else
@@ -404,7 +403,7 @@ if [ -d "/usr/local/novnc" ]; then
             log "noVNC started with launch.sh."
         fi
     else
-        log "noVNC is already running or not installed."
+        log "noVNC is already."
     fi
 else
     log "noVNC is not installed."

--- a/src/desktop-lite/install.sh
+++ b/src/desktop-lite/install.sh
@@ -403,7 +403,7 @@ if [ -d "/usr/local/novnc" ]; then
             log "noVNC started with launch.sh."
         fi
     else
-        log "noVNC is already."
+        log "noVNC is already running."
     fi
 else
     log "noVNC is not installed."

--- a/src/desktop-lite/install.sh
+++ b/src/desktop-lite/install.sh
@@ -7,7 +7,7 @@
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/desktop-lite.md
 # Maintainer: The VS Code and Codespaces Teams
 
-NOVNC_VERSION="${NOVNCVERSION:-"1.2.0"}" # TODO: Add in a 'latest' auto-detect and swap name to 'version'
+NOVNC_VERSION="${NOVNCVERSION:-"1.6.0"}" # TODO: Add in a 'latest' auto-detect and swap name to 'version'
 VNC_PASSWORD=${PASSWORD:-"vscode"}
 if [ "$VNC_PASSWORD" = "noPassword" ]; then
     unset VNC_PASSWORD
@@ -355,6 +355,13 @@ log()
     echo -e "[\$(date)] \$@" | sudoIf tee -a \$LOG > /dev/null
 }
 
+# Function to compare versions
+version_gt() {
+    # returns 0 if \$1 > \$2
+    [ "\$(printf '%s\n' "\$2" "\$1" | sort -V | head -n1)" != "\$1" ]
+}
+
+
 log "** SCRIPT START **"
 
 # Start dbus.
@@ -386,11 +393,21 @@ else
 fi
 
 # Spin up noVNC if installed and not running.
-if [ -d "/usr/local/novnc" ] && [ "\$(ps -ef | grep /usr/local/novnc/noVNC*/utils/launch.sh | grep -v grep)" = "" ]; then
-    keepRunningInBackground "noVNC" sudoIf "/usr/local/novnc/noVNC*/utils/launch.sh --listen ${NOVNC_PORT} --vnc localhost:${VNC_PORT}"
-    log "noVNC started."
+if [ -d "/usr/local/novnc" ]; then
+    NOVNC_VERSION_INSTALLED=\$(ls /usr/local/novnc | grep -oP 'noVNC-\K[0-9.]+' | head -n1)
+    if [ "\$(ps -ef | grep /usr/local/novnc/noVNC*/utils/launch.sh | grep -v grep)" = "" ] && [ "\$(ps -ef | grep /usr/local/novnc/noVNC*/utils/novnc_proxy | grep -v grep)" = "" ]; then
+        if version_gt "\$NOVNC_VERSION_INSTALLED" "1.2.0"; then
+            keepRunningInBackground "noVNC" sudoIf "/usr/local/novnc/noVNC*/utils/novnc_proxy --listen ${NOVNC_PORT} --vnc localhost:${VNC_PORT}"
+            log "noVNC started with novnc_proxy."
+        else
+            keepRunningInBackground "noVNC" sudoIf "/usr/local/novnc/noVNC*/utils/launch.sh --listen ${NOVNC_PORT} --vnc localhost:${VNC_PORT}"
+            log "noVNC started with launch.sh."
+        fi
+    else
+        log "noVNC is already running or not installed."
+    fi
 else
-    log "noVNC is already running or not installed."
+    log "noVNC is not installed."
 fi
 
 # Run whatever was passed in

--- a/test/desktop-lite/scenarios.json
+++ b/test/desktop-lite/scenarios.json
@@ -5,6 +5,14 @@
             "desktop-lite": {}
         }
     },
+    "test_xtigervnc_novnc_started_noVNC_old_launch_script": {
+        "image": "ubuntu:noble",
+        "features": {
+            "desktop-lite": {
+                "noVncVersion": "1.2.0"
+            }
+        }
+    },    
     "test_vnc_resolution_as_container_env_var": {
         "image": "ubuntu:noble",
         "features": {

--- a/test/desktop-lite/test_xtigervnc_novnc_started_noVNC_old_launch_script.sh
+++ b/test/desktop-lite/test_xtigervnc_novnc_started_noVNC_old_launch_script.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Check if xtigervnc & noVnc processes are running after successful installation and initialization
+check_process_running() {
+    port=$1
+    # Get process id of process running on specific port
+    PID=$(lsof -i :$port | awk 'NR==2 {print $2}')
+    if [ -n "$PID" ]; then
+        CMD=$(ps -p $PID -o cmd --no-headers)
+        GREEN='\033[0;32m'; NC='\033[0m'; RED='\033[0;31m'; YELLOW='\033[0;33m';
+        echo -e "${GREEN}Command running on port $port: ${YELLOW}$CMD${NC}"
+    else
+        echo -e "${RED}No process found listening on port $port.${NC}"
+    fi
+}
+
+check "Whether xtigervnc is Running" check_process_running 5901
+sleep 1
+check "Whether no_vnc is Running" check_process_running 6080
+
+check "desktop-init-exists" bash -c "ls /usr/local/share/desktop-init.sh"
+check "log-exists" bash -c "ls /tmp/container-init.log"
+check "log file contents" bash -c "cat /tmp/container-init.log"
+
+# Report result
+reportResults
+
+


### PR DESCRIPTION
**Ref:** #1393 

**Description:** This PR aims to solve https://github.com/devcontainers/features/issues/1393 by adding support for latest `noVnc` version. All the `noVnc` versions post `1.2.0` are currently not working with the `desktop-lite` feature due to unavailability of `launch.sh` script which is responsible for launching the `noVnc` client. In these higher versions of `noVnc` client post `1.2.0`, the client is required to be started using `novnc_proxy` utility. Changes are done for adding that support & also ensured that support for the older `noVnc` clients(<=1.2.0) remain as-is. 

**Changlog:** The following changes are done.

- Changed the code in install.sh to add support for `noVnc` client versions higher that `1.2.0`
- Updated the `devcontainer-feature.json` to do version bump & pining the `noVncVersion` property to the latest `1.6.0` version.
- Added a test for the older versions(<=1.2.0) separately.

**Checklist:**
- [x] All checks are passed.
