### PR TITLE
[rust] Add Alpine support for rust feature

### DIFF
--- a/src/rust/NOTES.md
+++ b/src/rust/NOTES.md
@@ -2,11 +2,7 @@
 
 ## OS Support
 
-This Feature should work on recent versions of Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, RockyLinux 
-and Mariner distributions with the `apt`, `yum`, `dnf`, `microdnf` and `tdnf` package manager installed.
-
-
-**Note:** Alpine is not supported because the rustup-init binary requires glibc to run, but Alpine Linux does not include `glibc` 
-by default. Instead, it uses musl libc, which is not binary-compatible with glibc.
+This Feature should work on recent versions of Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, RockyLinux,
+Mariner and Alpine distributions with the `apt`, `yum`, `dnf`, `microdnf`, `tdnf` and `apk` package manager installed.
 
 `bash` is required to execute the `install.sh` script.

--- a/src/rust/README.md
+++ b/src/rust/README.md
@@ -32,12 +32,8 @@ Installs Rust, common Rust utilities, and their required dependencies
 
 ## OS Support
 
-This Feature should work on recent versions of Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, RockyLinux 
-and Mariner distributions with the `apt`, `yum`, `dnf`, `microdnf` and `tdnf` package manager installed.
-
-
-**Note:** Alpine is not supported because the rustup-init binary requires glibc to run, but Alpine Linux does not include `glibc` 
-by default. Instead, it uses musl libc, which is not binary-compatible with glibc.
+This Feature should work on recent versions of Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, RockyLinux,
+Mariner and Alpine distributions with the `apt`, `yum`, `dnf`, `microdnf`, `tdnf` and `apk` package manager installed.
 
 `bash` is required to execute the `install.sh` script.
 

--- a/test/rust/rust_with_alpine.sh
+++ b/test/rust/rust_with_alpine.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Helper function to check component is installed
+check_component_installed() {
+    local component=$1
+    if rustup component list | grep -q "${component}.*installed"; then
+        return 0  # Component is installed (success)
+    else
+        return 1  # Component is not installed (failure)
+    fi
+}
+
+# Definition specific tests
+check "cargo version" cargo  --version
+check "rustc version" rustc  --version
+check "correct rust version" rustup target list | grep "aarch64-unknown-linux-musl.*installed"
+
+# Check that all specified extended components are installed
+check "rust-analyzer is installed" check_component_installed "rust-analyzer"
+check "rust-src is installed" check_component_installed "rust-src"
+check "rustfmt is installed" check_component_installed "rustfmt"
+check "clippy is installed" check_component_installed "clippy"
+check "rust-docs is installed" check_component_installed "rust-docs"
+
+# Report result
+reportResults
+

--- a/test/rust/scenarios.json
+++ b/test/rust/scenarios.json
@@ -64,14 +64,14 @@
                 "components": ""
             }
         }
-    },    
+    },
     "rust_with_centos": {
         "image": "centos:centos7",
         "features": {
             "rust": {
                 "version": "latest",
                 "targets": "aarch64-unknown-linux-gnu",
-                "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"                
+                "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"
             }
         }
     },
@@ -81,7 +81,7 @@
             "rust": {
                 "version": "latest",
                 "targets": "aarch64-unknown-linux-gnu",
-                "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"                
+                "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"
             }
         }
     },
@@ -91,7 +91,7 @@
             "rust": {
                 "version": "latest",
                 "targets": "aarch64-unknown-linux-gnu",
-                "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"                
+                "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"
             }
         }
     },
@@ -101,7 +101,7 @@
             "rust": {
                 "version": "latest",
                 "targets": "aarch64-unknown-linux-gnu",
-                "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"                
+                "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"
             }
         }
     },
@@ -111,7 +111,7 @@
             "rust": {
                 "version": "latest",
                 "targets": "aarch64-unknown-linux-gnu",
-                "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"                
+                "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"
             }
         }
     },
@@ -121,7 +121,7 @@
             "rust": {
                 "version": "latest",
                 "targets": "aarch64-unknown-linux-gnu",
-                "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"                
+                "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"
             }
         }
     },
@@ -131,8 +131,18 @@
             "rust": {
                 "version": "latest",
                 "targets": "aarch64-unknown-linux-gnu",
-                "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"                
+                "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"
             }
         }
-    }                                                                
+    },
+    "rust_with_alpine": {
+        "image": "mcr.microsoft.com/devcontainers/base:alpine-3.21",
+        "features": {
+            "rust": {
+                "version": "latest",
+                "targets": "aarch64-unknown-linux-musl",
+                "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"
+            }
+        }
+    }
 }


### PR DESCRIPTION
`musl` is supported by Rustup; it is just required to download the right version of `rustup-init`.