### PR TITLE
[git] - Fixing installation from source with new version `2.55.0`

### DIFF
--- a/src/git/devcontainer-feature.json
+++ b/src/git/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "git",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "name": "Git (from source)",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/git",
     "description": "Install an up-to-date version of Git, built from source as needed. Useful for when you want the latest and greatest features. Auto-detects latest stable version and installs needed dependencies.",

--- a/src/git/install.sh
+++ b/src/git/install.sh
@@ -318,6 +318,7 @@ cd /tmp/git-${GIT_VERSION}
 git_options=("prefix=/usr/local")
 git_options+=("sysconfdir=/etc")
 git_options+=("USE_LIBPCRE=YesPlease")
+git_options+=("NO_RUST=YesPlease")
 if [ "${ADJUSTED_ID}" = "alpine" ]; then
     # ref. <https://github.com/alpinelinux/aports/blob/32ac93ffb642031b88ba8639fbb3abb324169dea/main/git/APKBUILD#L126>
     git_options+=("NO_REGEX=YesPlease")


### PR DESCRIPTION
## Summary

Starting with **Git 2.55.0**, the upstream build system **enables Rust by default**. As a result, the `git` feature's "from source" build (`src/git/install.sh`) now fails when it tries to compile the latest Git on images that don't ship a Rust toolchain.

This PR fixes installation from source by explicitly opting out of Rust during the build (`NO_RUST=YesPlease`), restoring successful builds for `latest`/`current`/`lts` and any pinned `>= 2.55.0` version across all supported distros.
Reference: [What's new in Git 2.55.0? — Evolution of Rust in the Git codebase](https://about.gitlab.com/blog/whats-new-in-git-2-55-0/#evolution-of-rust-in-the-git-codebase)

## Problem

The `git` feature builds Git from source for non-OS-provided versions. Because this feature auto-detects and installs the **latest stable** Git, it began picking up `2.55.0`, and the build now fails on images without a Rust toolchain — which is the case for the dependency sets installed in `install.sh` (Debian/Ubuntu, Alpine, and RHEL/Fedora/Mariner). None of these install Rust, so the default Rust-enabled build cannot complete.

## Changes

- **`src/git/install.sh`** — Add `NO_RUST=YesPlease` to the `git_options` passed to `make`, so the source build keeps working without requiring a Rust toolchain:

  ```bash
  git_options=("prefix=/usr/local")
  git_options+=("sysconfdir=/etc")
  git_options+=("USE_LIBPCRE=YesPlease")
  git_options+=("NO_RUST=YesPlease")
  ```

- **`src/git/devcontainer-feature.json`** — Bump the feature version `1.3.5` → `1.3.6`.

## Why opt out instead of installing Rust?

Adding a full Rust toolchain to every build would significantly increase image build time and footprint across all supported distros, for a feature whose purpose is simply to provide an up-to-date Git binary. Opting out via `NO_RUST` keeps builds fast and lean while remaining fully supported by upstream for the 2.x series. This mirrors how several distro package recipes are handling the transition.

## Follow-up / future work

`NO_RUST` is a temporary opt-out and is slated for removal in **Git 3.0**. Before Git 3.0 lands, this feature will need a follow-up to provision a Rust toolchain (or otherwise satisfy the Rust build requirement) so source builds continue to succeed. Tracking this as a known future task.

## Testing

- [x] Build the latest Git (`>= 2.55.0`) from source on Debian/Ubuntu
- [x] Build on Alpine
- [x] Build on RHEL/Fedora/Mariner
- [x] Verify `git version` reports the expected `>= 2.55.0` version after install