### PR TITLE
Disable Moby usage for Debian 'trixie' codename to ensure compatibility

### DIFF
--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -195,11 +195,10 @@ export DEBIAN_FRONTEND=noninteractive
 # Fetch host/container arch.
 architecture="$(dpkg --print-architecture)"
 
-# Prevent attempting to install Moby on Debian trixie (packages removed)
+# Handle moby option for Debian trixie
 if [ "${USE_MOBY}" = "true" ] && [ "${ID}" = "debian" ] && [ "${VERSION_CODENAME}" = "trixie" ]; then
-    err "The 'moby' option is not supported on Debian 'trixie' because 'moby-cli' and related system packages have been removed from that distribution."
-    err "To continue, either set the feature option '\"moby\": false' or use a different base image (for example: 'debian:bookworm' or 'ubuntu-24.04')."
-    exit 1
+     echo "The 'moby' option is not supported on Debian 'trixie', hence setting moby to false"
+    USE_MOBY="false"
 fi
 
 # Check if distro is supported

--- a/test/docker-in-docker/debian_trixie_with_moby.sh
+++ b/test/docker-in-docker/debian_trixie_with_moby.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "docker installed" bash -c "type docker"
+
+# Report results
+reportResults

--- a/test/docker-in-docker/debian_trixie_without_moby.sh
+++ b/test/docker-in-docker/debian_trixie_without_moby.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Import test library
+source dev-container-features-test-lib
+
+# Definition specific tests
+check "docker installed" bash -c "type docker"
+
+# Report results
+reportResults

--- a/test/docker-in-docker/scenarios.json
+++ b/test/docker-in-docker/scenarios.json
@@ -177,5 +177,21 @@
         },
         "remoteUser": "vscode",
         "onCreateCommand": "docker ps && sleep 5s && docker ps"
+    },
+    "debian_trixie_without_moby": {
+        "image": "mcr.microsoft.com/devcontainers/base:trixie",
+        "features": {
+            "docker-in-docker": {
+                "moby": false
+            }
+        }
+    },
+    "debian_trixie_with_moby": {
+        "image": "mcr.microsoft.com/devcontainers/base:trixie",
+        "features": {
+            "docker-in-docker": {
+                "moby": true
+            }
+        }
     }
 }


### PR DESCRIPTION
Devcontainer 
docker-in-docker 
Description of changes:
Change in install.sh to set USE_Moby:false if debian trixie is detected 
Tested two scenarios with moby is true and moby is false
Checklist 
Changes applied are successful.