### PR TITLE
Fix install script to change directory before cleanup

### DIFF
--- a/src/go/install.sh
+++ b/src/go/install.sh
@@ -334,14 +334,15 @@ if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
     fi
 
     # Remove Go tools temp directory
+    cd "${TARGET_GOROOT}"
     rm -rf "${GOPATH}"
 fi
 
 
 chown -R "${USERNAME}:golang" "${TARGET_GOROOT}" "${TARGET_GOPATH}"
 chmod -R g+r+w "${TARGET_GOROOT}" "${TARGET_GOPATH}"
-find "${TARGET_GOROOT}" -type d -print0 | xargs -n 1 -0 chmod g+s
-find "${TARGET_GOPATH}" -type d -print0 | xargs -n 1 -0 chmod g+s
+find "${TARGET_GOROOT}" -type d -print0 | xargs -r -n 1 -0 chmod g+s
+find "${TARGET_GOPATH}" -type d -print0 | xargs -r -n 1 -0 chmod g+s
 
 # Clean up
 clean_up


### PR DESCRIPTION
Two related fixes in the Go feature's "install tools" block.
 
1. After installing the Go tools, the script never leaves `${GOPATH}`
   (a temp dir, default /tmp/gotools) before removing it with
   `rm -rf "${GOPATH}"`. The shell's cwd is left pointing at a deleted
   directory for the rest of the script. The two `find` calls that
   follow then fail while resolving their own initial working
   directory:
 
       find: Failed to save initial working directory: No such file or directory
 
   This is silent on filesystems/kernels where a process may keep
   using a cwd after it's been unlinked, but fails hard on at least
   some overlay2 configurations (reproduced on a Synology DSM host,
   kernel 4.4). Explicitly cd-ing to a directory that's guaranteed to
   still exist before the rm -rf makes this deterministic regardless
   of filesystem/kernel.
 
2. Because of (1), the piped `xargs -n 1 -0 chmod g+s` received empty
   input and (GNU xargs' documented default without -r) still ran
   `chmod g+s` once with no arguments:
 
       chmod: missing operand after 'g+s'
 
   Independently of fix (1), `-r`/`--no-run-if-empty` belongs on these
   invocations regardless: chmod should never be invoked at all when
   find legitimately produces no output.
