### PR TITLE
[docker-in-docker] Use iptables-legacy only if it's working

### DIFF
--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "2.12.2",
+    "version": "2.12.3",
     "name": "Docker (Docker-in-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
     "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -218,7 +218,7 @@ if ! type git > /dev/null 2>&1; then
 fi
 
 # Swap to legacy iptables for compatibility
-if type iptables-legacy > /dev/null 2>&1; then
+if type iptables-legacy > /dev/null 2>&1 && iptables-legacy -L > /dev/null 2>&1; then
     update-alternatives --set iptables /usr/sbin/iptables-legacy
     update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 fi

--- a/test/docker-in-docker/docker_with_iptables.sh
+++ b/test/docker-in-docker/docker_with_iptables.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Feature specific tests
+check "iptables works" sudo iptables -L
+check "iptables uses legacy" bash -c "iptables --version | grep legacy"
+
+check "version" docker  --version
+check "docker-ps" bash -c "docker ps"
+check "log-exists" bash -c "ls /tmp/dockerd.log"
+check "log-for-completion" bash -c "cat /tmp/dockerd.log | grep 'Daemon has completed initialization'"
+check "log-contents" bash -c "cat /tmp/dockerd.log | grep 'API listen on /var/run/docker.sock'"
+
+# Report result
+reportResults

--- a/test/docker-in-docker/docker_without_iptables.sh
+++ b/test/docker-in-docker/docker_without_iptables.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Feature specific tests
+check "iptables works" sudo iptables -L
+check "iptables uses nf_tables" bash -c "iptables --version | grep nf_tables"
+
+check "version" docker  --version
+check "docker-ps" bash -c "docker ps"
+check "log-exists" bash -c "ls /tmp/dockerd.log"
+check "log-for-completion" bash -c "cat /tmp/dockerd.log | grep 'Daemon has completed initialization'"
+check "log-contents" bash -c "cat /tmp/dockerd.log | grep 'API listen on /var/run/docker.sock'"
+
+# Report result
+reportResults

--- a/test/docker-in-docker/scenarios.json
+++ b/test/docker-in-docker/scenarios.json
@@ -158,6 +158,15 @@
             }
         }
     },
+    "docker_without_iptables": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "docker-in-docker": {
+                "moby": "false"
+            }
+        },
+        "initializeCommand": "sudo modprobe --remove --remove-holders ip_tables"
+    },
     // DO NOT REMOVE: This scenario is used by the docker-in-docker-stress-test workflow
     "docker_with_on_create_command": {
         "image": "mcr.microsoft.com/devcontainers/base:debian",

--- a/test/docker-in-docker/scenarios.json
+++ b/test/docker-in-docker/scenarios.json
@@ -165,7 +165,7 @@
                 "moby": "false"
             }
         },
-        "initializeCommand": "sudo modprobe --remove --remove-holders ip_tables"
+        "initializeCommand": "sudo modprobe --remove --remove-holders --wait 1000 ip_tables"
     },
     // DO NOT REMOVE: This scenario is used by the docker-in-docker-stress-test workflow
     "docker_with_on_create_command": {

--- a/test/docker-in-docker/scenarios.json
+++ b/test/docker-in-docker/scenarios.json
@@ -167,6 +167,15 @@
         },
         "initializeCommand": "sudo modprobe --remove --remove-holders --wait 1000 ip_tables"
     },
+    "docker_with_iptables": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "docker-in-docker": {
+                "moby": "false"
+            }
+        },
+        "initializeCommand": "sudo modprobe ip_tables"
+    },
     // DO NOT REMOVE: This scenario is used by the docker-in-docker-stress-test workflow
     "docker_with_on_create_command": {
         "image": "mcr.microsoft.com/devcontainers/base:debian",


### PR DESCRIPTION
Currently, docker-in-docker configures `iptables` to use `iptables-legacy` if it exists.

However, if the `ip_tables` kernel module is not loaded on the host (such as with Fedora hosts), `iptables-legacy` will not work (and `iptables-nft` will probably work).

With this change, docker-in-docker checks if `iptables-legacy` works before using `update-alternatives`.

Fixes #1235