### PR TITLE
docs(node): document pre-bundled items and how to opt out

### DIFF
--- a/src/node/NOTES.md
+++ b/src/node/NOTES.md
@@ -25,3 +25,27 @@ Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, and Rocky Linux distributi
 **Note**:  RedHat 7 Family (RedHat, CentOS, etc.) must use Node versions less than 18 due to its system libraries and long-term support (LTS) policies.
 
 `bash` is required to execute the `install.sh` script.
+
+## Pre-bundled items
+
+> [!NOTE]
+> Beyond the core install, this feature also sets up a few items by default for convenience — recommended VS Code extensions (such as a linter) and supporting tools. This is intentional behavior shared across features in this repository.
+
+## Excluding pre-bundled items
+
+Exclude a bundled **VS Code extension** by prefixing its ID with `-`, or disable a bundled **tool** by setting its option to `none` :
+
+```json
+{
+    "features": {
+        "ghcr.io/devcontainers/features/node:2": {
+            "pnpmVersion": "none"
+        }
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [ "-dbaeumer.vscode-eslint" ]
+        }
+    }
+}
+```

--- a/src/node/NOTES.md
+++ b/src/node/NOTES.md
@@ -33,7 +33,7 @@ Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, and Rocky Linux distributi
 
 ## Excluding pre-bundled items
 
-Exclude a bundled **VS Code extension** by prefixing its ID with `-`, or disable a bundled **tool** by setting its option to `none`:
+Exclude a bundled **VS Code extension** by prefixing its ID with `-`, or (when supported by a feature option) disable a bundled **tool** by setting its version option to `none` (for example, `pnpmVersion`: `none`):
 
 ```json
 {

--- a/src/node/NOTES.md
+++ b/src/node/NOTES.md
@@ -33,7 +33,7 @@ Debian/Ubuntu, RedHat Enterprise Linux, Fedora, Alma, and Rocky Linux distributi
 
 ## Excluding pre-bundled items
 
-Exclude a bundled **VS Code extension** by prefixing its ID with `-`, or disable a bundled **tool** by setting its option to `none` :
+Exclude a bundled **VS Code extension** by prefixing its ID with `-`, or disable a bundled **tool** by setting its option to `none`:
 
 ```json
 {


### PR DESCRIPTION
# docs(node): document pre-bundled items and how to opt out

Aimed to Solve #1693  · Related: #386 

## Problem
The `node` feature installs recommended extensions (e.g. `dbaeumer.vscode-eslint`)
and tools (yarn, pnpm) by default, but this isn't documented. Users wanting only
Node.js are surprised and find no opt-out guidance — the same concern raised in
#386 for the Node and Go features.

## Options considered
- **Remove the extension:** a breaking change to a long-standing default and
  inconsistent with sibling features.
- **Per-extension opt-out option:** proposed by @samruddhikhandale in #386, but
  never implemented as it needs a spec change; the native VS Code `-<id>` syntax
  now fills this role.
- **Document the behavior + `-<id>` opt-out:** chosen.

## Why this option
The behavior is intentional and the `-<id>` opt-out already exists — only the
documentation was missing. It's non-breaking, zero-risk, and directly answers
what users asked in #1693 and #386.

## Changes
Adds a short "Pre-bundled items" note to `src/node/NOTES.md` describing the default
extensions/tools and how to exclude them (extension → `-<id>`, tool → option
`"none"`). The README is auto-generated, so it regenerates on merge.

## Impact
Docs-only — no behavioral change and no runtime risk. Users get clear, discoverable
opt-out guidance, which should reduce duplicate reports.

## Future action
Only node is covered here; ~14 other features bundle extensions too. The durable fix
is to auto-emit this note from the docs generator (`devcontainers/action`, tracked in
action#139) rather than copying it per-feature.