### PR TITLE
Fix certificate verification for Ubuntu 24.04/Debian Trixie in docker features

### DIFF
--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,94 +1,94 @@
 {
-    "id": "docker-in-docker",
-    "version": "2.14.0",
-    "name": "Docker (Docker-in-Docker)",
-    "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
-    "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",
-    "options": {
-        "version": {
-            "type": "string",
-            "proposals": [
-                "latest",
-                "none",
-                "20.10"
-            ],
-            "default": "latest",
-            "description": "Select or enter a Docker/Moby Engine version. (Availability can vary by OS version.)"
-        },
-        "moby": {
-            "type": "boolean",
-            "default": true,
-            "description": "Install OSS Moby build instead of Docker CE"
-        },
-        "mobyBuildxVersion": {
-            "type": "string",
-            "default": "latest",
-            "description": "Install a specific version of moby-buildx when using Moby"
-        },
-        "dockerDashComposeVersion": {
-            "type": "string",
-            "enum": [
-                "none",
-                "v1",
-                "v2"
-            ],
-            "default": "v2",
-            "description": "Default version of Docker Compose (v1, v2 or none)"
-        },
-        "azureDnsAutoDetection": {
-            "type": "boolean",
-            "default": true,
-            "description": "Allow automatically setting the dockerd DNS server when the installation script detects it is running in Azure"
-        },
-        "dockerDefaultAddressPool": {
-            "type": "string",
-            "default": "",
-            "proposals": [],
-            "description": "Define default address pools for Docker networks. e.g. base=192.168.0.0/16,size=24"
-        },
-        "installDockerBuildx": {
-            "type": "boolean",
-            "default": true,
-            "description": "Install Docker Buildx"
-        },
-        "installDockerComposeSwitch": {
-            "type": "boolean",
-            "default": false,
-            "description": "Install Compose Switch (provided docker compose is available) which is a replacement to the Compose V1 docker-compose (python) executable. It translates the command line into Compose V2 docker compose then runs the latter."
-        },
-        "disableIp6tables": {
-            "type": "boolean",
-            "default": false,
-            "description": "Disable ip6tables (this option is only applicable for Docker versions 27 and greater)"
-        }
+  "id": "docker-in-docker",
+  "version": "2.16.0",
+  "name": "Docker (Docker-in-Docker)",
+  "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
+  "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",
+  "options": {
+    "version": {
+      "type": "string",
+      "proposals": [
+        "latest",
+        "none",
+        "20.10"
+      ],
+      "default": "latest",
+      "description": "Select or enter a Docker/Moby Engine version. (Availability can vary by OS version.)"
     },
-    "entrypoint": "/usr/local/share/docker-init.sh",
-    "privileged": true,
-    "containerEnv": {
-        "DOCKER_BUILDKIT": "1"
+    "moby": {
+      "type": "boolean",
+      "default": true,
+      "description": "Install OSS Moby build instead of Docker CE"
     },
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                "ms-azuretools.vscode-containers"
-            ],
-            "settings": {
-                "github.copilot.chat.codeGeneration.instructions": [
-                    {
-                        "text": "This dev container includes the Docker CLI (`docker`) pre-installed and available on the `PATH` for running and managing containers using a dedicated Docker daemon running inside the dev container."
-                    }
-                ]
-            }
-        }
+    "mobyBuildxVersion": {
+      "type": "string",
+      "default": "latest",
+      "description": "Install a specific version of moby-buildx when using Moby"
     },
-    "mounts": [
-        {
-            "source": "dind-var-lib-docker-${devcontainerId}",
-            "target": "/var/lib/docker",
-            "type": "volume"
-        }
-    ],
-    "installsAfter": [
-        "ghcr.io/devcontainers/features/common-utils"
-    ]
+    "dockerDashComposeVersion": {
+      "type": "string",
+      "enum": [
+        "none",
+        "v1",
+        "v2"
+      ],
+      "default": "v2",
+      "description": "Default version of Docker Compose (v1, v2 or none)"
+    },
+    "azureDnsAutoDetection": {
+      "type": "boolean",
+      "default": true,
+      "description": "Allow automatically setting the dockerd DNS server when the installation script detects it is running in Azure"
+    },
+    "dockerDefaultAddressPool": {
+      "type": "string",
+      "default": "",
+      "proposals": [],
+      "description": "Define default address pools for Docker networks. e.g. base=192.168.0.0/16,size=24"
+    },
+    "installDockerBuildx": {
+      "type": "boolean",
+      "default": true,
+      "description": "Install Docker Buildx"
+    },
+    "installDockerComposeSwitch": {
+      "type": "boolean",
+      "default": false,
+      "description": "Install Compose Switch (provided docker compose is available) which is a replacement to the Compose V1 docker-compose (python) executable. It translates the command line into Compose V2 docker compose then runs the latter."
+    },
+    "disableIp6tables": {
+      "type": "boolean",
+      "default": false,
+      "description": "Disable ip6tables (this option is only applicable for Docker versions 27 and greater)"
+    }
+  },
+  "entrypoint": "/usr/local/share/docker-init.sh",
+  "privileged": true,
+  "containerEnv": {
+    "DOCKER_BUILDKIT": "1"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-containers"
+      ],
+      "settings": {
+        "github.copilot.chat.codeGeneration.instructions": [
+          {
+            "text": "This dev container includes the Docker CLI (`docker`) pre-installed and available on the `PATH` for running and managing containers using a dedicated Docker daemon running inside the dev container."
+          }
+        ]
+      }
+    }
+  },
+  "mounts": [
+    {
+      "source": "dind-var-lib-docker-${devcontainerId}",
+      "target": "/var/lib/docker",
+      "type": "volume"
+    }
+  ],
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/common-utils"
+  ]
 }

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -303,6 +303,13 @@ if ! command -v git >/dev/null 2>&1; then
     check_packages git
 fi
 
+# Update CA certificates to ensure HTTPS connections work properly
+# This is especially important for Ubuntu 24.04 (Noble) and Debian Trixie
+# Only run for Debian-based systems (RHEL uses update-ca-trust instead)
+if [ "${ADJUSTED_ID}" = "debian" ] && command -v update-ca-certificates > /dev/null 2>&1; then
+    update-ca-certificates
+fi
+
 # Swap to legacy iptables for compatibility (Debian only)
 if [ "${ADJUSTED_ID}" = "debian" ] && type iptables-legacy > /dev/null 2>&1; then
     update-alternatives --set iptables /usr/sbin/iptables-legacy

--- a/src/docker-outside-of-docker/devcontainer-feature.json
+++ b/src/docker-outside-of-docker/devcontainer-feature.json
@@ -1,80 +1,80 @@
 {
-    "id": "docker-outside-of-docker",
-    "version": "1.6.5",
-    "name": "Docker (docker-outside-of-docker)",
-    "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker",
-    "description": "Re-use the host docker socket, adding the Docker CLI to a container. Feature invokes a script to enable using a forwarded Docker socket within a container to run Docker commands.",
-    "options": {
-        "version": {
-            "type": "string",
-            "proposals": [
-                "latest",
-                "none",
-                "20.10"
-            ],
-            "default": "latest",
-            "description": "Select or enter a Docker/Moby CLI version. (Availability can vary by OS version.)"
-        },
-        "moby": {
-            "type": "boolean",
-            "default": true,
-            "description": "Install OSS Moby build instead of Docker CE"
-        },
-        "mobyBuildxVersion": {
-            "type": "string",
-            "default": "latest",
-            "description": "Install a specific version of moby-buildx when using Moby"
-        },
-        "dockerDashComposeVersion": {
-            "type": "string",
-            "enum": [
-                "none",
-                "v1",
-                "v2"
-            ],
-            "default": "v2",
-            "description": "Compose version to use for docker-compose (v1 or v2 or none)"
-        },
-        "installDockerBuildx": {
-            "type": "boolean",
-            "default": true,
-            "description": "Install Docker Buildx"
-        },
-        "installDockerComposeSwitch": {
-            "type": "boolean",
-            "default": true,
-            "description": "Install Compose Switch (provided docker compose is available) which is a replacement to the Compose V1 docker-compose (python) executable. It translates the command line into Compose V2 docker compose then runs the latter."
-        }
+  "id": "docker-outside-of-docker",
+  "version": "1.8.0",
+  "name": "Docker (docker-outside-of-docker)",
+  "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker",
+  "description": "Re-use the host docker socket, adding the Docker CLI to a container. Feature invokes a script to enable using a forwarded Docker socket within a container to run Docker commands.",
+  "options": {
+    "version": {
+      "type": "string",
+      "proposals": [
+        "latest",
+        "none",
+        "20.10"
+      ],
+      "default": "latest",
+      "description": "Select or enter a Docker/Moby CLI version. (Availability can vary by OS version.)"
     },
-    "entrypoint": "/usr/local/share/docker-init.sh",
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                "ms-azuretools.vscode-containers"
-            ],
-            "settings": {
-                "github.copilot.chat.codeGeneration.instructions": [
-                    {
-                        "text": "This dev container includes the Docker CLI (`docker`) pre-installed and available on the `PATH` for running and managing containers using the Docker daemon on the host machine."
-                    }
-                ]
-            }
-        }
+    "moby": {
+      "type": "boolean",
+      "default": true,
+      "description": "Install OSS Moby build instead of Docker CE"
     },
-    "mounts": [
-        {
-            "source": "/var/run/docker.sock",
-            "target": "/var/run/docker-host.sock",
-            "type": "bind"
-        }
-    ],
-    "securityOpt": [
-        "label=disable"
-    ],
-    "installsAfter": [
-        "ghcr.io/devcontainers/features/common-utils"
-    ],
-    "legacyIds": [
-        "docker-from-docker"
-    ]
+    "mobyBuildxVersion": {
+      "type": "string",
+      "default": "latest",
+      "description": "Install a specific version of moby-buildx when using Moby"
+    },
+    "dockerDashComposeVersion": {
+      "type": "string",
+      "enum": [
+        "none",
+        "v1",
+        "v2"
+      ],
+      "default": "v2",
+      "description": "Compose version to use for docker-compose (v1 or v2 or none)"
+    },
+    "installDockerBuildx": {
+      "type": "boolean",
+      "default": true,
+      "description": "Install Docker Buildx"
+    },
+    "installDockerComposeSwitch": {
+      "type": "boolean",
+      "default": true,
+      "description": "Install Compose Switch (provided docker compose is available) which is a replacement to the Compose V1 docker-compose (python) executable. It translates the command line into Compose V2 docker compose then runs the latter."
+    }
+  },
+  "entrypoint": "/usr/local/share/docker-init.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-containers"
+      ],
+      "settings": {
+        "github.copilot.chat.codeGeneration.instructions": [
+          {
+            "text": "This dev container includes the Docker CLI (`docker`) pre-installed and available on the `PATH` for running and managing containers using the Docker daemon on the host machine."
+          }
+        ]
+      }
+    }
+  },
+  "mounts": [
+    {
+      "source": "/var/run/docker.sock",
+      "target": "/var/run/docker-host.sock",
+      "type": "bind"
+    }
+  ],
+  "securityOpt": [
+    "label=disable"
+  ],
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/common-utils"
+  ],
+  "legacyIds": [
+    "docker-from-docker"
+  ]
 }

--- a/src/docker-outside-of-docker/install.sh
+++ b/src/docker-outside-of-docker/install.sh
@@ -192,6 +192,11 @@ export DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
 check_packages apt-transport-https curl ca-certificates gnupg2 dirmngr wget
+# Update CA certificates to ensure HTTPS connections work properly
+# This is especially important for Ubuntu 24.04 (Noble) and Debian Trixie
+if command -v update-ca-certificates > /dev/null 2>&1; then
+    update-ca-certificates
+fi
 if ! type git > /dev/null 2>&1; then
     check_packages git
 fi

--- a/test/docker-outside-of-docker/docker_dash_compose_v1.sh
+++ b/test/docker-outside-of-docker/docker_dash_compose_v1.sh
@@ -6,7 +6,6 @@ set -e
 source dev-container-features-test-lib
 
 # Definition specific tests
-check "docker compose" bash -c "docker compose version | grep -E '2.[0-9]+.[0-9]+'"
 check "docker-compose" bash -c "docker-compose --version | grep -E '1.[0-9]+.[0-9]+'"
 
 # Report result


### PR DESCRIPTION
Certificates aren't up-to-date in base image, so this runs a certificate update which fixes validation issues.

Original PR (merged into another feature branch): https://github.com/devcontainers/features/pull/1569