### PR TITLE
[ruby] - Fixing ruby feature installation issue in debian trixie(13)

### DIFF
--- a/src/ruby/devcontainer-feature.json
+++ b/src/ruby/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "ruby",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "name": "Ruby (via rvm)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/ruby",
     "description": "Installs Ruby, rvm, rbenv, common Ruby utilities, and needed dependencies.",

--- a/src/ruby/install.sh
+++ b/src/ruby/install.sh
@@ -240,6 +240,7 @@ if [ "${architecture}" != "amd64" ] && [ "${architecture}" != "x86_64" ] && [ "$
 fi
 
 # Install dependencies
+# Removed software-properties-common package from here as it has been removed for debian trixie(13)
 check_packages curl ca-certificates build-essential gnupg2 libreadline-dev \
     procps dirmngr gawk autoconf automake bison libffi-dev libgdbm-dev libncurses5-dev \
     libsqlite3-dev libtool libyaml-dev pkg-config sqlite3 zlib1g-dev libgmp-dev libssl-dev

--- a/src/ruby/install.sh
+++ b/src/ruby/install.sh
@@ -240,11 +240,26 @@ if [ "${architecture}" != "amd64" ] && [ "${architecture}" != "x86_64" ] && [ "$
 fi
 
 # Install dependencies
-check_packages curl ca-certificates software-properties-common build-essential gnupg2 libreadline-dev \
+check_packages curl ca-certificates build-essential gnupg2 libreadline-dev \
     procps dirmngr gawk autoconf automake bison libffi-dev libgdbm-dev libncurses5-dev \
     libsqlite3-dev libtool libyaml-dev pkg-config sqlite3 zlib1g-dev libgmp-dev libssl-dev
 if ! type git > /dev/null 2>&1; then
     check_packages git
+fi
+
+# Conditionally install software-properties-common (skip on Debian Trixie)
+if type apt-get >/dev/null 2>&1; then
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        if [ "${ID}" = "debian" ] && [ "${VERSION_CODENAME}" = "trixie" ]; then
+            echo "Skipping software-properties-common on Debian Trixie."
+        else
+            check_packages software-properties-common
+        fi
+    else
+        # Fallback for apt-based systems without /etc/os-release
+        check_packages software-properties-common
+    fi
 fi
 
 # Function to fetch the version released prior to the latest version

--- a/test/ruby/install_additional_ruby_trixie.sh
+++ b/test/ruby/install_additional_ruby_trixie.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "ruby version 3.4.2 installed as default" ruby -v | grep 3.4.2
+check "ruby version 3.2.8 installed"  rvm list | grep 3.2.8
+check "ruby version 3.3.2 installed"  rvm list | grep 3.3.2
+
+check "rbenv" bash -c 'eval "$(rbenv init -)" && rbenv --version'
+check "rake" bash -c "gem list | grep rake"
+
+# Report result
+reportResults
+

--- a/test/ruby/install_ruby_trixie_base.sh
+++ b/test/ruby/install_ruby_trixie_base.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "ruby version" ruby  --version
+check "rvm" rvm --version
+check "gem version" gem --version
+
+# Report result
+reportResults
+

--- a/test/ruby/install_ruby_trixie_base/Dockerfile
+++ b/test/ruby/install_ruby_trixie_base/Dockerfile
@@ -1,0 +1,18 @@
+# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.4, 3.3, 3.2, 3-bookworm, 3.4-bookworm, 3.3-bookworm, 3.2-bookworm, 3-bullseye, 3.4-bullseye, 3.3-bullseye, 3.2-bullseye, 3-buster, 3.2-buster
+ARG VARIANT=3-trixie
+FROM ruby:${VARIANT}
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
+    && apt-get purge -y imagemagick imagemagick-6-common 
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install additional gems.
+# RUN gem install <your-gem-names-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+

--- a/test/ruby/scenarios.json
+++ b/test/ruby/scenarios.json
@@ -1,4 +1,34 @@
-{
+{   
+    "install_ruby_trixie_base": {
+        "build": {
+            "dockerfile": "Dockerfile"
+        },        
+        "features": {
+            "ghcr.io/devcontainers/features/common-utils:2": {
+                "installZsh": "true",
+                "username": "vscode",
+                "userUid": "1000",
+                "userGid": "1000",
+                "upgradePackages": "true"
+            },
+            "ruby": "none",
+            "ghcr.io/devcontainers/features/node:1": "none",
+            "ghcr.io/devcontainers/features/git:1": {
+                "version": "latest",
+                "ppa": "false"
+            }
+        },
+        "remoteUser": "vscode"
+    },
+    "install_additional_ruby_trixie": {
+        "image": "debian:trixie",
+        "features": {
+            "ruby": {
+                "version": "3.4.2",
+                "additionalVersions": "3.2,3.3.2"
+            }
+        }
+    },       
     "install_additional_ruby": {
         "image": "ubuntu:noble",
         "features": {


### PR DESCRIPTION
**Ref:** https://github.com/devcontainers/internal/issues/283#issuecomment-3220870722

**Description:** This PR aims to fix ruby feature installation issue in debian trixie(13). Actually `software-properties-common` package has been removed from debian trixie(13) and the same was used in the installation script of ruby dev container feature and it means that `add-apt-repository` can't be used to add new software sources/ repos going forward in debian trixie. Nevertheless, this doesn't appear to be necessary as `apt-get` works seamlessly with all ubuntu/ debian distributions. Removing the installation of this `software-properties-common` for debian trixie only as of now to unblock the installation with minimal impact. In due course will get this removed entirely.

**Changelog:** The following changes are included.

- The installation script is changed to skip installation of `software-properties-common` package for debian trixie(13)
- Change in devcontainer-feature.json to do version bump
- Test scripts for relevant options with debian trixie(13) and ruby trixie(13) base images.

**Checklist:**
- [x] All checks are passed. 

