### PR TITLE
chore(devcontainer): bump javascript-node image version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "mcr.microsoft.com/devcontainers/javascript-node:1-18",
+    "image": "mcr.microsoft.com/devcontainers/javascript-node:3-22",
     "features": {
         "ghcr.io/devcontainers/features/docker-in-docker:2": {}
     },


### PR DESCRIPTION
## Summary

Bug Fixes:
- Bump [javascript-node image](https://github.com/devcontainers/images/tree/main/src/javascript-node) version in [devcontainer.json](https://github.com/devcontainers/features/blob/main/.devcontainer/devcontainer.json) to the updated release

## Description

[[javascript-node, typescript-node] - Node 18 EOL changes. #1391](https://github.com/devcontainers/images/pull/1391) deleted mcr.microsoft.com/devcontainers/javascript-node:1-18-bullseye image.

This PR fixed non referenced image.