### PR TITLE
fix(nix): Resolve PATH mismatch for packages option in multi-user mode

### DIFF
--- a/src/nix/install.sh
+++ b/src/nix/install.sh
@@ -113,10 +113,8 @@ fi
 chmod +x,o+r ${FEATURE_DIR} ${FEATURE_DIR}/post-install-steps.sh
 if [ "${MULTIUSER}" = "true" ]; then
     /usr/local/share/nix-entrypoint.sh
-    su ${USERNAME} -c "
-        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-        ${FEATURE_DIR}/post-install-steps.sh
-    "
+    . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+    NIX_FEATURE_INSTALL_PROFILE=/nix/var/nix/profiles/default ${FEATURE_DIR}/post-install-steps.sh
 else
     su ${USERNAME} -c "
         . \$HOME/.nix-profile/etc/profile.d/nix.sh

--- a/src/nix/post-install-steps.sh
+++ b/src/nix/post-install-steps.sh
@@ -2,6 +2,14 @@
 set -e
 echo "(*) Executing post-installation steps..."
 
+# In multi-user mode, install into the default profile that is on PATH.
+NIX_ENV_PROFILE_ARGS=()
+NIX_PROFILE_INSTALL_ARGS=()
+if [ -n "${NIX_FEATURE_INSTALL_PROFILE}" ]; then
+  NIX_ENV_PROFILE_ARGS=(-p "${NIX_FEATURE_INSTALL_PROFILE}")
+  NIX_PROFILE_INSTALL_ARGS=(--profile "${NIX_FEATURE_INSTALL_PROFILE}")
+fi
+
 # if not starts with "nixpkgs." add it as prefix to package name
 add_nixpkgs_prefix() {
   local packages=$1
@@ -20,17 +28,17 @@ if [ ! -z "${PACKAGES}" ] && [ "${PACKAGES}" != "none" ]; then
   if [ "${USEATTRIBUTEPATH}" = "true" ]; then
     PACKAGES=$(add_nixpkgs_prefix "$PACKAGES")
     echo "Installing packages \"${PACKAGES}\" in profile..."
-    nix-env -iA ${PACKAGES}
+    nix-env "${NIX_ENV_PROFILE_ARGS[@]}" -iA ${PACKAGES}
   else
     echo "Installing packages \"${PACKAGES}\" in profile..."
-    nix-env --install ${PACKAGES}
+    nix-env "${NIX_ENV_PROFILE_ARGS[@]}" --install ${PACKAGES}
   fi
 fi
 
 # Install Nix flake in profile if specified
 if [ ! -z "${FLAKEURI}" ] && [ "${FLAKEURI}" != "none" ]; then
     echo "Installing flake ${FLAKEURI} in profile..."
-    nix profile install "${FLAKEURI}"
+  nix profile install "${NIX_PROFILE_INSTALL_ARGS[@]}" "${FLAKEURI}"
 fi
 
 nix-collect-garbage --delete-old

--- a/test/nix/packages.sh
+++ b/test/nix/packages.sh
@@ -29,6 +29,7 @@ check "nix-env" type nix-env
 check "vim_installed" type vim
 check "node_installed" type node
 check "yarn_installed" type yarn
+check "vim_in_default_profile" bash -lc "nix-env -p /nix/var/nix/profiles/default -q | grep -q '^vim'"
 
 # Report result
 # If any of the checks above exited with a non-zero exit code, the test will fail.

--- a/test/nix/scenarios.json
+++ b/test/nix/scenarios.json
@@ -86,7 +86,7 @@
         "remoteUser": "vscode",
         "features": {
             "nix": {
-                "packages": "nodePackages.nodejs,nixpkgs.vim,nixpkgs.yarn",
+                "packages": "nodejs,nixpkgs.vim,nixpkgs.yarn",
                 "useAttributePath": true
             }
         }


### PR DESCRIPTION
# fix(nix): Resolve PATH mismatch and attribute-path error for packages in multi-user mode

## Issues Fixed

### Issue 1 — Packages installed to wrong profile in multi-user mode { Reported As Issue on Feb-16-2026 at [#1573 ](https://github.com/devcontainers/features/issues/1573) }

**Problem:** In multi-user Nix installs, packages specified via the `packages` option were silently installed into the calling user's `~/.nix-profile` (inside a `su` subshell) instead of `/nix/var/nix/profiles/default` — the global profile that is on `PATH` at runtime.


**Reproduction:**
```sh
# devcontainer-feature.json: multiUser: true, packages: "nixpkgs.vim"
$ type vim
# → vim: command not found

$ nix-env -p /nix/var/nix/profiles/default -q
# → vim is absent from the default profile
```

**Root Cause:** `install.sh` ran `post-install-steps.sh` inside `su ${USERNAME} -c "..."`. Inside that subshell, `nix-env` defaulted to `~/.nix-profile`. Since only `/nix/var/nix/profiles/default/bin` is on `PATH` at runtime, the installs were unreachable.

**Fix:**
- **`src/nix/install.sh`** — Removed the `su` subshell in the multi-user branch. `nix-daemon.sh` is sourced in the root context and `NIX_FEATURE_INSTALL_PROFILE=/nix/var/nix/profiles/default` is passed as a prefixed env var to `post-install-steps.sh`.
- **`src/nix/post-install-steps.sh`** — When `NIX_FEATURE_INSTALL_PROFILE` is set, constructs `-p`/`--profile` arg arrays and forwards them to every `nix-env` and `nix profile install` invocation. Single-user mode is unaffected (arrays remain empty).

---

### Issue 2 — Wrong attribute path for `nodejs` in packages scenario

**Problem:** The `packages` test scenario in `scenarios.json` used `nodePackages.nodejs` with `useAttributePath: true`. The correct nixpkgs attribute path is simply `nodejs`; the `nodePackages.` prefix resolves a different attribute set and caused the scenario to fail at build time.

**Reproduction:**
```sh
# scenarios.json: packages: "nodePackages.nodejs,...", useAttributePath: true
$ nix-env -iA nixpkgs.nodePackages.nodejs
# → error: attribute 'nodePackages.nodejs' in selection path not found
```

**Fix:**
- **`test/nix/scenarios.json`** — Corrected `nodePackages.nodejs` → `nodejs` in the `packages` string for the `useAttributePath` scenario.

---

## Tests

- Added `check "vim_in_default_profile"` to `test/nix/packages.sh` — runs `nix-env -p /nix/var/nix/profiles/default -q | grep '^vim'` to directly assert packages land in the global profile.
- Existing `vim_installed` / `node_installed` / `yarn_installed` checks confirm end-to-end `PATH` visibility at runtime.
- Corrected `scenarios.json` ensures the `useAttributePath` + `packages` scenario no longer fails on attribute resolution before the profile bug is even exercised.

## Impact

- Multi-user containers with `packages` now correctly expose installed packages on `PATH`.
- The `useAttributePath` packages CI scenario is unblocked and runs cleanly.
- Single-user installs and the public feature interface are unchanged.
