### PR TITLE
[conda] - Version bump

### DIFF
--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -41,7 +41,6 @@ jobs:
             "terraform",
             "nix",
         ]
-        # ubuntu:focal reached EOL Apr 2025; Removed it now now.
         baseImage:
           [
             "ubuntu:jammy",

--- a/.github/workflows/test-all.yaml
+++ b/.github/workflows/test-all.yaml
@@ -41,9 +41,9 @@ jobs:
             "terraform",
             "nix",
         ]
+        # ubuntu:focal reached EOL Apr 2025; Removed it now now.
         baseImage:
           [
-            "ubuntu:focal",
             "ubuntu:jammy",
             "debian:11",
             "debian:12",

--- a/.github/workflows/test-manual.yaml
+++ b/.github/workflows/test-manual.yaml
@@ -9,7 +9,7 @@ on:
       baseImage:
         description: "Base image"
         required: true
-        default: "ubuntu:focal"
+        default: "ubuntu:noble"
       logLevel:
         description: "Log Level (info/debug/trace)"
         required: true

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -48,7 +48,6 @@ jobs:
     strategy:
       matrix:
         features: ${{ fromJSON(needs.detect-changes.outputs.features) }}
-        # ubuntu:focal reached EOL Apr 2025; Removed it now now.
         baseImage:
           [
             "ubuntu:jammy",

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -48,9 +48,9 @@ jobs:
     strategy:
       matrix:
         features: ${{ fromJSON(needs.detect-changes.outputs.features) }}
+        # ubuntu:focal reached EOL Apr 2025; Removed it now now.
         baseImage:
           [
-            "ubuntu:focal",
             "ubuntu:jammy",
             "debian:11",
             "debian:12",

--- a/src/conda/devcontainer-feature.json
+++ b/src/conda/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "conda",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "name": "Conda",
   "description": "A cross-platform, language-agnostic binary package manager",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/conda",


### PR DESCRIPTION
Version bump is done to push the [PR change](https://github.com/devcontainers/features/pull/1622) to GHCR. As per the current deployment logic in the CI pipeline, the feature will only be published in GHCR when a version change is detected, [ref](https://github.com/devcontainers/features/actions/runs/24516146012/job/71660570418#step:3:342).

Also removing `ubuntu:focal` base image reference from the test workflows as most of these tests are now failing on focal due to either unavailability of system package repositories or incompatibility with latest version of individual dev container feature. This is happening because `ubuntu:focal` has been deprecated for over an year now. Therefore it would be prudent to remove it as it isn't a stable platform for tests any longer due to obsolescence.