### PR TITLE
Fix `aws-cli` completion for ZSH

### DIFF
--- a/src/aws-cli/devcontainer-feature.json
+++ b/src/aws-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "aws-cli",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "name": "AWS CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/aws-cli",
     "description": "Installs the AWS CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.",

--- a/src/aws-cli/install.sh
+++ b/src/aws-cli/install.sh
@@ -119,16 +119,14 @@ install() {
     
     ./aws/install
 
-    # kubectl bash completion
+    # AWS bash completion
     mkdir -p /etc/bash_completion.d
     cp ./scripts/vendor/aws_bash_completer /etc/bash_completion.d/aws
 
-    # kubectl zsh completion
-    if [ -e "${USERHOME}/.oh-my-zsh" ]; then
-        mkdir -p "${USERHOME}/.oh-my-zsh/completions"
-        cp ./scripts/vendor/aws_zsh_completer.sh "${USERHOME}/.oh-my-zsh/completions/_aws"
-        chown -R "${USERNAME}" "${USERHOME}/.oh-my-zsh"
-    fi
+    # AWS zsh completion
+    mkdir -p /usr/local/share/zsh/site-functions/
+    cp ./scripts/vendor/aws_zsh_completer.sh /usr/local/share/zsh/site-functions/_aws
+    sed -i '1s/^/#compdef aws\n/' /usr/local/share/zsh/site-functions/_aws
 
     rm -rf ./aws
 }

--- a/test/aws-cli/scenarios.json
+++ b/test/aws-cli/scenarios.json
@@ -4,5 +4,14 @@
         "features": {
             "aws-cli": {}
         }
+    },
+    "zsh_completion": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "common-utils": {
+                "installZsh": true
+            },
+            "aws-cli": {}
+        }
     }
 }

--- a/test/aws-cli/zsh_completion.sh
+++ b/test/aws-cli/zsh_completion.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+# Import test library for `check` command
+source dev-container-features-test-lib
+
+# Check that the zsh completion file exists in the correct location
+check "zsh completion file installed" test -f /usr/local/share/zsh/site-functions/_aws
+
+# Check that the completion file has the proper zsh completion header
+check "zsh completion file has compdef header" grep -q "^#compdef aws" /usr/local/share/zsh/site-functions/_aws
+
+# Actual ZSH completion testing is a pain, so just ignoring it for now.
+
+# Report result
+reportResults


### PR DESCRIPTION
The ZSH completer script provided by the [aws/aws-cli repo](https://github.com/aws/aws-cli/blob/develop/bin/aws_zsh_completer.sh) is not set up to be used as a completer function, and thus cannot be dropped into a directory like `~/.oh-my-zsh/completions` and be expected to work.

This change also moves the completer to a more standard location for system-wide ZSH completions, and adds the necessary header to make it work as a completer.