### PR TITLE
[conda] - Upgrade incompatible pluggy library to prevent conda installation failure.

### DIFF
--- a/src/conda/devcontainer-feature.json
+++ b/src/conda/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "conda",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "name": "Conda",
   "description": "A cross-platform, language-agnostic binary package manager",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/conda",

--- a/src/conda/install.sh
+++ b/src/conda/install.sh
@@ -179,6 +179,9 @@ if ! conda --version &> /dev/null ; then
     install_user_package cryptography
     # Due to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-40897
     install_user_package setuptools
+
+    install_user_package pluggy
+
 fi
 
 # Display a notice on conda when not running in GitHub Codespaces

--- a/test/conda/conda_channel_creation.sh
+++ b/test/conda/conda_channel_creation.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+## Test Conda
+check "conda-update-conda" bash -c "conda update -c defaults -y conda"
+check "conda-install-tensorflow" bash -c "conda create --name test-env -c conda-forge --yes tensorflow"
+check "conda-install-pytorch" bash -c "conda create --name test-env -c conda-forge --yes pytorch"
+
+# Report result
+reportResults

--- a/test/conda/install_conda_package_after_upgrade.sh
+++ b/test/conda/install_conda_package_after_upgrade.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Test that conda can install packages without pluggy incompatibility errors
+# This validates the fix for the pluggy/conda version mismatch issue where
+# conda self-upgrades but the older pluggy lacks the 'wrapper' attribute
+check "conda version" conda --version
+check "install pyopenssl" conda install -y -c defaults pyopenssl
+check "install cryptography" conda install -y -c defaults cryptography
+check "conda-forge" conda config --show channels | grep conda-forge
+check "if conda-notice.txt exists" cat /usr/local/etc/vscode-dev-containers/conda-notice.txt
+
+# Report result
+reportResults

--- a/test/conda/scenarios.json
+++ b/test/conda/scenarios.json
@@ -7,5 +7,17 @@
                 "addCondaForge": "true"
             }
         }
+    },
+    "install_conda_package_after_upgrade": {
+        "image": "ubuntu:noble",
+        "features": {
+            "conda": {}
+        }
+    },
+    "conda_channel_creation": {
+        "image": "ubuntu:noble",
+        "features": {
+            "conda": {}
+        }
     }
 }


### PR DESCRIPTION
**Description:** Fixes the failing [universal image build](https://github.com/devcontainers/images/actions/runs/24035439256/job/70382620344) in devcontainers/images repository. The conda  dev container feature is installing the latest available conda version in anaconda `24.5.0` but while installing any python library using conda upgrades conda to `26.3.1` which is incompatible with existing version of existing conda system python library `pluggy`. Ideally this should be fixed upstream in anaconda but as a workaround upgrading `pluggy` in the conda feature installation script explicitly.

**Changelog:** 

- Upgrading `pluggy` in the conda feature installation script.
- Added tests.
- Version bump.

**Checklist:**
- [x] All checks are passed. 