### PR TITLE
Bump common-utils version

### DIFF
--- a/src/common-utils/devcontainer-feature.json
+++ b/src/common-utils/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "common-utils",
-    "version": "2.5.5",
+    "version": "2.5.6",
     "name": "Common Utilities",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/common-utils",
     "description": "Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.",


### PR DESCRIPTION
Bumping `common-utils` version to include the changes in #1484.

The version was bumped to 2.5.5 in separate PRs, #1510 and #1484, so the [release job](https://github.com/devcontainers/features/actions/runs/19537546598/job/55935224825#step:3:328) for #1484 didn't publish a new version of the feature.

cc @msarahan @AlvaroRausell