### PR TITLE
Declare installGoTools option to toggle tools installation

### DIFF
--- a/src/go/README.md
+++ b/src/go/README.md
@@ -17,6 +17,7 @@ Installs Go and common Go utilities. Auto-detects latest version and installs ne
 |-----|-----|-----|-----|
 | version | Select or enter a Go version to install | string | latest |
 | golangciLintVersion | Version of golangci-lint to install | string | latest |
+| installGoTools | Install common Go tools | boolean | true |
 
 ## Customizations
 

--- a/src/go/devcontainer-feature.json
+++ b/src/go/devcontainer-feature.json
@@ -20,7 +20,12 @@
             "type": "string",
             "default": "latest",
             "description": "Version of golangci-lint to install"
-        }
+        },
+		"installGoTools": {
+			"type": "boolean",
+			"default": true,
+			"description": "Install common Go tools (gopls, staticcheck, golint, revive, dlv, gomodifytags, goplay, gotests, impl, golangci-lint). Set to false to skip - useful when your postCreateCommand or CI already installs the tools it needs, or when you just want `go build`/`go install` support without the extra download/compile time."
+		}
     },
     "init": true,
     "customizations": {

--- a/src/go/install.sh
+++ b/src/go/install.sh
@@ -9,11 +9,11 @@
 
 TARGET_GO_VERSION="${VERSION:-"latest"}"
 GOLANGCILINT_VERSION="${GOLANGCILINTVERSION:-"latest"}"
+INSTALL_GO_TOOLS="${INSTALLGOTOOLS:-"true"}"
 
 TARGET_GOROOT="${TARGET_GOROOT:-"/usr/local/go"}"
 TARGET_GOPATH="${TARGET_GOPATH:-"/go"}"
 USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
-INSTALL_GO_TOOLS="${INSTALL_GO_TOOLS:-"true"}"
 
 # https://www.google.com/linuxrepositories/
 GO_GPG_KEY_URI="https://dl.google.com/linux/linux_signing_key.pub"


### PR DESCRIPTION
The tools-installation block on (controlled by variable `INSTALL_GO_TOOLS`) should by a user-facing toggle.
Prior to this patch `INSTALL_GO_TOOLS` had to be put into devcontainer.json and was not documented.
This adds the missing option declaration and fixes install.sh to read the correctly-exported name, consistent with the version and golangCiLintVersion pattern immediately above it.
