### PR TITLE
[docker-in-docker, docker-outside-of-docker] - Update documentation and putting a check to stop installation for Debian Trixie(13)

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -62,6 +62,10 @@ jobs:
             baseImage: ubuntu:jammy
           - features: oryx
             baseImage: mcr.microsoft.com/devcontainers/base:ubuntu
+          - features: docker-in-docker
+            baseImage: mcr.microsoft.com/devcontainers/base:debian         
+          - features: docker-outside-of-docker
+            baseImage: mcr.microsoft.com/devcontainers/base:debian             
     steps:
       - uses: actions/checkout@v4
 

--- a/src/docker-in-docker/NOTES.md
+++ b/src/docker-in-docker/NOTES.md
@@ -13,4 +13,6 @@ This docker-in-docker Dev Container Feature is roughly based on the [official do
 
 This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
 
+Debian Trixie (13) does not include moby-cli and related system packages, so the feature cannot install with "moby": "true". To use this feature on Trixie, please set "moby": "false" or choose a different base image (for example, Ubuntu 24.04).
+
 `bash` is required to execute the `install.sh` script.

--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-in-docker",
-    "version": "2.12.3",
+    "version": "2.12.4",
     "name": "Docker (Docker-in-Docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
     "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -195,6 +195,13 @@ export DEBIAN_FRONTEND=noninteractive
 # Fetch host/container arch.
 architecture="$(dpkg --print-architecture)"
 
+# Prevent attempting to install Moby on Debian trixie (packages removed)
+if [ "${USE_MOBY}" = "true" ] && [ "${ID}" = "debian" ] && [ "${VERSION_CODENAME}" = "trixie" ]; then
+    err "The 'moby' option is not supported on Debian 'trixie' because 'moby-cli' and related system packages have been removed from that distribution."
+    err "To continue, either set the feature option '\"moby\": false' or use a different base image (for example: 'debian:bookworm' or 'ubuntu-24.04')."
+    exit 1
+fi
+
 # Check if distro is supported
 if [ "${USE_MOBY}" = "true" ]; then
     if [[ "${DOCKER_MOBY_ARCHIVE_VERSION_CODENAMES}" != *"${VERSION_CODENAME}"* ]]; then

--- a/src/docker-outside-of-docker/NOTES.md
+++ b/src/docker-outside-of-docker/NOTES.md
@@ -58,4 +58,6 @@ services:
 
 This Feature should work on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed.
 
+Debian Trixie (13) does not include moby-cli and related system packages, so the feature cannot install with "moby": "true". To use this feature on Trixie, please set "moby": "false" or choose a different base image (for example, Ubuntu 24.04).
+
 `bash` is required to execute the `install.sh` script.

--- a/src/docker-outside-of-docker/devcontainer-feature.json
+++ b/src/docker-outside-of-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "docker-outside-of-docker",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "name": "Docker (docker-outside-of-docker)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker",
     "description": "Re-use the host docker socket, adding the Docker CLI to a container. Feature invokes a script to enable using a forwarded Docker socket within a container to run Docker commands.",

--- a/src/docker-outside-of-docker/install.sh
+++ b/src/docker-outside-of-docker/install.sh
@@ -201,6 +201,13 @@ fi
 # Fetch host/container arch.
 architecture="$(dpkg --print-architecture)"
 
+# Prevent attempting to install Moby on Debian trixie (packages removed)
+if [ "${USE_MOBY}" = "true" ] && [ "${ID}" = "debian" ] && [ "${VERSION_CODENAME}" = "trixie" ]; then
+    err "The 'moby' option is not supported on Debian 'trixie' because 'moby-cli' and related system packages have been removed from that distribution."
+    err "To continue, either set the feature option '\"moby\": false' or use a different base image (for example: 'debian:bookworm' or 'ubuntu-24.04')."
+    exit 1
+fi
+
 # Check if distro is supported
 if [ "${USE_MOBY}" = "true" ]; then
     if [[ "${DOCKER_MOBY_ARCHIVE_VERSION_CODENAMES}" != *"${VERSION_CODENAME}"* ]]; then

--- a/test/docker-in-docker/scenarios.json
+++ b/test/docker-in-docker/scenarios.json
@@ -154,7 +154,7 @@
         "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "docker-in-docker": {
-                "version": "26.1.4",
+                "version": "28.4.0",
                 "moby": "false",
                 "mobyBuildxVersion": "latest",
                 "dockerDashComposeVersion": "none",
@@ -170,7 +170,10 @@
     "docker_with_on_create_command": {
         "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
-            "docker-in-docker": {}
+            "docker-in-docker": {
+                "version": "latest",
+                "moby": "false"
+            }
         },
         "remoteUser": "vscode",
         "onCreateCommand": "docker ps && sleep 5s && docker ps"


### PR DESCRIPTION
Ref: #1466 

**Description:** This PR is related to #1466.  

**Changelog:** 

- A restriction put in place for both feature to stop installation with correct message for Debian Trixie(13) when `"moby": "true"`
- Update documentation
- Version bump.

**Checklist:**
- [x] All checks are passed. 