### PR TITLE
[node] - Install pnpm as non-root user to prevent root-owned npm cache

### DIFF
--- a/src/node/devcontainer-feature.json
+++ b/src/node/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "node",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "name": "Node.js (via nvm), yarn and pnpm.",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/node",
     "description": "Installs Node.js, nvm, yarn, pnpm, and needed dependencies.",

--- a/src/node/devcontainer-feature.json
+++ b/src/node/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "node",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "name": "Node.js (via nvm), yarn and pnpm.",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/node",
     "description": "Installs Node.js, nvm, yarn, pnpm, and needed dependencies.",

--- a/src/node/install.sh
+++ b/src/node/install.sh
@@ -482,13 +482,7 @@ if [ ! -z "${PNPM_VERSION}" ] && [ "${PNPM_VERSION}" = "none" ]; then
     echo "Ignoring installation of PNPM"
 else
     if bash -c ". '${NVM_DIR}/nvm.sh' && type npm >/dev/null 2>&1"; then
-        (
-            . "${NVM_DIR}/nvm.sh"
-            [ ! -z "$http_proxy" ] && npm set proxy="$http_proxy"
-            [ ! -z "$https_proxy" ] && npm set https-proxy="$https_proxy"
-            [ ! -z "$no_proxy" ] && npm set noproxy="$no_proxy"
-            npm install -g pnpm@$PNPM_VERSION --force
-        )
+        su ${USERNAME} -c "umask 0002 && . '${NVM_DIR}/nvm.sh' && npm install -g pnpm@${PNPM_VERSION} --force"
     else
         echo "Skip installing pnpm because npm is missing"
     fi


### PR DESCRIPTION
Currently, the pnpm installation block runs `npm install -g pnpm` in a bare subshell as root, unlike every other npm/nvm operation in the script which uses `su ${USERNAME}`. This causes the npm cache directory to be created owned by `root:root`, leading to `EACCES` errors for the non-root user on subsequent npm operations.

This is particularly reproducible on macOS with Rosetta 2 emulation, where the cache directory may not already exist from prior steps.

Note, the explicit setting of proxy env vars (`http_proxy`, `https_proxy`, `no_proxy`) is likely a workaround for https://github.com/npm/cli/issues/6835. No other commands in this script use that workaround anymore, so this change uses the same `su` syntax as all other commands.