### PR TITLE
Fix broken golangci-lint installation in go feature

### DIFF
--- a/src/go/install.sh
+++ b/src/go/install.sh
@@ -325,11 +325,11 @@ if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
     # Install golangci-lint from precompiled binares
     if [ "$GOLANGCILINT_VERSION" = "latest" ] || [ "$GOLANGCILINT_VERSION" = "" ]; then
         echo "Installing golangci-lint latest..."
-        curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
+        curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh | \
             sh -s -- -b "${TARGET_GOPATH}/bin"
     else
         echo "Installing golangci-lint ${GOLANGCILINT_VERSION}..."
-        curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
+        curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh | \
             sh -s -- -b "${TARGET_GOPATH}/bin" "v${GOLANGCILINT_VERSION}"
     fi
 

--- a/src/go/install.sh
+++ b/src/go/install.sh
@@ -325,11 +325,11 @@ if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
     # Install golangci-lint from precompiled binares
     if [ "$GOLANGCILINT_VERSION" = "latest" ] || [ "$GOLANGCILINT_VERSION" = "" ]; then
         echo "Installing golangci-lint latest..."
-        curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh | \
+        curl -fsSL https://golangci-lint.run/install.sh | \
             sh -s -- -b "${TARGET_GOPATH}/bin"
     else
         echo "Installing golangci-lint ${GOLANGCILINT_VERSION}..."
-        curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh | \
+        curl -fsSL https://golangci-lint.run/install.sh | \
             sh -s -- -b "${TARGET_GOPATH}/bin" "v${GOLANGCILINT_VERSION}"
     fi
 


### PR DESCRIPTION
Currently using the go-feature in devcontainers without specifying an older version to install breaks building devcontainers.

After investigating, 2 reasons were identified for breaking:
- golangci-lint now releases sbom-files with their binary releases. The install-script now finds 2 hashes matching the filename, which was corrected by the maintainers yesterday (and released today, 3 hours ago in https://github.com/golangci/golangci-lint/pull/6539).
- The golangci-lint project switched their primary branch from master to main, date irrelevant. Their fix for the first issue was properly merged into main, but the installation script for this container-feature was never updated, still pointing to master - missing the fix.

This should be merged quickly.

Potential workaround: Using `v2.11.4` as version for golangci-lint should work since sbom-files were added in v2.12 for the first time. 