### PR TITLE
Fix SDKMAN GLIBC 2.30 incompatibility on RHEL 8 family systems

### DIFF
--- a/src/java/devcontainer-feature.json
+++ b/src/java/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "java",
-  "version": "1.6.3",
+  "version": "1.7.2",
   "name": "Java (via SDKMAN!)",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/java",
   "description": "Installs Java, SDKMAN! (if not installed), and needed dependencies.",

--- a/test/java/install_latest_version.sh
+++ b/test/java/install_latest_version.sh
@@ -9,7 +9,7 @@ echo 'public class HelloWorld { public static void main(String[] args) { System.
 javac HelloWorld.java
 
 check "hello world" /bin/bash -c "java HelloWorld | grep "Hello, World!""
-check "java version latest installed" grep "24" <(java --version)
+check "java version latest installed" grep "25" <(java --version)
 
 # Report result
 reportResults


### PR DESCRIPTION
Fixes SDKMAN GLIBC issue for RHEL 8 causing failing Action.

Original PR (merged into another feature branch): https://github.com/devcontainers/features/pull/1568