### PR TITLE
[sshd] Add GatewayPorts option

### DIFF
--- a/src/sshd/README.md
+++ b/src/sshd/README.md
@@ -15,6 +15,7 @@ Adds a SSH server into a container so that you can use an external terminal, sft
 
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
+| gatewayPorts | Enable other hosts in the same network to connect to the forwarded ports | string | no
 | version | Currently unused. | string | latest |
 
 ## Usage

--- a/src/sshd/devcontainer-feature.json
+++ b/src/sshd/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "sshd",
-    "version": "1.0.10",
+    "version": "1.1.0",
     "name": "SSH server",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/sshd",
     "description": "Adds a SSH server into a container so that you can use an external terminal, sftp, or SSHFS to interact with it.",
@@ -12,6 +12,16 @@
             ],
             "default": "latest",
             "description": "Currently unused."
+        },
+        "gatewayPorts": {
+            "type": "string",
+            "enum": [
+                "no",
+                "yes",
+                "clientspecified"
+            ],
+            "default": "no",
+            "description": "Enable other hosts in the same network to connect to the forwarded ports"
         }
     },
     "entrypoint": "/usr/local/share/ssh-init.sh",

--- a/src/sshd/install.sh
+++ b/src/sshd/install.sh
@@ -13,6 +13,7 @@ SSHD_PORT="${SSHD_PORT:-"2222"}"
 USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
 START_SSHD="${START_SSHD:-"false"}"
 NEW_PASSWORD="${NEW_PASSWORD:-"skip"}"
+GATEWAY_PORTS="${GATEWAYPORTS:-"no"}" 
 
 set -e
 
@@ -89,6 +90,7 @@ mkdir -p /var/run/sshd
 sed -i 's/session\s*required\s*pam_loginuid\.so/session optional pam_loginuid.so/g' /etc/pam.d/sshd
 sed -i 's/#*PermitRootLogin prohibit-password/PermitRootLogin yes/g' /etc/ssh/sshd_config
 sed -i -E "s/#*\s*Port\s+.+/Port ${SSHD_PORT}/g" /etc/ssh/sshd_config
+sed -i "s/#GatewayPorts no/GatewayPorts ${GATEWAY_PORTS}/g" /etc/ssh/sshd_config
 # Need to UsePAM so /etc/environment is processed
 sed -i -E "s/#?\s*UsePAM\s+.+/UsePAM yes/g" /etc/ssh/sshd_config
 

--- a/test/sshd/scenarios.json
+++ b/test/sshd/scenarios.json
@@ -1,0 +1,18 @@
+{
+    "sshd_with_default_gateway_ports": {
+        "image": "ubuntu:noble",
+        "features": {
+            "sshd": {
+                "gatewayPorts": "no"
+            }
+        }
+    },
+    "sshd_with_pinned_gateway_ports_clientspecified": {
+        "image": "ubuntu:noble",
+        "features": {
+            "sshd": {
+                "gatewayPorts": "clientspecified"
+            }
+        }
+    }                                                           
+}

--- a/test/sshd/sshd_with_default_gateway_ports.sh
+++ b/test/sshd/sshd_with_default_gateway_ports.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "correct default GatewayPorts" grep "GatewayPorts no" /etc/ssh/sshd_config
+
+# Report result
+reportResults

--- a/test/sshd/sshd_with_pinned_gateway_ports_clientspecified.sh
+++ b/test/sshd/sshd_with_pinned_gateway_ports_clientspecified.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "correct default GatewayPorts" grep "GatewayPorts clientspecified" /etc/ssh/sshd_config
+
+# Report result
+reportResults


### PR DESCRIPTION
We want to optionlly enable the GatewayPorts option in sshd.

To test: `devcontainer features test --features sshd`

Background:
Our development setup runs in Codespaces with Docker Compose. To handle TLS termination and spoof internal IPs, we use a reverse tunnel via `gh cs ssh -- -R` and proxys on workstations.

Without GatewayPorts, only the main container can access the tunnel—other containers can’t. Enabling GatewayPorts allows the tunnel to bind to the container’s public interfaces too, so other containers can use it. This is required for our transparent proxy setup.