### PR TITLE
[github-cli] - Fix excessive wget download output in GitHub CLI feature

### DIFF
--- a/src/github-cli/devcontainer-feature.json
+++ b/src/github-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "github-cli",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "name": "GitHub CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/github-cli",
     "description": "Installs the GitHub CLI. Auto-detects latest version and installs needed dependencies.",

--- a/src/github-cli/install.sh
+++ b/src/github-cli/install.sh
@@ -195,14 +195,14 @@ install_deb_using_github() {
 
     mkdir -p /tmp/ghcli
     pushd /tmp/ghcli
-    wget https://github.com/cli/cli/releases/download/v${CLI_VERSION}/${cli_filename}
+    wget -q --show-progress --progress=dot:giga https://github.com/cli/cli/releases/download/v${CLI_VERSION}/${cli_filename}
     exit_code=$?
     set -e
     if [ "$exit_code" != "0" ]; then
         # Handle situation where git tags are ahead of what was is available to actually download
         echo "(!) github-cli version ${CLI_VERSION} failed to download. Attempting to fall back one version to retry..."
         find_prev_version_from_git_tags CLI_VERSION https://github.com/cli/cli
-        wget https://github.com/cli/cli/releases/download/v${CLI_VERSION}/${cli_filename}
+        wget -q --show-progress --progress=dot:giga https://github.com/cli/cli/releases/download/v${CLI_VERSION}/${cli_filename}
     fi
 
     dpkg -i /tmp/ghcli/${cli_filename}


### PR DESCRIPTION
**Ref:** #1477 

**Description:** This PR aims to solve #1477. This pull request makes  The update adds options for quieter output and better progress visibility during downloads.

**Changelog:** 

- A minor improvement to the `install_deb_using_github()` function in `src/github-cli/install.sh` by enhancing the `wget` command used to download the GitHub CLI release.
- Version bump.

**Checklist:**
- [x] All checks are passed. 