### PR TITLE
[rust] - Introducing new options to install components.

### DIFF
--- a/src/rust/README.md
+++ b/src/rust/README.md
@@ -18,6 +18,8 @@ Installs Rust, common Rust utilities, and their required dependencies
 | version | Select or enter a version of Rust to install. | string | latest |
 | profile | Select a rustup install profile. | string | minimal |
 | targets | Optional comma separated list of additional Rust targets to install. | string | - |
+| customComponents | Optional a flag to allow installing rust components based on input. | boolean | false |
+| components | Optional comma separeated list of rust components to be installed based on input. | string | - |
 
 ## Customizations
 

--- a/src/rust/devcontainer-feature.json
+++ b/src/rust/devcontainer-feature.json
@@ -57,7 +57,23 @@
                 "armv7-unknown-linux-gnueabihf",
                 "x86_64-unknown-redox,x86_64-unknown-uefi"
             ]
-        }
+        },
+        "customComponents": {
+            "type": "boolean",
+            "default": false,
+            "description": "Use custom components list instead of default components (rust-analyzer, rust-src, rustfmt, clippy)."
+        },
+        "components": {
+            "type": "string",
+            "default": "",
+            "description": "Optional comma separated list of Rust components to install when customComponents is true.",
+            "proposals": [
+                "rust-analyzer,rust-src,rustfmt,clippy",
+                "rust-analyzer,rust-src",
+                "rustfmt,clippy,rust-docs",
+                "llvm-tools-preview,rust-src,rustfmt"
+            ]
+        }        
     },
     "customizations": {
         "vscode": {

--- a/src/rust/install.sh
+++ b/src/rust/install.sh
@@ -10,6 +10,8 @@
 RUST_VERSION="${VERSION:-"latest"}"
 RUSTUP_PROFILE="${PROFILE:-"minimal"}"
 RUSTUP_TARGETS="${TARGETS:-""}"
+CUSTOM_COMPONENTS="${CUSTOMCOMPONENTS:-"false"}"
+RUST_COMPONENTS="${COMPONENTS:-""}"
 
 export CARGO_HOME="${CARGO_HOME:-"/usr/local/cargo"}"
 export RUSTUP_HOME="${RUSTUP_HOME:-"/usr/local/rustup"}"
@@ -188,7 +190,7 @@ else
     mkdir -p /tmp/rustup/target/${download_architecture}-unknown-linux-gnu/release/
     curl -sSL --proto '=https' --tlsv1.2 "https://static.rust-lang.org/rustup/dist/${download_architecture}-unknown-linux-gnu/rustup-init" -o /tmp/rustup/target/${download_architecture}-unknown-linux-gnu/release/rustup-init
     curl -sSL --proto '=https' --tlsv1.2 "https://static.rust-lang.org/rustup/dist/${download_architecture}-unknown-linux-gnu/rustup-init.sha256" -o /tmp/rustup/rustup-init.sha256
-    cd /tmp/rustup
+    cd /tmp/rustup  
     cp /tmp/rustup/target/${download_architecture}-unknown-linux-gnu/release/rustup-init  /tmp/rustup/rustup-init
     sha256sum -c rustup-init.sha256
     chmod +x target/${download_architecture}-unknown-linux-gnu/release/rustup-init
@@ -202,8 +204,24 @@ if [ "${UPDATE_RUST}" = "true" ]; then
     echo "Updating Rust..."
     rustup update 2>&1
 fi
-echo "Installing common Rust dependencies..."
-rustup component add rust-analyzer rust-src rustfmt clippy 2>&1
+# Install Rust components based on flag
+if [ "${CUSTOM_COMPONENTS}" = "true" ] && [ -n "${RUST_COMPONENTS}" ]; then
+    echo "Installing custom Rust components..."
+    IFS=',' read -ra components <<< "${RUST_COMPONENTS}"
+    for component in "${components[@]}"; do
+        # Trim whitespace
+        component=$(echo "${component}" | xargs)
+        if [ -n "${component}" ]; then
+            echo "Installing Rust component: ${component}"
+            if ! rustup component add "${component}" 2>&1; then
+                echo "Warning: Failed to install component '${component}'. It may not be available for this toolchain." >&2
+            fi
+        fi
+    done
+else
+    echo "Installing common Rust dependencies..."
+    rustup component add rust-analyzer rust-src rustfmt clippy 2>&1
+fi
 
 if [ -n "${RUSTUP_TARGETS}" ]; then
     IFS=',' read -ra targets <<< "${RUSTUP_TARGETS}"

--- a/test/rust/rust_with_custom_components.sh
+++ b/test/rust/rust_with_custom_components.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Helper function to check component is installed
+check_component_installed() {
+    local component=$1
+    if rustup component list | grep -q "${component}.*installed"; then
+        return 0  # Component is installed (success)
+    else
+        return 1  # Component is not installed (failure)
+    fi
+}
+
+# Helper function to check component is NOT installed
+check_component_not_installed() {
+    local component=$1
+    if rustup component list | grep -q "${component}.*installed"; then
+        return 1  # Component is installed (failure)
+    else
+        return 0  # Component is not installed (success)
+    fi
+}
+
+# Definition specific tests
+check "cargo version" cargo --version
+check "rustc version" rustc --version
+
+# Check that specified custom components are installed
+check "rust-analyzer is installed" check_component_installed "rust-analyzer"
+check "rust-src is installed" check_component_installed "rust-src"
+check "rustfmt is installed" check_component_installed "rustfmt"
+
+# Check that clippy NOT installed
+check "clippy not installed" check_component_not_installed "clippy"
+
+# Report result
+reportResults
+

--- a/test/rust/rust_with_default_components.sh
+++ b/test/rust/rust_with_default_components.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Helper function to check component is installed
+check_component_installed() {
+    local component=$1
+    if rustup component list | grep -q "${component}.*installed"; then
+        return 0  # Component is installed (success)
+    else
+        return 1  # Component is not installed (failure)
+    fi
+}
+
+# Definition specific tests
+check "cargo version" cargo --version
+check "rustc version" rustc --version
+
+# Check that default components are installed
+check "rust-analyzer is installed" check_component_installed "rust-analyzer"
+check "rust-src is installed" check_component_installed "rust-src"
+check "rustfmt is installed" check_component_installed "rustfmt"
+check "clippy is installed" check_component_installed "clippy"
+
+# Report result
+reportResults
+

--- a/test/rust/rust_with_empty_components.sh
+++ b/test/rust/rust_with_empty_components.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Helper function to check component is installed
+check_component_installed() {
+    local component=$1
+    if rustup component list | grep -q "${component}.*installed"; then
+        return 0  # Component is installed (success)
+    else
+        return 1  # Component is not installed (failure)
+    fi
+}
+
+# Helper function to check component is NOT installed
+check_component_not_installed() {
+    local component=$1
+    if rustup component list | grep -q "${component}.*installed"; then
+        return 1  # Component is installed (failure)
+    else
+        return 0  # Component is not installed (success)
+    fi
+}
+
+# Definition specific tests
+check "cargo version" cargo --version
+check "rustc version" rustc --version
+
+# Check that no additional components are installed when empty list is provided
+# Only the basic rust toolchain should be available
+check "basic rust toolchain" rustc --version
+
+# Verify that default components are automatically installed
+check "rust-analyzer is installed" check_component_installed "rust-analyzer"
+check "rust-src is installed" check_component_installed "rust-src"
+check "rustfmt is installed" check_component_installed "rustfmt"
+check "clippy is installed" check_component_installed "clippy"
+
+# Report result
+reportResults
+

--- a/test/rust/rust_with_extended_components.sh
+++ b/test/rust/rust_with_extended_components.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Helper function to check component is installed
+check_component_installed() {
+    local component=$1
+    if rustup component list | grep -q "${component}.*installed"; then
+        return 0  # Component is installed (success)
+    else
+        return 1  # Component is not installed (failure)
+    fi
+}
+
+# Definition specific tests
+check "cargo version" cargo --version
+check "rustc version" rustc --version
+
+# Check that all specified extended components are installed
+check "rust-analyzer is installed" check_component_installed "rust-analyzer"
+check "rust-src is installed" check_component_installed "rust-src"
+check "rustfmt is installed" check_component_installed "rustfmt"
+check "clippy is installed" check_component_installed "clippy"
+check "rust-docs is installed" check_component_installed "rust-docs"
+
+# Report result
+reportResults
+

--- a/test/rust/rust_with_minimal_components.sh
+++ b/test/rust/rust_with_minimal_components.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Helper function to check component is installed
+check_component_installed() {
+    local component=$1
+    if rustup component list | grep -q "${component}.*installed"; then
+        return 0  # Component is installed (success)
+    else
+        return 1  # Component is not installed (failure)
+    fi
+}
+
+# Helper function to check component is NOT installed
+check_component_not_installed() {
+    local component=$1
+    if rustup component list | grep -q "${component}.*installed"; then
+        return 1  # Component is installed (failure)
+    else
+        return 0  # Component is not installed (success)
+    fi
+}
+
+# Definition specific tests
+check "cargo version" cargo --version
+check "rustc version" rustc --version
+
+# Check that only specified minimal components are installed
+check "rust-analyzer is installed" check_component_installed "rust-analyzer"
+check "rust-src is installed" check_component_installed "rust-src"
+
+# Check that other default components are NOT installed
+check "rustfmt not installed" check_component_not_installed "rustfmt"
+check "clippy not installed" check_component_not_installed "clippy"
+
+# Report result
+reportResults
+

--- a/test/rust/scenarios.json
+++ b/test/rust/scenarios.json
@@ -15,5 +15,54 @@
                 "targets": "aarch64-unknown-linux-gnu"
             }
         }
+    },
+    "rust_with_default_components": {
+        "image": "ubuntu:noble",
+        "features": {
+            "rust": {
+                "version": "latest",
+                "customComponents": false
+            }
+        }
+    },
+    "rust_with_custom_components": {
+        "image": "ubuntu:noble",
+        "features": {
+            "rust": {
+                "version": "latest",
+                "customComponents": true,
+                "components": "rust-analyzer,rust-src,rustfmt"
+            }
+        }
+    },
+    "rust_with_minimal_components": {
+        "image": "ubuntu:noble",
+        "features": {
+            "rust": {
+                "version": "latest",
+                "customComponents": true,
+                "components": "rust-analyzer,rust-src"
+            }
+        }
+    },
+    "rust_with_extended_components": {
+        "image": "ubuntu:noble",
+        "features": {
+            "rust": {
+                "version": "latest",
+                "customComponents": true,
+                "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"
+            }
+        }
+    },
+    "rust_with_empty_components": {
+        "image": "ubuntu:noble",
+        "features": {
+            "rust": {
+                "version": "latest",
+                "customComponents": true,
+                "components": ""
+            }
+        }
     }
 }


### PR DESCRIPTION
**Ref:** #1273 

**Description:** This PR aims to solve https://github.com/devcontainers/features/issues/1273 to introduce new options `customComponents` and `components` to install rust components based on user input

**Changelog:** The following changes are included.

- The installation script is changed to introduce new options `customComponents` and `components` (comma separated value for the components to installed ) to install rust components based on user input.
- Change in devcontainer-feature.json by adding the new options `customComponents` and `components` to install rust components based on user input.
- Test scripts for different components in different combinations
- The readme file modified with the added information.

**Checklist:**
- [x] All checks are passed. 