### PR TITLE
Add default `copilot update` to `postStartCommand`

### DIFF
--- a/src/copilot-cli/devcontainer-feature.json
+++ b/src/copilot-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "copilot-cli",
-    "version": "1.1.1",
+    "version": "1.1.0",
     "name": "GitHub Copilot CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/copilot-cli",
     "description": "Installs the GitHub Copilot CLI.",

--- a/src/copilot-cli/devcontainer-feature.json
+++ b/src/copilot-cli/devcontainer-feature.json
@@ -15,7 +15,7 @@
             "description": "Select version of the GitHub Copilot CLI, if not latest."
         }
     },
-    "postStartCommand": "[ -f /etc/devcontainer-copilot-cli/use-latest ] && copilot update || true",
+    "postStartCommand": "[ -f /etc/devcontainer-copilot-cli/auto-update ] && copilot update || true",
     "customizations": {
         "vscode": {
             "settings": {

--- a/src/copilot-cli/devcontainer-feature.json
+++ b/src/copilot-cli/devcontainer-feature.json
@@ -15,7 +15,7 @@
             "description": "Select version of the GitHub Copilot CLI, if not latest."
         }
     },
-    "postStartCommand": "copilot update",
+    "postStartCommand": "[ -f /etc/devcontainer-copilot-cli/use-latest ] && copilot update || true",
     "customizations": {
         "vscode": {
             "settings": {

--- a/src/copilot-cli/devcontainer-feature.json
+++ b/src/copilot-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "copilot-cli",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "name": "GitHub Copilot CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/copilot-cli",
     "description": "Installs the GitHub Copilot CLI.",

--- a/src/copilot-cli/devcontainer-feature.json
+++ b/src/copilot-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "copilot-cli",
-    "version": "1.1.0",
+    "version": "1.1.2",
     "name": "GitHub Copilot CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/copilot-cli",
     "description": "Installs the GitHub Copilot CLI.",

--- a/src/copilot-cli/devcontainer-feature.json
+++ b/src/copilot-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "copilot-cli",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "name": "GitHub Copilot CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/copilot-cli",
     "description": "Installs the GitHub Copilot CLI.",

--- a/src/copilot-cli/devcontainer-feature.json
+++ b/src/copilot-cli/devcontainer-feature.json
@@ -15,6 +15,7 @@
             "description": "Select version of the GitHub Copilot CLI, if not latest."
         }
     },
+    "postStartCommand": "copilot update",
     "customizations": {
         "vscode": {
             "settings": {

--- a/src/copilot-cli/install.sh
+++ b/src/copilot-cli/install.sh
@@ -80,3 +80,9 @@ echo "Downloading GitHub Copilot CLI..."
 
 install_using_github
 
+# Create a flag file if using "latest" so the postStartCommand knows to auto-update
+if [ "${CLI_VERSION}" = "latest" ]; then
+    mkdir -p /etc/devcontainer-copilot-cli
+    touch /etc/devcontainer-copilot-cli/use-latest
+fi
+

--- a/src/copilot-cli/install.sh
+++ b/src/copilot-cli/install.sh
@@ -81,7 +81,7 @@ echo "Downloading GitHub Copilot CLI..."
 install_using_github
 
 # Create a flag file if using "latest" or "prerelease" so the postStartCommand knows to auto-update
-if [ "${CLI_VERSION}" = "latest" || "${CLI_VERSION}" = "prerelease" ]; then
+if [ "${CLI_VERSION}" = "latest" ] || [ "${CLI_VERSION}" = "prerelease" ]; then
     mkdir -p /etc/devcontainer-copilot-cli
     touch /etc/devcontainer-copilot-cli/auto-update
 fi

--- a/src/copilot-cli/install.sh
+++ b/src/copilot-cli/install.sh
@@ -80,9 +80,9 @@ echo "Downloading GitHub Copilot CLI..."
 
 install_using_github
 
-# Create a flag file if using "latest" so the postStartCommand knows to auto-update
-if [ "${CLI_VERSION}" = "latest" ]; then
+# Create a flag file if using "latest" or "prerelease" so the postStartCommand knows to auto-update
+if [ "${CLI_VERSION}" = "latest" || "${CLI_VERSION}" = "prerelease" ]; then
     mkdir -p /etc/devcontainer-copilot-cli
-    touch /etc/devcontainer-copilot-cli/use-latest
+    touch /etc/devcontainer-copilot-cli/auto-update
 fi
 


### PR DESCRIPTION
Now every time the container restarts copilot will upgrade itself so that you're on the latest version.

Open to feedback on if this should be in `postCreateCommand` so that it's only done once when the container is created.