### PR TITLE
feat(github-cli): support private extension installs

### DIFF
--- a/src/github-cli/NOTES.md
+++ b/src/github-cli/NOTES.md
@@ -6,4 +6,6 @@ This Feature should work on recent versions of Debian/Ubuntu-based distributions
 
 ## Extensions
 
-If you set the `extensions` option, the feature will run `gh extension install` for each entry (comma-separated). Extensions are installed for the most appropriate non-root user (based on `USERNAME` / `_REMOTE_USER`), with a fallback to `root`.
+If you set the `extensions` option, the feature will install each comma-separated entry. Extensions are installed for the most appropriate non-root user (based on `USERNAME` / `_REMOTE_USER`), with a fallback to `root`.
+
+Private extensions can be installed when `GH_TOKEN` or `GITHUB_TOKEN` is available during feature installation. The token is forwarded to the selected non-root user and used through the GitHub CLI Git credential helper.

--- a/src/github-cli/devcontainer-feature.json
+++ b/src/github-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "github-cli",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "name": "GitHub CLI",
     "documentationURL": "https://github.com/devcontainers/features/tree/main/src/github-cli",
     "description": "Installs the GitHub CLI. Auto-detects latest version and installs needed dependencies.",

--- a/src/github-cli/install.sh
+++ b/src/github-cli/install.sh
@@ -271,7 +271,11 @@ if [ -n "${EXTENSIONS}" ]; then
     else
         EXTENSIONS_ESCAPED="$(printf '%q' "${EXTENSIONS}")"
         USERNAME_ESCAPED="$(printf '%q' "${USERNAME}")"
-        su - "${USERNAME}" -c "EXTENSIONS=${EXTENSIONS_ESCAPED} USERNAME=${USERNAME_ESCAPED} INSTALL_EXTENSIONS=true bash '${EXTENSIONS_SCRIPT}'"
+        su \
+            --login \
+            --whitelist-environment=GH_TOKEN,GITHUB_TOKEN \
+            --command "EXTENSIONS=${EXTENSIONS_ESCAPED} USERNAME=${USERNAME_ESCAPED} INSTALL_EXTENSIONS=true bash '${EXTENSIONS_SCRIPT}'" \
+            "${USERNAME}"
         INSTALL_EXTENSIONS=false bash "${EXTENSIONS_SCRIPT}"
     fi
 fi

--- a/src/github-cli/scripts/install-extensions.sh
+++ b/src/github-cli/scripts/install-extensions.sh
@@ -26,18 +26,32 @@ install_extension() {
 
     mkdir -p "${extensions_root}"
     if [ ! -d "${extensions_root}/${repo_name}" ]; then
-        git clone --depth 1 "https://github.com/${extension}.git" "${extensions_root}/${repo_name}"
+        git \
+            -c credential.helper= \
+            -c credential.helper='!gh auth git-credential' \
+            clone --depth 1 "https://github.com/${extension}.git" "${extensions_root}/${repo_name}"
     fi
 }
 
 ensure_gh_extension_list_wrapper() {
+    local gh_config_dir
+
     if [ "$(id -u)" -ne 0 ]; then
         return
     fi
 
-    if gh extension list >/dev/null 2>&1; then
+    gh_config_dir="$(mktemp -d)"
+    if env \
+        -u GH_TOKEN \
+        -u GITHUB_TOKEN \
+        -u GH_ENTERPRISE_TOKEN \
+        -u GITHUB_ENTERPRISE_TOKEN \
+        GH_CONFIG_DIR="${gh_config_dir}" \
+        gh extension list >/dev/null 2>&1; then
+        rm -rf "${gh_config_dir}"
         return
     fi
+    rm -rf "${gh_config_dir}"
 
     cat > /usr/local/bin/gh <<'EOF'
 #!/usr/bin/env bash


### PR DESCRIPTION
- Support installing private extensions with  `GH_TOKEN`/`GITHUB_TOKEN`
- Forward authentication to the selected non-root user and use `gh auth git-credential` for cloning
- Prevent temporary build authentication from incorrectly disabling the extension-list fallback

Testing

- Passed the existing public extension scenario
- Built with a private repository using a BuildKit secret and verified the token was not persisted in the image