### PR TITLE
[azure-cli] - Fix azure-cli installation in debian trixie(13)

### DIFF
--- a/src/azure-cli/devcontainer-feature.json
+++ b/src/azure-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-cli",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "name": "Azure CLI",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/azure-cli",
   "description": "Installs the Azure CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",

--- a/src/azure-cli/install.sh
+++ b/src/azure-cli/install.sh
@@ -19,7 +19,7 @@ AZ_BICEPVERSION=${BICEPVERSION:-latest}
 INSTALL_USING_PYTHON=${INSTALLUSINGPYTHON:-false}
 MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
 AZCLI_ARCHIVE_ARCHITECTURES="amd64 arm64"
-AZCLI_ARCHIVE_VERSION_CODENAMES="stretch bookworm buster bullseye bionic focal jammy noble"
+AZCLI_ARCHIVE_VERSION_CODENAMES="stretch bookworm buster bullseye bionic focal jammy noble trixie"
 
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'

--- a/test/azure-cli/install_bicep_trixie.sh
+++ b/test/azure-cli/install_bicep_trixie.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# Import test library for `check` command
+source dev-container-features-test-lib
+
+# Check to make sure the user is vscode
+check "user is vscode" whoami | grep vscode
+
+check "version" az  --version
+
+# Bicep-specific tests
+check "bicep" bicep --version
+check "az bicep" az bicep version
+
+# Report result
+reportResults
+

--- a/test/azure-cli/install_extensions_trixie.sh
+++ b/test/azure-cli/install_extensions_trixie.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+# Import test library for `check` command
+source dev-container-features-test-lib
+
+./install_extensions.sh
+

--- a/test/azure-cli/install_with_python_3_13_trixie.sh
+++ b/test/azure-cli/install_with_python_3_13_trixie.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+# Import test library for `check` command
+source dev-container-features-test-lib
+
+
+echo -e "\n🔄 Testing 'O.S'"
+if cat /etc/os-release | grep -q 'PRETTY_NAME="Debian GNU/Linux 13 (trixie)"'; then
+    echo -e "\n✅ Passed 'O.S is Linux 13 (trixie)'!\n"
+else
+    echo -e "\n❌ Failed 'O.S is other than Linux 13 (trixie)'!\n"
+fi
+
+# Check to make sure the user is vscode
+check "user is vscode" whoami | grep vscode
+check "version" az  --version
+
+# Report result
+reportResults
+

--- a/test/azure-cli/scenarios.json
+++ b/test/azure-cli/scenarios.json
@@ -1,4 +1,14 @@
 {
+  "install_extensions_trixie": {
+    "image": "mcr.microsoft.com/devcontainers/base:trixie",
+    "user": "vscode",
+    "features": {
+      "azure-cli": {
+        "version": "latest",
+        "extensions": "aks-preview,amg,containerapp"
+      }
+    }
+  },  
   "install_extensions": {
     "image": "mcr.microsoft.com/devcontainers/base:jammy",
     "user": "vscode",
@@ -29,6 +39,16 @@
       }
     }
   },
+    "install_bicep_trixie": {
+    "image": "mcr.microsoft.com/devcontainers/base:trixie",
+    "user": "vscode",
+    "features": {
+      "azure-cli": {
+        "version": "latest",
+        "installBicep": true
+      }
+    }
+  },
   "install_with_python": {
     "image": "mcr.microsoft.com/devcontainers/base:jammy",
     "user": "vscode",
@@ -39,6 +59,16 @@
       }
     }
   },
+  "install_with_python_3_13_trixie": {
+    "image": "mcr.microsoft.com/devcontainers/python:2-3.13-trixie",
+    "user": "vscode",
+    "features": {
+      "azure-cli": {
+        "version": "latest",
+        "installUsingPython": true
+      }
+    }
+  },  
   "install_with_python_3_12_bookworm": {
     "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
     "user": "vscode",


### PR DESCRIPTION
**Ref:** #1474  

**Description:** This PR aims to solve https://github.com/devcontainers/features/issues/1474 to support azure-cli installation in debian trixie(13). 

**Changelog:** The following changes are included.

- The installation script is changed to add support for Debian Trixie.
- Change in devcontainer-feature.json to do version bump
- Test scripts for relevant options with Debian trixie base image.

**Checklist:**
- [x] All checks are passed. 