### PR TITLE
Revert "Add default `copilot update` to `postStartCommand`"

### DIFF
--- a/src/copilot-cli/devcontainer-feature.json
+++ b/src/copilot-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "copilot-cli",
-    "version": "1.0.0",
+    "version": "1.2.0",
     "name": "GitHub Copilot CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/copilot-cli",
     "description": "Installs the GitHub Copilot CLI.",

--- a/src/copilot-cli/devcontainer-feature.json
+++ b/src/copilot-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "copilot-cli",
-    "version": "1.1.2",
+    "version": "1.0.0",
     "name": "GitHub Copilot CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/copilot-cli",
     "description": "Installs the GitHub Copilot CLI.",
@@ -15,7 +15,6 @@
             "description": "Select version of the GitHub Copilot CLI, if not latest."
         }
     },
-    "postStartCommand": "[ -f /etc/devcontainer-copilot-cli/auto-update ] && copilot update || true",
     "customizations": {
         "vscode": {
             "settings": {

--- a/src/copilot-cli/install.sh
+++ b/src/copilot-cli/install.sh
@@ -80,9 +80,3 @@ echo "Downloading GitHub Copilot CLI..."
 
 install_using_github
 
-# Create a flag file if using "latest" or "prerelease" so the postStartCommand knows to auto-update
-if [ "${CLI_VERSION}" = "latest" ] || [ "${CLI_VERSION}" = "prerelease" ]; then
-    mkdir -p /etc/devcontainer-copilot-cli
-    touch /etc/devcontainer-copilot-cli/auto-update
-fi
-


### PR DESCRIPTION
Reverts devcontainers/features#1624. Initial testing shows that it blcoks for around 25 seconds on Codespaces starts.