### PR TITLE
Use /etc/profile.d to set PATH for dotnet tools

### DIFF
--- a/src/dotnet/devcontainer-feature.json
+++ b/src/dotnet/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "dotnet",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "name": "Dotnet CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/dotnet",
     "description": "This Feature installs the latest .NET SDK, which includes the .NET CLI and the shared runtime. Options are provided to choose a different version or additional versions.",
@@ -45,7 +45,7 @@
     },
     "containerEnv": {
         "DOTNET_ROOT": "/usr/share/dotnet",
-        "PATH": "$PATH:$DOTNET_ROOT:~/.dotnet/tools",
+        "PATH": "$PATH:$DOTNET_ROOT",
         "DOTNET_RUNNING_IN_CONTAINER": "true",
         "DOTNET_USE_POLLING_FILE_WATCHER": "true"
     },

--- a/src/dotnet/install.sh
+++ b/src/dotnet/install.sh
@@ -146,6 +146,13 @@ if [ ! -e /usr/bin/dotnet ]; then
     ln --symbolic "$DOTNET_ROOT/dotnet" /usr/bin/dotnet
 fi
 
+# Add .NET Core SDK tools to PATH for bash and zsh users
+# This is where 'dotnet tool install --global <tool>' installs tools to
+# Use single-quoted EOF to defer $PATH expansion until sourcing the file
+cat << 'EOF' >> /etc/profile.d/dotnet.sh
+export PATH="$PATH:$HOME/.dotnet/tools"
+EOF
+
 # Clean up
 rm -rf /var/lib/apt/lists/*
 rm -rf scripts


### PR DESCRIPTION
Back in #628, I added `~/.dotnet/tools` to the `PATH` using a relative path in `containerEnv`, so dotnet global tools would work regardless of the container user.

While this worked for running dotnet global tools, it broke compatibility with `find -execdir`, which treats relative paths in `PATH` as unsafe.

This PR removes the relative path from `containerEnv` and instead adds a script to `/etc/profile.d` that appends `$HOME/.dotnet/tools` to `PATH` for login shells. This preserves global tool functionality without compromising security.