### PR TITLE
Add 'resolute' to GPG codenames for compatibility

### DIFF
--- a/src/terraform/install.sh
+++ b/src/terraform/install.sh
@@ -19,8 +19,8 @@ INSTALL_SENTINEL=${INSTALLSENTINEL:-false}
 INSTALL_TFSEC=${INSTALLTFSEC:-false}
 INSTALL_TERRAFORM_DOCS=${INSTALLTERRAFORMDOCS:-false}
 CUSTOM_DOWNLOAD_SERVER="${CUSTOMDOWNLOADSERVER:-""}"
-# This is because ubuntu noble and debian trixie don't support the old format of GPG keys and validation 
-NEW_GPG_CODENAMES="trixie noble"
+# This is because ubuntu noble, resolute and debian trixie don't support the old format of GPG keys and validation 
+NEW_GPG_CODENAMES="trixie noble resolute"
 
 TERRAFORM_SHA256="${TERRAFORM_SHA256:-"automatic"}"
 TFLINT_SHA256="${TFLINT_SHA256:-"automatic"}"


### PR DESCRIPTION
Updated GPG codenames to include 'resolute' for Ubuntu and to adapt GPG keyserver changes for the recent LTS release.

Should fix #1681