### PR TITLE
fix(github-cli): install binary-only extensions correctly

### DIFF
--- a/src/github-cli/scripts/install-extensions.sh
+++ b/src/github-cli/scripts/install-extensions.sh
@@ -82,8 +82,8 @@ if [ "$#" -ge 2 ]; then
                     url="${url#git@github.com:}"
                     echo "$url"
                 elif [ -f "$d/manifest.yml" ]; then
-                    owner="$(sed -n 's/^owner: //p' "$d/manifest.yml")"
-                    name="$(sed -n 's/^name: //p' "$d/manifest.yml")"
+                    owner="$(sed -nE 's/^[[:space:]]*owner:[[:space:]]*"?([^"#]+)"?.*$/\1/p' "$d/manifest.yml" | sed -n '1p')"
+                    name="$(sed -nE 's/^[[:space:]]*name:[[:space:]]*"?([^"#]+)"?.*$/\1/p' "$d/manifest.yml" | sed -n '1p')"
                     if [ -n "$owner" ] && [ -n "$name" ]; then
                         echo "$owner/$name"
                     fi

--- a/src/github-cli/scripts/install-extensions.sh
+++ b/src/github-cli/scripts/install-extensions.sh
@@ -26,10 +26,12 @@ install_extension() {
 
     mkdir -p "${extensions_root}"
     if [ ! -d "${extensions_root}/${repo_name}" ]; then
-        git \
-            -c credential.helper= \
-            -c credential.helper='!gh auth git-credential' \
-            clone --depth 1 "https://github.com/${extension}.git" "${extensions_root}/${repo_name}"
+        if ! gh extension install "${extension}"; then
+            git \
+                -c credential.helper= \
+                -c credential.helper='!gh auth git-credential' \
+                clone --depth 1 "https://github.com/${extension}.git" "${extensions_root}/${repo_name}"
+        fi
     fi
 }
 
@@ -79,6 +81,12 @@ if [ "$#" -ge 2 ]; then
                     url="${url#ssh://git@github.com/}"
                     url="${url#git@github.com:}"
                     echo "$url"
+                elif [ -f "$d/manifest.yml" ]; then
+                    owner="$(sed -n 's/^owner: //p' "$d/manifest.yml")"
+                    name="$(sed -n 's/^name: //p' "$d/manifest.yml")"
+                    if [ -n "$owner" ] && [ -n "$name" ]; then
+                        echo "$owner/$name"
+                    fi
                 fi
             done
         fi

--- a/test/github-cli/install_extensions.sh
+++ b/test/github-cli/install_extensions.sh
@@ -9,6 +9,7 @@ check "gh-version" gh --version
 
 check "gh-extension-installed" gh extension list | grep -q 'dlvhdr/gh-dash'
 check "gh-extension-installed-2" gh extension list | grep -q 'github/gh-copilot'
+check "gh-extension-installed-3" gh extension list | grep -q 'github/gh-aw'
 check "gh-aw-runs" gh aw version
 
 # Report result

--- a/test/github-cli/install_extensions.sh
+++ b/test/github-cli/install_extensions.sh
@@ -9,6 +9,7 @@ check "gh-version" gh --version
 
 check "gh-extension-installed" gh extension list | grep -q 'dlvhdr/gh-dash'
 check "gh-extension-installed-2" gh extension list | grep -q 'github/gh-copilot'
+check "gh-aw-runs" gh aw version
 
 # Report result
 reportResults

--- a/test/github-cli/scenarios.json
+++ b/test/github-cli/scenarios.json
@@ -13,7 +13,7 @@
     "features": {
       "github-cli": {
         "version": "latest",
-        "extensions": "dlvhdr/gh-dash,github/gh-copilot"
+        "extensions": "dlvhdr/gh-dash,github/gh-copilot,github/gh-aw"
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes `github-cli` extension installation for binary-only extensions such as `github/gh-aw`.

## Changes

- Install extensions with `gh extension install` so GitHub CLI downloads release binaries when required.
- Keep the existing directory guard to avoid overwriting installed extensions.
- Fall back to the prior shallow clone for extensions that cannot be installed through `gh`, including `github/gh-copilot`.
- Recognize manifest-based binary extensions in the `gh extension list` compatibility wrapper.
- Add a regression test that installs `github/gh-aw` and runs `gh aw version`.

## Validation

```text
devcontainer features test -p . -f github-cli --skip-autogenerated --skip-duplicated