### PR TITLE
fix(docker-in-docker): create /usr/local/share directory if it doesn't exist before writing …

### DIFF
--- a/src/docker-in-docker/devcontainer-feature.json
+++ b/src/docker-in-docker/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "docker-in-docker",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "name": "Docker (Docker-in-Docker)",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-in-docker",
   "description": "Create child containers *inside* a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.",

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -861,6 +861,10 @@ if [ "$DISABLE_IP6_TABLES" == true ]; then
     fi
 fi
 
+if [ ! -d /usr/local/share ]; then
+    mkdir -p /usr/local/share
+fi
+
 tee /usr/local/share/docker-init.sh > /dev/null \
 << EOF
 #!/bin/sh


### PR DESCRIPTION
When using a hardened images, such as https://hub.docker.com/hardened-images/catalog/dhi/debian-base the folder `/usr/local/share` doesn't exist. This causes errors such as:
```
tee: /usr/local/share/docker-init.sh: No such file or directory
```

This PR checks that the directory exists before creating the `/usr/local/share/docker-init.sh` script.