### PR TITLE
fix(rust): support Azure Linux base images

### DIFF
--- a/src/rust/NOTES.md
+++ b/src/rust/NOTES.md
@@ -2,8 +2,8 @@
 
 ## OS Support
 
-This Feature should work on recent versions of Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, RockyLinux 
-and Mariner distributions with the `apt`, `yum`, `dnf`, `microdnf` and `tdnf` package manager installed.
+This Feature should work on recent versions of Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, RockyLinux, 
+Mariner and Azure Linux distributions with the `apt`, `yum`, `dnf`, `microdnf` and `tdnf` package manager installed.
 
 
 **Note:** Alpine is not supported because the rustup-init binary requires glibc to run, but Alpine Linux does not include `glibc` 

--- a/src/rust/README.md
+++ b/src/rust/README.md
@@ -32,8 +32,8 @@ Installs Rust, common Rust utilities, and their required dependencies
 
 ## OS Support
 
-This Feature should work on recent versions of Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, RockyLinux 
-and Mariner distributions with the `apt`, `yum`, `dnf`, `microdnf` and `tdnf` package manager installed.
+This Feature should work on recent versions of Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, RockyLinux, 
+Mariner and Azure Linux distributions with the `apt`, `yum`, `dnf`, `microdnf` and `tdnf` package manager installed.
 
 
 **Note:** Alpine is not supported because the rustup-init binary requires glibc to run, but Alpine Linux does not include `glibc` 

--- a/src/rust/devcontainer-feature.json
+++ b/src/rust/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "rust",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "name": "Rust",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/rust",
     "description": "Installs Rust, common Rust utilities, and their required dependencies",

--- a/src/rust/install.sh
+++ b/src/rust/install.sh
@@ -30,7 +30,7 @@ if [ "${ID}" = "debian" ] || [ "${ID_LIKE}" = "debian" ]; then
     ADJUSTED_ID="debian"
 elif [ "${ID}" = "alpine" ]; then
     ADJUSTED_ID="alpine"
-elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"mariner"* ]]; then
+elif [[ "${ID}" = "rhel" || "${ID}" = "fedora" || "${ID}" = "azurelinux" || "${ID}" = "mariner" || "${ID_LIKE}" = *"rhel"* || "${ID_LIKE}" = *"fedora"* || "${ID_LIKE}" = *"azurelinux"* || "${ID_LIKE}" = *"mariner"* ]]; then
     ADJUSTED_ID="rhel"
     VERSION_CODENAME="${ID}${VERSION_ID}"
 else
@@ -264,6 +264,7 @@ check_packages() {
                     "python3-minimal") packages[$i]="python3" ;;
                     "libpython3.*") packages[$i]="python3-devel" ;;
                     "gnupg2") packages[$i]="gnupg" ;;
+                    "passwd") packages[$i]="shadow-utils" ;;
                 esac
                 ;;
         esac
@@ -303,7 +304,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 # Install curl, lldb, python3-minimal,libpython and rust dependencies if missing
 echo "Installing required dependencies..."
-check_packages curl ca-certificates gcc libc6-dev gnupg2 git
+check_packages curl ca-certificates gcc libc6-dev gnupg2 git passwd
 
 # Install optional dependencies (continue if they fail)
 case "$PKG_MANAGER" in
@@ -315,7 +316,7 @@ case "$PKG_MANAGER" in
         ;;
     tdnf)
         check_packages python3 python3-devel || true
-        # LLDB might not be available in Photon/Mariner
+        # LLDB might not be available in Photon/Mariner/Azure Linux
         ;;
 esac
 

--- a/test/rust/rust_with_azurelinux.sh
+++ b/test/rust/rust_with_azurelinux.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Helper function to check component is installed
+check_component_installed() {
+    local component=$1
+    if rustup component list | grep -q "${component}.*installed"; then
+        return 0  # Component is installed (success)
+    else
+        return 1  # Component is not installed (failure)
+    fi
+}
+
+# Definition specific tests
+check "cargo version" cargo  --version
+check "rustc version" rustc  --version
+check "correct rust version" rustup target list | grep aarch64-unknown-linux-gnu
+
+# Check that all specified extended components are installed
+check "rust-analyzer is installed" check_component_installed "rust-analyzer"
+check "rust-src is installed" check_component_installed "rust-src"
+check "rustfmt is installed" check_component_installed "rustfmt"
+check "clippy is installed" check_component_installed "clippy"
+check "rust-docs is installed" check_component_installed "rust-docs"
+
+# Report result
+reportResults

--- a/test/rust/scenarios.json
+++ b/test/rust/scenarios.json
@@ -134,5 +134,15 @@
                 "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"                
             }
         }
+    },
+    "rust_with_azurelinux": {
+        "image": "mcr.microsoft.com/azurelinux/base/core:3.0",
+        "features": {
+            "rust": {
+                "version": "latest",
+                "targets": "aarch64-unknown-linux-gnu",
+                "components": "rust-analyzer,rust-src,rustfmt,clippy,rust-docs"                
+            }
+        }
     }                                                                
 }


### PR DESCRIPTION
Explicitly support Azure Linux base images in Rust feature.

Required two minor changes:

* Explicitly recognize distro ID `azurelinux` and map it to the same behavior as `mariner`
* Explicitly install `passwd`/`shadow-utils` package dependency for the `groupadd` command (which is not present by default in Azure Linux base images)

Also add a `rust_with_azurelinux` test scenario to validate expected behavior.

Changes validated by running `devcontainer features test -f rust` locally.