### PR TITLE
#1635 - Fix: changed the golangci-lint script url

### DIFF
--- a/src/go/devcontainer-feature.json
+++ b/src/go/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "go",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "name": "Go",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/go",
     "description": "Installs Go and common Go utilities. Auto-detects latest version and installs needed dependencies.",

--- a/src/go/install.sh
+++ b/src/go/install.sh
@@ -325,11 +325,11 @@ if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
     # Install golangci-lint from precompiled binares
     if [ "$GOLANGCILINT_VERSION" = "latest" ] || [ "$GOLANGCILINT_VERSION" = "" ]; then
         echo "Installing golangci-lint latest..."
-        curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
+        curl -fsSL https://golangci-lint.run/install.sh | \
             sh -s -- -b "${TARGET_GOPATH}/bin"
     else
         echo "Installing golangci-lint ${GOLANGCILINT_VERSION}..."
-        curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
+        curl -fsSL https://golangci-lint.run/install.sh | \
             sh -s -- -b "${TARGET_GOPATH}/bin" "v${GOLANGCILINT_VERSION}"
     fi
 


### PR DESCRIPTION
Fixes #1635

Switches the golangci-lint install script URL from https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh to https://golangci-lint.run/install.sh, as recommended by upstream in the [v2.12.1 release notes](https://github.com/golangci/golangci-lint/releases/tag/v2.12.1). The master branch is no longer maintained and contains a checksum-verification bug that breaks installs of v2.12.1.

Verified with `devcontainer features test -f go` - passes without errors.