### PR TITLE
[Desktop-lite]  desktop-init.sh drops entrypoint args due to heredoc variable expansion

### DIFF
--- a/src/desktop-lite/devcontainer-feature.json
+++ b/src/desktop-lite/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "desktop-lite",
-    "version": "1.2.8",
+    "version": "1.2.9",
     "name": "Light-weight Desktop",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/desktop-lite",
     "description": "Adds a lightweight Fluxbox based desktop to the container that can be accessed using a VNC viewer or the web. GUI-based commands executed from the built-in VS code terminal will open on the desktop automatically.",

--- a/src/desktop-lite/install.sh
+++ b/src/desktop-lite/install.sh
@@ -409,9 +409,9 @@ else
 fi
 
 # Run whatever was passed in
-if [ -n "$1" ]; then
+if [ -n "\$1" ]; then
     log "Executing \"\$@\"."
-    exec "$@"
+    exec "\$@"
 else
     log "No command provided to execute."
 fi

--- a/test/desktop-lite/scenarios.json
+++ b/test/desktop-lite/scenarios.json
@@ -12,13 +12,12 @@
                 "noVncVersion": "1.2.0"
             }
         }
-    },    
+    },
     "test_vnc_resolution_as_container_env_var": {
         "image": "ubuntu:noble",
         "features": {
             "desktop-lite": {}
-        }
-        ,
+        },
         "containerEnv": {
             "VNC_RESOLUTION": "1920x1080x32"
         },
@@ -42,6 +41,12 @@
     },
     "test_xtigervnc_novnc_started_trixie": {
         "image": "debian:trixie",
+        "features": {
+            "desktop-lite": {}
+        }
+    },
+    "test_desktop_init_exec_passthrough": {
+        "image": "ubuntu:noble",
         "features": {
             "desktop-lite": {}
         }

--- a/test/desktop-lite/test_desktop_init_exec_passthrough.sh
+++ b/test/desktop-lite/test_desktop_init_exec_passthrough.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Verify that desktop-init.sh correctly passes through commands.
+# Previously, the heredoc in install.sh did not escape $1 and $@, causing them to expand
+# to empty strings at install time, so any command passed to desktop-init.sh was silently ignored.
+
+check "command is passed through and executed" \
+    bash -c "result=\$(/usr/local/share/desktop-init.sh echo 'passthrough-test-token' 2>/dev/null) && echo \"\$result\" | grep -q 'passthrough-test-token'"
+
+# Report result
+reportResults


### PR DESCRIPTION
Fix: https://github.com/devcontainers/features/issues/1615

The desktop-lite feature's install.sh generates the entrypoint script desktop-init.sh using an unquoted heredoc (cat << EOF). At the end of this heredoc, `$1 and $@ `were not escaped, so they expanded to empty strings at install time. So any command passed to the container entrypoint was silently ignored.