### PR TITLE
Implement YOLO mode for package installation check

### DIFF
--- a/src/aws-cli/install.sh
+++ b/src/aws-cli/install.sh
@@ -61,6 +61,7 @@ apt_get_update()
 
 # Checks if packages are installed and installs them if not
 check_packages() {
+    if ! command -v dpkg &> /dev/null; then return; fi # system doesn't have dpkg. YOLO mode. we still have `set -e`
     if ! dpkg -s "$@" > /dev/null 2>&1; then
         apt_get_update
         apt-get -y install --no-install-recommends "$@"

--- a/src/aws-cli/install.sh
+++ b/src/aws-cli/install.sh
@@ -94,12 +94,13 @@ install() {
     if [ "${VERSION}" != "latest" ]; then
         local versionStr=-${VERSION}
     fi
-    architecture=$(dpkg --print-architecture)
-    case "${architecture}" in
-        amd64) architectureStr=x86_64 ;;
-        arm64) architectureStr=aarch64 ;;
+    # Detect architecture without relying on dpkg (works on Alpine and non-debian systems)
+    arch=$(uname -m)
+    case "${arch}" in
+        x86_64|amd64) architectureStr=x86_64 ;;
+        aarch64|arm64) architectureStr=aarch64 ;;
         *)
-            echo "AWS CLI does not support machine architecture '$architecture'. Please use an x86-64 or ARM64 machine."
+            echo "AWS CLI does not support machine architecture '${arch}'. Please use an x86-64 or ARM64 machine."
             exit 1
     esac
     local scriptUrl=https://awscli.amazonaws.com/awscli-exe-linux-${architectureStr}${versionStr}.zip


### PR DESCRIPTION
Add YOLO mode check for dpkg availability in package installation. 

This immediately extends support to practically every Linux distro (or at least all the modern RHEL derivatives. pretty sure even ubi10 can check a gpg signature.)