### PR TITLE
[dotnet] - Removing dotnet 10 preview and daily versions.

### DIFF
--- a/src/dotnet/devcontainer-feature.json
+++ b/src/dotnet/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "dotnet",
-    "version": "2.4.1",
+    "version": "2.4.2",
     "name": "Dotnet CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/dotnet",
     "description": "This Feature installs the latest .NET SDK, which includes the .NET CLI and the shared runtime. Options are provided to choose a different version or additional versions.",
@@ -12,8 +12,6 @@
                 "lts",
                 "none",
                 "10.0",
-                "10.0-preview",
-                "10.0-daily",
                 "9.0",
                 "8.0",
                 "7.0",

--- a/test/dotnet/install_dotnet_specific_release.sh
+++ b/test/dotnet/install_dotnet_specific_release.sh
@@ -13,13 +13,13 @@ source dev-container-features-test-lib
 source dotnet_env.sh
 source dotnet_helpers.sh
 
-expected=$(fetch_latest_version_in_channel "8.0")
+expected=$(fetch_latest_version_in_channel "10.0")
 
-check ".NET Core SDK 8.0 installed" \
+check ".NET Core SDK 10.0 installed" \
 is_dotnet_sdk_version_installed "$expected"
 
 check "Build and run example project" \
-dotnet run --project projects/net8.0 
+dotnet run --project projects/net10.0 
 
 # Report results
 # If any of the checks above exited with a non-zero exit code, the test will fail.

--- a/test/dotnet/scenarios.json
+++ b/test/dotnet/scenarios.json
@@ -13,7 +13,7 @@
         "remoteUser": "vscode",
         "features": {
             "dotnet": {
-                "version": "8.0"
+                "version": "10.0"
             }
         }
     },
@@ -46,30 +46,6 @@
                     "8.0",
                     "7.0"
                 ]
-            }
-        }
-    },
-    "install_dotnet_preview": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-        "remoteUser": "vscode",
-        "features": {
-            "dotnet": {
-                "version": "10.0-preview",
-                "additionalVersions": "10.0.1xx-preview",
-                "aspnetcoreRuntimeVersions": "10.0-preview",
-                "dotnetRuntimeVersions": "10.0-preview"
-            }
-        }
-    },
-    "install_dotnet_daily": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
-        "remoteUser": "vscode",
-        "features": {
-            "dotnet": {
-                "version": "10.0-daily",
-                "additionalVersions": "10.0.1xx-daily",
-                "aspnetcoreRuntimeVersions": "10.0-daily",
-                "dotnetRuntimeVersions": "10.0-daily"
             }
         }
     },


### PR DESCRIPTION
Ref: [Internal issue](https://github.com/devcontainers/internal/issues/333#issuecomment-3744646299) 

**Description:** This PR is done to remove `preview` and `daily` version of dotnet 10 and dotnet 10 lts version is now available. 

**Changelog:** 

- Update devcontainer-feature.json to remove `preview` and `daily` versions of dotnet 10
- Version bump.
- Update scenarios.json to remove tests related to `preview` and `daily` versions of dotnet 10.

**Checklist:**
- [x] All checks are passed. 