### PR TITLE
Fix kubectl-helm-minikube installation failures on debian:11 and ubuntu:focal

### DIFF
--- a/src/kubectl-helm-minikube/devcontainer-feature.json
+++ b/src/kubectl-helm-minikube/devcontainer-feature.json
@@ -35,6 +35,11 @@
       ],
       "default": "latest",
       "description": "Select or enter a Minikube version to install"
+    },
+    "kubectlFallbackVersion": {
+      "type": "string",
+      "default": "v1.35.1",
+      "description": "Fallback kubectl version to use when the latest stable version cannot be fetched"
     }
   },
   "mounts": [

--- a/src/kubectl-helm-minikube/install.sh
+++ b/src/kubectl-helm-minikube/install.sh
@@ -12,8 +12,8 @@ set -e
 # Clean up
 rm -rf /var/lib/apt/lists/*
 
-# Fallback version when stable.txt cannot be fetched (updated: 2026-02)
-KUBECTL_FALLBACK_VERSION="v1.35.1"
+# Fallback version when stable.txt cannot be fetched
+KUBECTL_FALLBACK_VERSION="${KUBECTLFALLBACKVERSION:-"v1.35.1"}"
 
 KUBECTL_VERSION="${VERSION:-"latest"}"
 HELM_VERSION="${HELM:-"latest"}"


### PR DESCRIPTION
The https://dl.k8s.io/release/stable.txt API used for determining latest K8s version can sometimes timeout, causing the feature to break. This fixes it by adding longer timeouts and fallback options.