### PR TITLE
Fix Java feature: fallback to LTS when latest feature release is unavailable

### DIFF
--- a/src/java/devcontainer-feature.json
+++ b/src/java/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "java",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "name": "Java (via SDKMAN!)",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/java",
   "description": "Installs Java, SDKMAN! (if not installed), and needed dependencies.",

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -265,8 +265,19 @@ sdk_install() {
             set -e
         fi
         if [ -z "${requested_version}" ] || ! echo "${version_list}" | grep "^${requested_version//./\\.}$" > /dev/null 2>&1; then
-            echo -e "Version $2 not found. Available versions:\n${version_list}" >&2
-            exit 1
+            # Fallback to LTS if "latest" was requested and not found (java only)
+            if [ "$2" = "latest" ] && [ "${install_type}" = "java" ]; then
+                echo "Latest version not found in SDKMAN. Falling back to LTS..."
+                find_version_list "$prefix" "$suffix" "$install_type" "true" version_list "lts"
+                requested_version="$(echo "${version_list}" | head -n 1)"
+                if [ -z "${requested_version}" ] || ! echo "${version_list}" | grep "^${requested_version//./\\.}$" > /dev/null 2>&1; then
+                    echo -e "Version $2 (and LTS fallback) not found. Available versions:\n${version_list}" >&2
+                    exit 1
+                fi
+            else
+                echo -e "Version $2 not found. Available versions:\n${version_list}" >&2
+                exit 1
+            fi
         fi
     fi
     if [ "${set_as_default}" = "true" ]; then


### PR DESCRIPTION
**Description:** Fixes the failing [test-scenarios(java)](https://github.com/devcontainers/features/actions/runs/23594257734/job/68745367320#step:4:1484) GitHub Actions workflow. The Adoptium API now reports `most_recent_feature_release: 26`, but JDK 26 is not an LTS version and is therefore not available in either the `ms` (Microsoft OpenJDK) or `tem` (Eclipse Temurin) SDKMAN distributions. This causes the Java feature installation to fail when requesting `version: "latest"`.

**Changelog:** 

- Update the install script to fallback to `LTS` when the requested version is `latest` but resolved version not found for installation.
- Version bump.

**Checklist:**
- [x] All checks are passed. 