### PR TITLE
Fix docker in docker not working in ubuntu 26.04

### DIFF
--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -310,10 +310,16 @@ if [ "${ADJUSTED_ID}" = "debian" ] && command -v update-ca-certificates > /dev/n
     update-ca-certificates
 fi
 
-# Swap to legacy iptables for compatibility (Debian only)
 if [ "${ADJUSTED_ID}" = "debian" ] && type iptables-legacy > /dev/null 2>&1; then
-    update-alternatives --set iptables /usr/sbin/iptables-legacy
-    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+    # Check if host kernel supports ip_tables/iptable_nat
+    if iptables-legacy -t nat -L > /dev/null 2>&1; then
+        update-alternatives --set iptables /usr/sbin/iptables-legacy
+        update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+    else
+        # first appeared in Ubuntu ≥ 26.04
+        update-alternatives --set iptables  /usr/sbin/iptables-nft
+        update-alternatives --set ip6tables /usr/sbin/ip6tables-nft
+    fi
 fi
 
 # Set up the necessary repositories

--- a/src/docker-in-docker/install.sh
+++ b/src/docker-in-docker/install.sh
@@ -310,6 +310,7 @@ if [ "${ADJUSTED_ID}" = "debian" ] && command -v update-ca-certificates > /dev/n
     update-ca-certificates
 fi
 
+# Swap to legacy iptables for compatibility (Debian only)
 if [ "${ADJUSTED_ID}" = "debian" ] && type iptables-legacy > /dev/null 2>&1; then
     # Check if host kernel supports ip_tables/iptable_nat
     if iptables-legacy -t nat -L > /dev/null 2>&1; then


### PR DESCRIPTION
Closes #1633 

#1235 references fedora specifically and I see a few merges that are already in that seem to be fedora specific

I have intentionally tried to only touch the existing ubuntu components that I am able to test

# Testing
`devcontainer features test --features docker-in-docker --filter docker_build --project-folder .`
## Before
```
🔄 Testing 'docker-ps'

Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?


❌ docker-ps check failed.

🔄 Testing 'docker-build'

ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?


❌ docker-build check failed.
```
## After
```
Test Passed!
🧪 Executing duplicate test for feature 'docker-in-docker'...
⚠️ Skipping duplicate test for docker-in-docker because '/home/stephen/code/patch-features/test/docker-in-docker/duplicate.sh' does not exist.


  ================== TEST REPORT ==================
✅ Passed:      'docker-in-docker'
✅ Passed:      'docker_build_fallback_compose'
✅ Passed:      'docker_build'
✅ Passed:      'docker_build_with_compose_switch'
✅ Passed:      'docker_build_2'
✅ Passed:      'docker_build_older'
✅ Passed:      'docker_build_no_compose'
✅ Passed:      'docker_buildx'
✅ Passed:      'docker_build_fallback_buildx'

```


