### PR TITLE
fix(java): Add retry logic for transient SDKMAN bootstrap failures

### DIFF
--- a/src/java/devcontainer-feature.json
+++ b/src/java/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "java",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "name": "Java (via SDKMAN!)",
   "documentationURL": "https://github.com/devcontainers/features/tree/main/src/java",
   "description": "Installs Java, SDKMAN! (if not installed), and needed dependencies.",

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -195,6 +195,29 @@ updaterc() {
     fi
 }
 
+run_with_retries() {
+    local max_attempts="$1"
+    local wait_seconds="$2"
+    local operation="$3"
+    local attempt=1
+    shift 3
+
+    until "$@"; do
+        if [ "${attempt}" -ge "${max_attempts}" ]; then
+            echo "(!) ${operation} failed after ${max_attempts} attempts."
+            return 1
+        fi
+
+        echo "(*) ${operation} failed on attempt ${attempt}. Retrying in ${wait_seconds}s..."
+        attempt=$((attempt + 1))
+        sleep "${wait_seconds}"
+    done
+}
+
+install_sdkman_cli() {
+    bash -o pipefail -c 'curl -sSL "https://get.sdkman.io?rcupdate=false" | bash'
+}
+
 find_version_list() {
     prefix="$1"
     suffix="$2"
@@ -284,7 +307,8 @@ sdk_install() {
         JAVA_VERSION=${requested_version}
     fi
 
-    su ${USERNAME} -c "umask 0002 && . ${SDKMAN_DIR}/bin/sdkman-init.sh && sdk install ${install_type} ${requested_version} && sdk flush archives && sdk flush temp"
+    run_with_retries 5 10 "Installing ${install_type} ${requested_version} via SDKMAN" \
+        su ${USERNAME} -c "umask 0002 && . ${SDKMAN_DIR}/bin/sdkman-init.sh && sdk install ${install_type} ${requested_version} && sdk flush archives && sdk flush temp"
 }
 
 export DEBIAN_FRONTEND=noninteractive
@@ -323,7 +347,7 @@ if [ ! -d "${SDKMAN_DIR}" ]; then
     if [ "${ADJUSTED_ID}" = "rhel" ] && [ "${MAJOR_VERSION_ID}" = "8" ]; then
         export SDKMAN_NATIVE_VERSION="false"
     fi
-    curl -sSL "https://get.sdkman.io?rcupdate=false" | bash
+    run_with_retries 5 10 "Installing SDKMAN" install_sdkman_cli
     # For RHEL 8 systems, also disable native CLI in config file and remove native binaries
     if [ "${ADJUSTED_ID}" = "rhel" ] && [ "${MAJOR_VERSION_ID}" = "8" ]; then
         # Disable native CLI in config to prevent future usage

--- a/src/java/install.sh
+++ b/src/java/install.sh
@@ -215,7 +215,7 @@ run_with_retries() {
 }
 
 install_sdkman_cli() {
-    bash -o pipefail -c 'curl -sSL "https://get.sdkman.io?rcupdate=false" | bash'
+    bash -o pipefail -c 'curl -fsSL "https://get.sdkman.io?rcupdate=false" | bash'
 }
 
 find_version_list() {

--- a/test/java/install_latest_version.sh
+++ b/test/java/install_latest_version.sh
@@ -9,7 +9,7 @@ echo 'public class HelloWorld { public static void main(String[] args) { System.
 javac HelloWorld.java
 
 check "hello world" /bin/bash -c "java HelloWorld | grep "Hello, World!""
-check "java version latest installed" grep "25" <(java --version)
+check "java version latest installed" grep "26" <(java --version)
 
 # Report result
 reportResults

--- a/test/java/install_latest_version.sh
+++ b/test/java/install_latest_version.sh
@@ -8,7 +8,7 @@ source dev-container-features-test-lib
 echo 'public class HelloWorld { public static void main(String[] args) { System.out.println("Hello, World!"); } }' > HelloWorld.java
 javac HelloWorld.java
 
-check "hello world" /bin/bash -c "java HelloWorld | grep "Hello, World!""
+check "hello world" /bin/bash -c 'java HelloWorld | grep "Hello, World!"'
 check "java version latest installed" grep "26" <(java --version)
 
 # Report result


### PR DESCRIPTION
# Fix: Java feature transient SDKMAN 503 failures

## Problem

The Java feature fails intermittently when `get.sdkman.io` returns HTTP 503 during bootstrap/install. No recovery mechanism exists, causing build failures and manual reruns. Reported at #1684 & #454.

**Error:** `curl: (22) The requested URL returned error: 503`

## Solutions

### 1. Add Retry Logic (Temporary)
5 attempts, 10-second intervals (~50s total). Mirrors existing patterns in git, python, ruby, terraform features.
- Minimal: 30 lines added
- Proven: Same approach works in other features
- Only tolerates transient failures (doesn't solve chronic SDKMAN downtime)

### 2. Switch to Alternative Package Source (Permanent)
Use OS package manager (`apt install openjdk-*`) or direct Temurin downloads instead of SDKMAN.
- Limited to OpenJDK/LTS versions (no GraalVM, Corretto, Microsoft Java)
- Breaks reproducibility (different JVMs per distro)
- High maintenance: per-distro logic, test matrix explosion

## Current Choice: Retry Logic

**Why temporary over permanent?**
- No 100% viable alternative (all permanent solutions lose significant feature coverage)
- Problem is transient, not systemic (intermittent 503s, not chronic downtime)
- Maintenance burden unjustified by severity
- SDKMAN is still the best solution when working

**Strategy:** Monitor for 2-3 weeks post-merge. If failures persist, revisit permanent solutions.

## Implementation

**Added to `src/java/install.sh`:**

```bash
run_with_retries() {
    local max_attempts="$1" wait_seconds="$2" operation="$3" attempt=1
    shift 3
    until "$@"; do
        [ "${attempt}" -ge "${max_attempts}" ] && return 1
        echo "(*) ${operation} failed on attempt ${attempt}. Retrying in ${wait_seconds}s..."
        attempt=$((attempt + 1))
        sleep "${wait_seconds}"
    done
}

install_sdkman_cli() {
    bash -o pipefail -c 'curl -sSL "https://get.sdkman.io?rcupdate=false" | bash'
}
```

**Applied to:**
- SDKMAN bootstrap: `run_with_retries 5 10 "Installing SDKMAN" install_sdkman_cli`
- SDK install: `run_with_retries 5 10 "Installing ${install_type} ${requested_version} via SDKMAN" ...`

**Total change:** ~30 lines

## Testing & Validation

**Deterministic proof:**
- Baseline (unpatched + injected 503): Failed at 12s
- Patched (same injected 503): Recovered at 79s with retry evidence in logs
- No regression on healthy path: ~84-85s (same as before)

```bash
# Test command
devcontainer features test -f java --skip-scenarios -i ubuntu:noble --log-level info .

# Watch for retries
grep -i "retrying\|failed on attempt" logs
```

## Impact

- Reduces the transient SDKMAN 503s error due to added waiting.
- No impact on user performance.
- No Performance overhead.
- No change in support of Java versions/distributions